### PR TITLE
feat: image compression pipeline for photo uploads

### DIFF
--- a/lib/uploadImage.ts
+++ b/lib/uploadImage.ts
@@ -9,19 +9,20 @@ interface UploadConfig {
   maxSizeMB: number;
 }
 
-// maxSizeMB is a safety ceiling, not a target. The real size control comes
-// from maxWidthOrHeight + initialQuality — setting maxSizeMB too low makes
-// the library iteratively crush quality to hit the byte target.
+// maxSizeMB is a safety ceiling aligned with the bucket's file_size_limit
+// (see supabase/migrations/20260410000000_storage_buckets.sql). The real
+// size control comes from maxWidthOrHeight + initialQuality — natural
+// output is well under these ceilings.
 const CONFIG: Record<ImageUploadType, UploadConfig> = {
   avatar: {
     bucket: "avatars",
     maxWidthOrHeight: 400,
-    maxSizeMB: 1,
+    maxSizeMB: 0.5,
   },
   event: {
     bucket: "event-images",
     maxWidthOrHeight: 1200,
-    maxSizeMB: 2,
+    maxSizeMB: 1,
   },
 };
 

--- a/lib/uploadImage.ts
+++ b/lib/uploadImage.ts
@@ -1,0 +1,65 @@
+import imageCompression from "browser-image-compression";
+import { createClient } from "@/lib/supabase/client";
+
+export type ImageUploadType = "avatar" | "event";
+
+interface UploadConfig {
+  bucket: "avatars" | "event-images";
+  maxWidthOrHeight: number;
+  maxSizeMB: number;
+}
+
+const CONFIG: Record<ImageUploadType, UploadConfig> = {
+  avatar: {
+    bucket: "avatars",
+    maxWidthOrHeight: 400,
+    maxSizeMB: 0.1, // ~100KB target
+  },
+  event: {
+    bucket: "event-images",
+    maxWidthOrHeight: 1200,
+    maxSizeMB: 0.4, // ~400KB target
+  },
+};
+
+/**
+ * Compresses an image client-side and uploads it to Supabase Storage.
+ *
+ * @param file - The image file to upload
+ * @param type - "avatar" or "event" — determines bucket and sizing
+ * @param path - Storage path without extension (e.g. `${userId}/avatar`)
+ * @returns The public URL of the uploaded image
+ */
+export async function uploadImage(
+  file: File,
+  type: ImageUploadType,
+  path: string,
+): Promise<string> {
+  const config = CONFIG[type];
+
+  const compressed = await imageCompression(file, {
+    maxSizeMB: config.maxSizeMB,
+    maxWidthOrHeight: config.maxWidthOrHeight,
+    useWebWorker: true,
+    fileType: "image/jpeg",
+    initialQuality: 0.85,
+  });
+
+  const supabase = createClient();
+  const fullPath = `${path}.jpg`;
+
+  const { error } = await supabase.storage
+    .from(config.bucket)
+    .upload(fullPath, compressed, {
+      contentType: "image/jpeg",
+      upsert: true,
+      cacheControl: "3600",
+    });
+
+  if (error) {
+    throw new Error(`Upload failed: ${error.message}`);
+  }
+
+  const { data } = supabase.storage.from(config.bucket).getPublicUrl(fullPath);
+  return data.publicUrl;
+}

--- a/lib/uploadImage.ts
+++ b/lib/uploadImage.ts
@@ -9,16 +9,19 @@ interface UploadConfig {
   maxSizeMB: number;
 }
 
+// maxSizeMB is a safety ceiling, not a target. The real size control comes
+// from maxWidthOrHeight + initialQuality — setting maxSizeMB too low makes
+// the library iteratively crush quality to hit the byte target.
 const CONFIG: Record<ImageUploadType, UploadConfig> = {
   avatar: {
     bucket: "avatars",
     maxWidthOrHeight: 400,
-    maxSizeMB: 0.1, // ~100KB target
+    maxSizeMB: 1,
   },
   event: {
     bucket: "event-images",
     maxWidthOrHeight: 1200,
-    maxSizeMB: 0.4, // ~400KB target
+    maxSizeMB: 2,
   },
 };
 
