### PR TITLE
feat: gate content behind auth, fix ICS subscriptions

### DIFF
--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -17,10 +17,10 @@
 # disclosure. This is by design and contains no sensitive server-side data.
 10027	IGNORE	# Information Disclosure - Suspicious Comments (Next.js build metadata)
 
-# CSP unsafe-inline in style-src: Next.js requires this without nonce-based CSP
-# middleware (CSS-in-JS and Tailwind inject inline styles at runtime). Removing it
-# would break the UI. The risk is limited compared to unsafe-inline in script-src.
-10055	IGNORE	# CSP: style-src unsafe-inline
+# CSP: style-src unsafe-inline. Next.js/Tailwind require this (CSS-in-JS injects
+# inline styles at runtime). Risk is limited since only styles, not scripts.
+# script-src unsafe-inline was removed via nonce-based CSP in middleware.
+10055	IGNORE	# CSP: style-src unsafe-inline (only; script-src now uses nonce)
 
 # ZAP identifying the app as a Next.js SPA. Informational only, not a vulnerability.
 10109	IGNORE	# Modern Web Application
@@ -45,6 +45,12 @@
 # ZAP flags its own spider-injected test emails (e.g. zaproxy@example.com) appearing
 # in URLs it constructed. Our forms submit via JS (onSubmit), not GET.
 10024	IGNORE	# Information Disclosure - Sensitive Information in URL
+
+# User Controllable HTML Element Attribute: ZAP flags the login ?email= and ?redirect=
+# parameters as potentially appearing in HTML attributes. This is a false positive:
+# neither login nor forgot-password reads the email param; the redirect param is
+# only used in router.replace() post-auth, never rendered into any HTML attribute.
+10031	IGNORE	# User Controllable HTML Element Attribute (false positive)
 
 # Retrieved from Cache: informational only — Vercel CDN caching is intentional.
 10050	IGNORE	# Retrieved from Cache

--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/server";
 import { generateMultiEventICS } from "@/lib/ics-utils";
 import type { Event } from "@/lib/types";
 
@@ -12,7 +12,7 @@ export async function GET(request: Request) {
     return new Response("Invalid calendar ID", { status: 400 });
   }
 
-  const supabase = await createClient();
+  const supabase = await createServiceClient();
 
   // Bound results to a reasonable time window
   const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
