### PR TITLE
chore(deps): align blocknote packages and group renovate updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.2.0",
-    "@blocknote/core": "^0.47.3",
+    "@blocknote/core": "^0.48.0",
     "@blocknote/react": "^0.48.0",
-    "@blocknote/shadcn": "^0.47.3",
+    "@blocknote/shadcn": "^0.48.0",
     "@supabase/ssr": "^0.10.0",
     "@supabase/supabase-js": "^2.98.0",
     "@types/dompurify": "^3.2.0",

--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,12 @@
   ],
   "lockFileMaintenance": {
     "automergeSchedule": ["at any time"]
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Group all non-major npm dependency updates into a single PR",
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "non-major dependencies"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Bumps `@blocknote/core` and `@blocknote/shadcn` to `^0.48.0` to match `@blocknote/react`, fixing version mismatch that caused Vercel preview build failures on PRs #73 and #75
- Adds a Renovate `packageRule` to group all non-major dependency updates into a single PR, preventing future version conflicts between tightly-coupled packages

## Notes
- Lockfile not included — Renovate will regenerate it cleanly on merge
- Once merged, close PRs #73, #75, and #69 as superseded

## Test plan
- [ ] Verify Vercel preview deployment succeeds
- [ ] Confirm Renovate creates grouped PRs for future minor/patch updates