### PR TITLE
fix: remove unsupported secrets from semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -16,6 +16,3 @@ permissions:
 jobs:
   semgrep:
     uses: krypsis-io/.github/.github/workflows/semgrep.yml@main
-    secrets:
-      APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
The krypsis-io semgrep workflow does not accept APP_ID and APP_PRIVATE_KEY secrets. Remove them to fix the workflow validation error.