@@ -20,7 +20,6 @@ export async function GET(request: Request) {
   let query = supabase
     .from("events")
     .select("*")
-    .eq("is_private", false)
     .gte("start_time", thirtyDaysAgo)
     .order("start_time", { ascending: true })
     .limit(500);

--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -4,15 +4,31 @@ import type { Event } from "@/lib/types";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
+  const token = searchParams.get("token");
   const calendarId = searchParams.get("calendar");
 
-  // Validate calendarId if provided
+  // Require a valid subscription token
   const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-  if (calendarId && !uuidRegex.test(calendarId)) {
-    return new Response("Invalid calendar ID", { status: 400 });
+  if (!token || !uuidRegex.test(token)) {
+    return new Response("Unauthorized", { status: 401 });
   }
 
   const supabase = await createServiceClient();
+
+  const { data: sub } = await supabase
+    .from("calendar_subscription_tokens")
+    .select("id")
+    .eq("token", token)
+    .single();
+
+  if (!sub) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  // Validate calendarId if provided
+  if (calendarId && !uuidRegex.test(calendarId)) {
+    return new Response("Invalid calendar ID", { status: 400 });
+  }
 
   // Bound results to a reasonable time window
   const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();

--- a/app/api/events/[id]/ics/route.ts
+++ b/app/api/events/[id]/ics/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/server";
 import { generateSingleEventICS } from "@/lib/ics-utils";
 import type { Event } from "@/lib/types";
 
@@ -7,7 +7,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
-  const supabase = await createClient();
+  const supabase = await createServiceClient();
 
   const { data: event, error } = await supabase
     .from("events")

--- a/app/api/events/[id]/ics/route.ts
+++ b/app/api/events/[id]/ics/route.ts
@@ -3,11 +3,30 @@ import { generateSingleEventICS } from "@/lib/ics-utils";
 import type { Event } from "@/lib/types";
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
+  const { searchParams } = new URL(request.url);
+  const token = searchParams.get("token");
+
+  // Require a valid subscription token
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!token || !uuidRegex.test(token)) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
   const supabase = await createServiceClient();
+
+  const { data: sub } = await supabase
+    .from("calendar_subscription_tokens")
+    .select("id")
+    .eq("token", token)
+    .single();
+
+  if (!sub) {
+    return new Response("Unauthorized", { status: 401 });
+  }
 
   const { data: event, error } = await supabase
     .from("events")

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -25,28 +25,11 @@ export async function generateMetadata({
   const supabase = await createClient();
   const { data: event } = await supabase
     .from("events")
-    .select("title, is_private")
+    .select("title")
     .eq("id", id)
     .single();
 
   if (!event) {
-    return { title: `Event | ${siteConfig.name}` };
-  }
-
-  // Don't leak private event titles to non-members
-  if (event.is_private) {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (user) {
-      const { data: profile } = await supabase
-        .from("profiles")
-        .select("role")
-        .eq("id", user.id)
-        .single();
-      const isMember = profile?.role === "member" || profile?.role === "content_editor" || profile?.role === "admin";
-      if (isMember) {
-        return { title: `${event.title} | ${siteConfig.name}` };
-      }
-    }
     return { title: `Event | ${siteConfig.name}` };
   }
 
@@ -103,9 +86,6 @@ export default async function EventDetailPage({
     profile?.role === "member" ||
     profile?.role === "content_editor" ||
     isAdmin;
-
-  // Hide private events from non-members
-  if (event.is_private && !isMember) notFound();
 
   // Fetch current user's RSVP
   let userRsvp: Rsvp | null = null;

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -87,6 +87,17 @@ export default async function EventDetailPage({
     profile?.role === "content_editor" ||
     isAdmin;
 
+  // Fetch the user's calendar subscription token
+  let subscriptionToken: string | null = null;
+  if (user && isMember) {
+    const { data: tokenRow } = await supabase
+      .from("calendar_subscription_tokens")
+      .select("token")
+      .eq("user_id", user.id)
+      .single();
+    subscriptionToken = tokenRow?.token ?? null;
+  }
+
   // Fetch current user's RSVP
   let userRsvp: Rsvp | null = null;
   if (user && isMember) {
@@ -251,7 +262,7 @@ export default async function EventDetailPage({
               location={event.location}
               description={event.description}
             />
-            <SubscribeToEventButton eventId={event.id} />
+            <SubscribeToEventButton eventId={event.id} subscriptionToken={subscriptionToken} />
           </div>
 
           {/* RSVP */}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -47,10 +47,6 @@ export default async function EventsPage() {
     .order("start_time", { ascending: true })
     .limit(500);
 
-  if (!isMember) {
-    allEventsQuery = allEventsQuery.eq("is_private", false);
-  }
-
   // Fetch upcoming events for list view.
   // Include non-recurring events starting from now, AND recurring anchors whose
   // series hasn't ended yet (recurrence_until IS NULL or >= now).
@@ -64,10 +60,6 @@ export default async function EventsPage() {
     .order("start_time", { ascending: true })
     .limit(1000);
 
-  if (!isMember) {
-    upcomingEventsQuery = upcomingEventsQuery.eq("is_private", false);
-  }
-
   const { data: allEventsRaw, error: allEventsError } = await allEventsQuery;
   if (allEventsError) {
     console.error("Failed to fetch events:", allEventsError);
@@ -78,16 +70,11 @@ export default async function EventsPage() {
     console.error("Failed to fetch upcoming events:", upcomingEventsError);
   }
 
-  // Fetch event calendars — for non-members, only include calendars with public events
-  const { data: calendarsRaw, error: calendarsError } = isMember
-    ? await supabase.from("event_calendars").select("*").order("name", { ascending: true })
-    : await supabase
-        .from("event_calendars")
-        .select("*, events!inner(id)")
-        .eq("events.is_private", false)
-        .gte("events.start_time", oneYearAgo)
-        .lte("events.start_time", oneYearAhead)
-        .order("name", { ascending: true });
+  // Fetch event calendars
+  const { data: calendarsRaw, error: calendarsError } = await supabase
+    .from("event_calendars")
+    .select("*")
+    .order("name", { ascending: true });
   if (calendarsError) {
     console.error("Failed to fetch event calendars:", calendarsError);
   }

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -79,6 +79,27 @@ export default async function EventsPage() {
     console.error("Failed to fetch event calendars:", calendarsError);
   }
 
+  // Fetch or create the user's calendar subscription token
+  let subscriptionToken: string | null = null;
+  if (user && isMember) {
+    const { data: existingToken } = await supabase
+      .from("calendar_subscription_tokens")
+      .select("token")
+      .eq("user_id", user.id)
+      .single();
+
+    if (existingToken) {
+      subscriptionToken = existingToken.token;
+    } else {
+      const { data: newToken } = await supabase
+        .from("calendar_subscription_tokens")
+        .insert({ user_id: user.id })
+        .select("token")
+        .single();
+      subscriptionToken = newToken?.token ?? null;
+    }
+  }
+
   // Fetch user's RSVPs if logged in
   let userRsvps: Record<string, Rsvp> = {};
   if (user && isMember) {
@@ -109,6 +130,7 @@ export default async function EventsPage() {
         userId={user?.id ?? null}
         isMember={isMember}
         isAdmin={isAdmin}
+        subscriptionToken={subscriptionToken}
       />
     </div>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { AppShell } from "@/components/layout/AppShell";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { siteConfig } from "@/lib/config";
 import "./globals.css";
@@ -37,6 +37,8 @@ export default async function RootLayout({
   // Skip the getUser() call entirely when there are no auth cookies.
   // This avoids noisy "Invalid Refresh Token" errors for unauthenticated visitors.
   const cookieStore = await cookies();
+  const headerStore = await headers();
+  const nonce = headerStore.get("x-nonce") ?? "";
   const hasAuthCookie = cookieStore.getAll().some((c) => c.name.includes("auth-token"));
 
   let profile = null;

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -15,7 +15,9 @@ export default function LoginPage() {
   const supabase = createClient();
   const searchParams = useSearchParams();
   const router = useRouter();
-  const redirect = searchParams.get("redirect") || "/dashboard";
+  const rawRedirect = searchParams.get("redirect") || "/dashboard";
+  // Prevent open-redirect: only allow relative paths starting with /
+  const redirect = rawRedirect.startsWith("/") && !rawRedirect.startsWith("//") ? rawRedirect : "/dashboard";
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,28 +1,11 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { EventCard } from "@/components/events/EventCard";
-import { AnnouncementCard } from "@/components/announcements/AnnouncementCard";
 import { createClient } from "@/lib/supabase/server";
 import { siteConfig } from "@/lib/config";
 import { Heart, Users, BookOpen, ArrowRight, Sparkles } from "lucide-react";
 
 export default async function HomePage() {
   const supabase = await createClient();
-
-  const { data: events } = await supabase
-    .from("events")
-    .select("*")
-    .eq("is_private", false)
-    .gte("start_time", new Date().toISOString())
-    .order("start_time", { ascending: true })
-    .limit(3);
-
-  const { data: announcements } = await supabase
-    .from("announcements")
-    .select("*")
-    .eq("is_published", true)
-    .order("published_at", { ascending: false })
-    .limit(1);
 
   const { data: donationSetting } = await supabase
     .from("site_settings")
@@ -104,9 +87,9 @@ export default async function HomePage() {
                 size="lg"
                 className="text-lg px-8 py-6 font-semibold border-2 border-white/40 text-white bg-white/10 hover:bg-white/20 hover:border-white/60 backdrop-blur-sm"
                 nativeButton={false}
-                render={<Link href="/events" />}
+                render={<Link href="/login" />}
               >
-                View Events
+                Sign In
               </Button>
             </div>
           </div>
@@ -181,56 +164,6 @@ export default async function HomePage() {
           </div>
         </div>
       </section>
-
-      {/* ── Upcoming Events ── */}
-      {events && events.length > 0 && (
-        <section className="py-20" style={{ background: "#ecfdf5" }}>
-          <div className="container mx-auto px-4">
-            <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-4 mb-12">
-              <div>
-                <p className="text-brand-primary-light font-bold text-base uppercase tracking-widest mb-2">
-                  On the Calendar
-                </p>
-                <h2 className="font-display text-4xl font-bold text-brand-primary">
-                  Upcoming Events
-                </h2>
-              </div>
-              <Button
-                variant="outline"
-                size="lg"
-                className="text-base font-semibold border-2 border-emerald-300 text-brand-primary hover:bg-brand-primary-light hover:text-white hover:border-emerald-600 transition-all"
-                nativeButton={false}
-                render={<Link href="/events" />}
-              >
-                View All Events
-                <ArrowRight className="ml-2 h-4 w-4" />
-              </Button>
-            </div>
-            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {events.map((event) => (
-                <EventCard key={event.id} event={event} />
-              ))}
-            </div>
-          </div>
-        </section>
-      )}
-
-      {/* ── Latest Announcement ── */}
-      {announcements && announcements.length > 0 && (
-        <section className="py-20">
-          <div className="container mx-auto px-4 max-w-3xl">
-            <div className="text-center mb-10">
-              <p className="text-brand-accent font-bold text-base uppercase tracking-widest mb-2">
-                From the Group
-              </p>
-              <h2 className="font-display text-4xl font-bold text-brand-primary">
-                Latest Announcement
-              </h2>
-            </div>
-            <AnnouncementCard announcement={announcements[0]} />
-          </div>
-        </section>
-      )}
 
       {/* ── Donation CTA ── */}
       {donationUrl && (

--- a/components/events/EventsPageClient.tsx
+++ b/components/events/EventsPageClient.tsx
@@ -89,9 +89,7 @@ export function EventsPageClient({
             <div>
               <h1 className="text-3xl md:text-4xl font-bold text-brand-primary">Calendar</h1>
               <p className="mt-2 text-lg text-muted-foreground">
-                {isMember
-                  ? "Browse the shared calendar for our group."
-                  : "Browse the public calendar. Sign in to see all events and RSVP."}
+                Browse the shared calendar for our group.
               </p>
             </div>
           </div>

--- a/components/events/EventsPageClient.tsx
+++ b/components/events/EventsPageClient.tsx
@@ -28,6 +28,7 @@ interface EventsPageClientProps {
   userId: string | null;
   isMember: boolean;
   isAdmin: boolean;
+  subscriptionToken: string | null;
 }
 
 export function EventsPageClient({
@@ -38,6 +39,7 @@ export function EventsPageClient({
   userId,
   isMember,
   isAdmin,
+  subscriptionToken,
 }: EventsPageClientProps) {
   const [view, setView] = useState<View>("calendar");
   const [showSubscribeMenu, setShowSubscribeMenu] = useState(false);
@@ -131,7 +133,7 @@ export function EventsPageClient({
                 <div className="absolute right-0 z-20 mt-2 w-56 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-lg">
                   <button
                     onClick={() => {
-                      window.location.href = `webcal://${window.location.host}/api/calendar/feed.ics`;
+                      window.location.href = `webcal://${window.location.host}/api/calendar/feed.ics?token=${subscriptionToken}`;
                       setShowSubscribeMenu(false);
                     }}
                     className="w-full cursor-pointer border-b border-slate-100 px-4 py-2.5 text-left text-sm text-slate-700 hover:bg-slate-50"
@@ -142,7 +144,7 @@ export function EventsPageClient({
                     <button
                       key={cal.id}
                       onClick={() => {
-                        window.location.href = `webcal://${window.location.host}/api/calendar/feed.ics?calendar=${cal.id}`;
+                        window.location.href = `webcal://${window.location.host}/api/calendar/feed.ics?token=${subscriptionToken}&calendar=${cal.id}`;
                         setShowSubscribeMenu(false);
                       }}
                       className="flex w-full cursor-pointer items-center gap-2 border-b border-slate-100 px-4 py-2.5 text-left text-sm text-slate-700 hover:bg-slate-50 last:border-b-0"

--- a/components/events/NewEventForm.tsx
+++ b/components/events/NewEventForm.tsx
@@ -158,7 +158,6 @@ export function NewEventForm() {
       location: nextLocation || null,
       start_time: localToUTCISO(startTime),
       end_time: endTime ? localToUTCISO(endTime) : null,
-      is_private: true,
       calendar_id: calendarId || null,
       is_rsvp_enabled: isRsvpEnabled,
       created_by: user?.id,

--- a/components/events/SubscribeToEventButton.tsx
+++ b/components/events/SubscribeToEventButton.tsx
@@ -5,13 +5,16 @@ import { Button } from "@/components/ui/button";
 
 interface SubscribeToEventButtonProps {
   eventId: string;
+  subscriptionToken: string | null;
 }
 
-export function SubscribeToEventButton({ eventId }: SubscribeToEventButtonProps) {
+export function SubscribeToEventButton({ eventId, subscriptionToken }: SubscribeToEventButtonProps) {
+  if (!subscriptionToken) return null;
+
   return (
     <Button
       onClick={() => {
-        window.location.href = `webcal://${window.location.host}/api/events/${eventId}/ics`;
+        window.location.href = `webcal://${window.location.host}/api/events/${eventId}/ics?token=${subscriptionToken}`;
       }}
       variant="outline"
       size="lg"

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -35,11 +35,6 @@ export function Header({ profile }: HeaderProps) {
   const isAdmin = profile?.role === "admin";
   const isMember = profile?.role === "member" || isAdmin;
 
-  const publicLinks = [
-    { href: "/events", label: "Calendar" },
-    { href: "/lectures", label: "Lectures" },
-  ];
-
   const memberLinks = [
     { href: "/dashboard", label: "Dashboard" },
     { href: "/events", label: "Calendar" },
@@ -47,7 +42,7 @@ export function Header({ profile }: HeaderProps) {
     { href: "/lectures", label: "Lectures" },
   ];
 
-  const links = isMember ? memberLinks : publicLinks;
+  const links = isMember ? memberLinks : [];
 
   return (
     <header
@@ -104,25 +99,15 @@ export function Header({ profile }: HeaderProps) {
                 Sign Out
               </Button>
             ) : (
-              <>
-                <Button
-                  variant="ghost"
-                  size="lg"
-                  className="text-base text-slate-600 hover:text-brand-primary"
-                  nativeButton={false}
-                  render={<Link href="/login" />}
-                >
-                  Sign In
-                </Button>
-                <Button
-                  size="lg"
-                  className="text-base bg-brand-accent hover:bg-brand-accent/90 text-white shadow-sm hover:shadow-md transition-all px-6"
-                  nativeButton={false}
-                  render={<Link href="/join" />}
-                >
-                  Join Us
-                </Button>
-              </>
+              <Button
+                variant="ghost"
+                size="lg"
+                className="text-base text-slate-600 hover:text-brand-primary"
+                nativeButton={false}
+                render={<Link href="/login" />}
+              >
+                Sign In
+              </Button>
             )}
           </div>
         </nav>
@@ -172,25 +157,15 @@ export function Header({ profile }: HeaderProps) {
                     Sign Out
                   </Button>
                 ) : (
-                  <>
-                    <Button
-                      variant="outline"
-                      size="lg"
-                      className="w-full text-lg border-emerald-200 text-brand-primary"
-                      nativeButton={false}
-                      render={<Link href="/login" onClick={() => setOpen(false)} />}
-                    >
-                      Sign In
-                    </Button>
-                    <Button
-                      size="lg"
-                      className="w-full text-lg bg-brand-accent hover:bg-brand-accent/90 text-white"
-                      nativeButton={false}
-                      render={<Link href="/join" onClick={() => setOpen(false)} />}
-                    >
-                      Join Us
-                    </Button>
-                  </>
+                  <Button
+                    variant="outline"
+                    size="lg"
+                    className="w-full text-lg border-emerald-200 text-brand-primary"
+                    nativeButton={false}
+                    render={<Link href="/login" onClick={() => setOpen(false)} />}
+                  >
+                    Sign In
+                  </Button>
                 )}
               </div>
             </nav>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -33,7 +33,7 @@ export function Header({ profile }: HeaderProps) {
   };
 
   const isAdmin = profile?.role === "admin";
-  const isMember = profile?.role === "member" || isAdmin;
+  const isMember = profile?.role === "member" || profile?.role === "content_editor" || isAdmin;
 
   const memberLinks = [
     { href: "/dashboard", label: "Dashboard" },

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -32,7 +32,7 @@ export async function updateSession(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
   // Protected routes - require authentication
-  const protectedPaths = ["/dashboard", "/announcements", "/update-password"];
+  const protectedPaths = ["/dashboard", "/announcements", "/update-password", "/events", "/lectures"];
   const adminPaths = ["/admin"];
 
   const isProtected = protectedPaths.some((p) => pathname.startsWith(p));

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,8 +1,45 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
+const isDev = process.env.NODE_ENV === "development";
+
+// Narrow the CSP img-src allowlist to the specific Supabase project
+// origin rather than a wildcard. Falls back empty if not configured.
+const supabaseOrigin = (() => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!url) return "";
+  try {
+    return new URL(url).origin;
+  } catch {
+    return "";
+  }
+})();
+
 export async function updateSession(request: NextRequest) {
-  let supabaseResponse = NextResponse.next({ request });
+  // Generate a nonce for CSP
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+
+  // Create request headers with nonce for downstream RSC access
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+
+  // Build CSP dynamically with nonce instead of unsafe-inline
+  const cspHeader = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}'${isDev ? " 'unsafe-eval'" : ""} https://va.vercel-scripts.com https://maps.googleapis.com https://maps.gstatic.com blob:`,
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    `img-src 'self' data: blob: https://maps.gstatic.com https://maps.googleapis.com${supabaseOrigin ? ` ${supabaseOrigin}` : ""}${isDev ? " http://127.0.0.1:* http://localhost:*" : ""}`,
+    "font-src 'self' https://fonts.gstatic.com",
+    `connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vitals.vercel-insights.com https://maps.googleapis.com https://places.googleapis.com https://maps.gstatic.com blob:${isDev ? " http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:*" : ""}`,
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "worker-src blob:",
+    "manifest-src 'self'",
+  ].join("; ");
+
+  let supabaseResponse = NextResponse.next({ request: { headers: requestHeaders } });
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -16,7 +53,7 @@ export async function updateSession(request: NextRequest) {
           cookiesToSet.forEach(({ name, value }) =>
             request.cookies.set(name, value)
           );
-          supabaseResponse = NextResponse.next({ request });
+          supabaseResponse = NextResponse.next({ request: { headers: requestHeaders } });
           cookiesToSet.forEach(({ name, value, options }) =>
             supabaseResponse.cookies.set(name, value, options)
           );
@@ -58,6 +95,9 @@ export async function updateSession(request: NextRequest) {
       return NextResponse.redirect(url);
     }
   }
+
+  // Set CSP header on the response
+  supabaseResponse.headers.set("Content-Security-Policy", cspHeader);
 
   return supabaseResponse;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -132,7 +132,6 @@ export interface Event {
   location: string | null;
   start_time: string;
   end_time: string | null;
-  is_private: boolean;
   calendar_id: string | null;
   is_rsvp_enabled: boolean;
   created_by: string | null;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,43 +1,8 @@
 import type { NextConfig } from "next";
 
-const isDev = process.env.NODE_ENV === "development";
-
-// Narrow the CSP img-src allowlist to the specific Supabase project
-// origin rather than a wildcard. Falls back empty if not configured.
-const supabaseOrigin = (() => {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  if (!url) return "";
-  try {
-    return new URL(url).origin;
-  } catch {
-    return "";
-  }
-})();
-
 const securityHeaders = [
-  {
-    key: "Content-Security-Policy",
-    value: [
-      "default-src 'self'",
-      // Next.js requires unsafe-inline without nonce-based CSP middleware.
-      // Do NOT add unsafe-eval — production builds don't need it, and it
-      // opens the door to eval-based XSS. If something breaks, investigate
-      // what's calling eval() rather than blanket-allowing it.
-      `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://va.vercel-scripts.com https://maps.googleapis.com https://maps.gstatic.com blob:`,
-      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-      `img-src 'self' data: blob: https://maps.gstatic.com https://maps.googleapis.com${supabaseOrigin ? ` ${supabaseOrigin}` : ""}${isDev ? " http://127.0.0.1:* http://localhost:*" : ""}`,
-      "font-src 'self' https://fonts.gstatic.com",
-      // Supabase realtime + API, Vercel Analytics, Google Maps
-      `connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vitals.vercel-insights.com https://maps.googleapis.com https://places.googleapis.com https://maps.gstatic.com blob:${isDev ? " http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:*" : ""}`,
-      "frame-ancestors 'none'",
-      "object-src 'none'",
-      "base-uri 'self'",
-      // Restrict form submissions and worker scripts.
-      "form-action 'self'",
-      "worker-src blob:",
-      "manifest-src 'self'",
-    ].join("; "),
-  },
+  // CSP is now generated dynamically per-request in lib/supabase/middleware.ts
+  // using a cryptographic nonce instead of unsafe-inline for script-src.
   {
     key: "Permissions-Policy",
     value: "camera=(), microphone=(), geolocation=(), payment=(), usb=()",

--- a/supabase/migrations/20260421000000_remove_is_private.sql
+++ b/supabase/migrations/20260421000000_remove_is_private.sql
@@ -1,0 +1,8 @@
+-- Remove is_private column from events table
+-- All events are now members-only (enforced by middleware + RLS)
+
+-- Drop the public events policy (no longer needed)
+drop policy if exists "Public events visible to all" on public.events;
+
+-- Drop the is_private column
+alter table public.events drop column if exists is_private;

--- a/supabase/migrations/20260421000001_calendar_subscription_tokens.sql
+++ b/supabase/migrations/20260421000001_calendar_subscription_tokens.sql
@@ -1,0 +1,24 @@
+-- Subscription tokens for authenticated calendar (ICS) feeds.
+-- Each member gets one unguessable token; external calendar apps
+-- include it in the webcal URL so the ICS endpoint can verify access.
+
+create table public.calendar_subscription_tokens (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  token uuid not null default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  constraint calendar_subscription_tokens_user_id_key unique (user_id),
+  constraint calendar_subscription_tokens_token_key unique (token)
+);
+
+alter table public.calendar_subscription_tokens enable row level security;
+
+-- Members can read their own token
+create policy "Members can view own subscription token"
+  on public.calendar_subscription_tokens for select
+  using (auth.uid() = user_id);
+
+-- Members can insert their own token
+create policy "Members can create own subscription token"
+  on public.calendar_subscription_tokens for insert
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- **ICS fix**: Calendar subscription endpoints now use the service client so external calendar apps (Apple Calendar, etc.) can fetch event data without browser cookies
- **Auth gating**: Events, lectures, and calendar are now protected routes — unauthenticated users are redirected to login
- **Remove `is_private`**: Drops the column and RLS policy since all events are now members-only
- **Homepage cleanup**: Removes event/announcement previews for unauthenticated visitors; hero CTA changed from "View Events" to "Sign In"
- **Header cleanup**: Unauthenticated users see only the logo and Sign In — no Calendar, Lectures, or Join Us links

## Test plan
- [ ] Apply migration: verify `is_private` column and public RLS policy are dropped
- [ ] Visit `/events` and `/lectures` while logged out — should redirect to `/login`
- [ ] Homepage should show hero, pillars, and donation CTA only (no events/announcements)
- [ ] Header should show only logo + Sign In when logged out
- [ ] Log in as member — Calendar, Lectures, Dashboard, Announcements all accessible
- [ ] Subscribe to calendar via `webcal://` URL — should succeed and return valid ICS
- [ ] Create a new event as admin — should work without `is_private` field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Features**
  * All authenticated users can now access and view all events
  * Events and lectures pages now require sign-in to access

* **Refactor**
  * Simplified homepage by removing event and announcement preview sections
  * Streamlined navigation for unauthenticated users (removed "Join Us" button)
  * Removed event privacy controls from event creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->