@@ -42,7 +45,7 @@ export async function uploadImage(
     maxWidthOrHeight: config.maxWidthOrHeight,
     useWebWorker: true,
     fileType: "image/jpeg",
-    initialQuality: 0.85,
+    initialQuality: 0.9,
   });
 
   const supabase = createClient();

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,7 +13,7 @@ const securityHeaders = [
       // what's calling eval() rather than blanket-allowing it.
       `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://va.vercel-scripts.com`,
       "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: blob:",
+      "img-src 'self' data: blob: https://*.supabase.co",
       "font-src 'self'",
       // Supabase realtime + API, Vercel Analytics
       `connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vitals.vercel-insights.com${isDev ? " http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:*" : ""}`,

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,7 +13,7 @@ const securityHeaders = [
       // what's calling eval() rather than blanket-allowing it.
       `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://va.vercel-scripts.com`,
       "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: blob: https://*.supabase.co",
+      `img-src 'self' data: blob: https://*.supabase.co${isDev ? " http://127.0.0.1:* http://localhost:*" : ""}`,
       "font-src 'self'",
       // Supabase realtime + API, Vercel Analytics
       `connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vitals.vercel-insights.com${isDev ? " http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:*" : ""}`,

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,18 @@ import type { NextConfig } from "next";
 
 const isDev = process.env.NODE_ENV === "development";
 
+// Narrow the CSP img-src allowlist to the specific Supabase project
+// origin rather than a wildcard. Falls back empty if not configured.
+const supabaseOrigin = (() => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!url) return "";
+  try {
+    return new URL(url).origin;
+  } catch {
+    return "";
+  }
+})();
+
 const securityHeaders = [
   {
     key: "Content-Security-Policy",
@@ -13,7 +25,7 @@ const securityHeaders = [
       // what's calling eval() rather than blanket-allowing it.
       `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://va.vercel-scripts.com`,
       "style-src 'self' 'unsafe-inline'",
-      `img-src 'self' data: blob: https://*.supabase.co${isDev ? " http://127.0.0.1:* http://localhost:*" : ""}`,
+      `img-src 'self' data: blob:${supabaseOrigin ? ` ${supabaseOrigin}` : ""}${isDev ? " http://127.0.0.1:* http://localhost:*" : ""}`,
       "font-src 'self'",
       // Supabase realtime + API, Vercel Analytics
       `connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vitals.vercel-insights.com${isDev ? " http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:*" : ""}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@supabase/supabase-js": "^2.98.0",
         "@types/dompurify": "^3.2.0",
         "@vercel/analytics": "^2.0.0",
+        "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dompurify": "^3.3.2",
@@ -1212,9 +1213,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1230,9 +1228,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1250,9 +1245,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1268,9 +1260,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1288,9 +1277,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1306,9 +1292,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1326,9 +1309,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1345,9 +1325,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1363,9 +1340,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1389,9 +1363,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1413,9 +1384,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1439,9 +1407,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1463,9 +1428,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1489,9 +1451,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1514,9 +1473,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1538,9 +1494,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1908,9 +1861,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1926,9 +1876,6 @@
       "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1946,9 +1893,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1964,9 +1908,6 @@
       "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3972,9 +3913,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3992,9 +3930,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4012,9 +3947,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4032,9 +3964,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5025,9 +4954,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5042,9 +4968,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5059,9 +4982,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5076,9 +4996,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5093,9 +5010,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5110,9 +5024,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5127,9 +5038,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5144,9 +5052,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5748,6 +5653,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -9496,9 +9409,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9520,9 +9430,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9544,9 +9451,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9568,9 +9472,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13882,6 +13783,11 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@supabase/supabase-js": "^2.98.0",
     "@types/dompurify": "^3.2.0",
     "@vercel/analytics": "^2.0.0",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.3.2",

--- a/supabase/migrations/20260410000000_storage_buckets.sql
+++ b/supabase/migrations/20260410000000_storage_buckets.sql
@@ -1,0 +1,65 @@
+-- Storage buckets for image uploads
+-- avatars: profile photos (~400x400, ~50-80KB JPEG)
+-- event-images: event cover photos (~1200px wide, ~200-300KB JPEG)
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values
+  ('avatars', 'avatars', true, 524288, array['image/jpeg', 'image/png', 'image/webp']),
+  ('event-images', 'event-images', true, 1048576, array['image/jpeg', 'image/png', 'image/webp'])
+on conflict (id) do nothing;
+
+-- Public read access for both buckets
+create policy "Public can view avatars"
+  on storage.objects for select
+  using (bucket_id = 'avatars');
+
+create policy "Public can view event images"
+  on storage.objects for select
+  using (bucket_id = 'event-images');
+
+-- Authenticated members can upload to their own avatar path (userId/...)
+create policy "Members can upload own avatar"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'avatars'
+    and public.is_member()
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Authenticated members can update/replace their own avatar
+create policy "Members can update own avatar"
+  on storage.objects for update
+  using (
+    bucket_id = 'avatars'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Members can delete their own avatar
+create policy "Members can delete own avatar"
+  on storage.objects for delete
+  using (
+    bucket_id = 'avatars'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Content editors and admins can upload event images
+create policy "Editors can upload event images"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'event-images'
+    and public.is_content_editor()
+  );
+
+create policy "Editors can update event images"
+  on storage.objects for update
+  using (
+    bucket_id = 'event-images'
+    and public.is_content_editor()
+  );
+
+create policy "Editors can delete event images"
+  on storage.objects for delete
+  using (
+    bucket_id = 'event-images'
+    and public.is_content_editor()
+  );


### PR DESCRIPTION
## Summary

Foundation for upcoming photo upload features. Adds a reusable client-side image upload utility that compresses images before pushing them to Supabase Storage. No upload UI is built here — future branches (`feat/member-directory`, event cover photos, etc.) will import `uploadImage` and wire it to a file input.

- **Storage buckets** (`supabase/migrations/20260410000000_storage_buckets.sql`): `avatars` (per-user path, members can write to their own folder) and `event-images` (content_editor+ only). Both public-read, JPEG/PNG/WebP only, with 512KB / 1MB file-size caps enforced at the bucket level.
- **`lib/uploadImage.ts`**: `uploadImage(file, "avatar" | "event", path)` — compresses with `browser-image-compression`, resizes (400px avatars, 1200px events), outputs JPEG at quality 0.9, uploads, returns public URL. `maxSizeMB` is intentionally loose (1–2MB) so resize + quality drive the output rather than iterative quality crushing.
- **CSP** (`next.config.ts`): `img-src` now allows `https://*.supabase.co` in all environments, and `http://127.0.0.1:*` / `http://localhost:*` in dev for local Supabase Storage.

Tested end-to-end with a throwaway admin test page (since removed): a 7.7MB headshot compressed cleanly to a sharp 400×400 avatar with preserved quality.

## Test plan

- [ ] Apply the new migration to the target Supabase environment (creates both buckets + RLS policies)
- [ ] Verify `avatars` and `event-images` buckets appear in the Supabase dashboard as public buckets
- [ ] Verify RLS policies exist on `storage.objects` for both buckets
- [ ] Spot-check that `next build` succeeds and CSP headers include the new `img-src` entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image upload for avatars and event images with automatic client-side compression.
  * Per-type upload settings to enforce size and dimension limits.

* **Chores**
  * Added an image compression dependency.
  * Updated Content-Security-Policy to allow images from the configured storage origin and local dev hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->