### PR TITLE
feat(directory): directory UX polish — groups view, family photos, printable directory, birthday browsing

### DIFF
--- a/app/admin/families/page.tsx
+++ b/app/admin/families/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
+import { uploadImage } from "@/lib/uploadImage";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -24,7 +25,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { toast } from "sonner";
-import { Plus, Pencil, Trash2, Users, X } from "lucide-react";
+import { Camera, Plus, Pencil, Trash2, Users, X } from "lucide-react";
 import type { FamilyUnit, Profile, FamilyMember, FamilyMemberRelationship } from "@/lib/types";
 import {
   titleCaseName,
@@ -139,6 +140,11 @@ export default function FamiliesPage() {
   const [showMemberForm, setShowMemberForm] = useState(false);
   const [savingMember, setSavingMember] = useState(false);
 
+  // Family photo state (edit mode only — the path needs the family id)
+  const [photoUrl, setPhotoUrl] = useState<string | null>(null);
+  const [uploadingPhoto, setUploadingPhoto] = useState(false);
+  const photoInputRef = useRef<HTMLInputElement>(null);
+
   const supabase = createClient();
 
   useEffect(() => {
@@ -200,6 +206,7 @@ export default function FamiliesPage() {
   function openCreate() {
     setEditing(null);
     setForm(EMPTY_FORM);
+    setPhotoUrl(null);
     setFamilyMembers([]);
     setShowMemberForm(false);
     setEditingMember(null);
@@ -210,6 +217,7 @@ export default function FamiliesPage() {
   function openEdit(family: FamilyUnit) {
     setEditing(family);
     setForm(fromFamily(family));
+    setPhotoUrl(family.photo_url);
     setShowMemberForm(false);
     setEditingMember(null);
     setMemberForm(EMPTY_MEMBER_FORM);
@@ -298,6 +306,49 @@ export default function FamiliesPage() {
     }
     toast.success("Family deleted.");
     setDialogOpen(false);
+    loadFamilies();
+  }
+
+  async function handlePhotoUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file || !editing) return;
+
+    setUploadingPhoto(true);
+    try {
+      const url = await uploadImage(file, "family", `families/${editing.id}/photo`);
+      const { error } = await supabase
+        .from("family_units")
+        .update({ photo_url: url })
+        .eq("id", editing.id);
+      if (error) throw error;
+      // Cache-bust so the new image shows immediately
+      setPhotoUrl(`${url}?t=${Date.now()}`);
+      toast.success("Family photo updated.");
+      loadFamilies();
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to upload family photo.");
+    } finally {
+      setUploadingPhoto(false);
+      if (photoInputRef.current) photoInputRef.current.value = "";
+    }
+  }
+
+  async function handlePhotoRemove() {
+    if (!editing) return;
+    const { error } = await supabase
+      .from("family_units")
+      .update({ photo_url: null })
+      .eq("id", editing.id);
+    if (error) {
+      toast.error("Failed to remove family photo.");
+      return;
+    }
+    await supabase.storage
+      .from("avatars")
+      .remove([`families/${editing.id}/photo.jpg`]);
+    setPhotoUrl(null);
+    toast.success("Family photo removed.");
     loadFamilies();
   }
 
@@ -501,6 +552,65 @@ export default function FamiliesPage() {
                 placeholder="e.g. The Smiths"
               />
             </div>
+
+            {editing && (
+              <div className="space-y-2">
+                <Label>Family photo</Label>
+                {photoUrl ? (
+                  <div className="relative">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={photoUrl}
+                      alt={`${form.family_name} family photo`}
+                      className="w-full aspect-[4/3] object-cover rounded-lg"
+                    />
+                    <div className="absolute bottom-2 right-2 flex gap-2">
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        disabled={uploadingPhoto}
+                        onClick={() => photoInputRef.current?.click()}
+                      >
+                        <Camera className="mr-1 h-4 w-4" />
+                        {uploadingPhoto ? "Uploading..." : "Replace"}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        onClick={handlePhotoRemove}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        <span className="sr-only">Remove photo</span>
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={uploadingPhoto}
+                    onClick={() => photoInputRef.current?.click()}
+                  >
+                    <Camera className="mr-1 h-4 w-4" />
+                    {uploadingPhoto ? "Uploading..." : "Upload family photo"}
+                  </Button>
+                )}
+                <input
+                  ref={photoInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handlePhotoUpload}
+                  className="hidden"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Shown on the household&apos;s directory card in place of
+                  individual avatars.
+                </p>
+              </div>
+            )}
 
             <div className="space-y-2">
               <Label htmlFor="f_address1">Street address</Label>

--- a/app/admin/groups/GroupRosterDialog.tsx
+++ b/app/admin/groups/GroupRosterDialog.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import { Search } from "lucide-react";
+import { setGroupMembership } from "@/lib/memberGroups";
+import { displayName, initials } from "@/lib/names";
+import type { MemberGroup, Profile } from "@/lib/types";
+
+type RosterProfile = Pick<
+  Profile,
+  "id" | "first_name" | "last_name" | "preferred_name" | "avatar_url"
+>;
+
+interface GroupRosterDialogProps {
+  group: MemberGroup | null;
+  onClose: () => void;
+  /** Called with the new member count whenever the roster changes */
+  onCountChange: (groupId: string, count: number) => void;
+}
+
+/**
+ * Manage a group's roster in one place: every member of the class with a
+ * switch to add/remove them from the group. Functional-role booleans are
+ * kept in sync via setGroupMembership.
+ */
+export function GroupRosterDialog({
+  group,
+  onClose,
+  onCountChange,
+}: GroupRosterDialogProps) {
+  const [profiles, setProfiles] = useState<RosterProfile[]>([]);
+  const [assigned, setAssigned] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState("");
+  const [toggling, setToggling] = useState<string | null>(null);
+  const supabase = createClient();
+
+  useEffect(() => {
+    if (!group) return;
+    let cancelled = false;
+
+    async function load(groupId: string) {
+      setLoading(true);
+      setQuery("");
+      const [{ data: members, error: mErr }, { data: rows, error: rErr }] =
+        await Promise.all([
+          supabase
+            .from("profiles")
+            .select("id, first_name, last_name, preferred_name, avatar_url")
+            .in("role", ["member", "content_editor", "admin"])
+            .order("last_name", { ascending: true })
+            .order("first_name", { ascending: true }),
+          supabase
+            .from("profile_groups")
+            .select("profile_id")
+            .eq("group_id", groupId),
+        ]);
+
+      if (cancelled) return;
+      if (mErr || rErr) {
+        toast.error("Failed to load roster.");
+        setLoading(false);
+        return;
+      }
+      setProfiles((members || []) as RosterProfile[]);
+      setAssigned(
+        new Set((rows || []).map((r: { profile_id: string }) => r.profile_id)),
+      );
+      setLoading(false);
+    }
+
+    load(group.id);
+    return () => {
+      cancelled = true;
+    };
+  }, [group?.id]);
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return profiles;
+    const q = query.trim().toLowerCase();
+    return profiles.filter((p) =>
+      [p.first_name, p.last_name, p.preferred_name]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase()
+        .includes(q),
+    );
+  }, [profiles, query]);
+
+  async function handleToggle(profile: RosterProfile, checked: boolean) {
+    if (!group) return;
+    setToggling(profile.id);
+
+    const errorMessage = await setGroupMembership(profile.id, group, checked);
+    if (errorMessage) {
+      toast.error(errorMessage);
+      setToggling(null);
+      return;
+    }
+
+    const next = new Set(assigned);
+    if (checked) next.add(profile.id);
+    else next.delete(profile.id);
+    setAssigned(next);
+    onCountChange(group.id, next.size);
+    setToggling(null);
+  }
+
+  return (
+    <Dialog open={!!group} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-md max-h-[85vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {group?.color && (
+              <span
+                className="inline-block w-3 h-3 rounded-full"
+                style={{ backgroundColor: group.color }}
+              />
+            )}
+            {group?.name} — {assigned.size} member{assigned.size !== 1 ? "s" : ""}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="relative shrink-0">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            type="search"
+            placeholder="Search members..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="pl-10"
+          />
+        </div>
+
+        <div className="overflow-y-auto flex-1 -mx-1 px-1">
+          {loading ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">
+              Loading members...
+            </p>
+          ) : filtered.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">
+              No members match your search.
+            </p>
+          ) : (
+            <div className="divide-y">
+              {filtered.map((p) => (
+                <div key={p.id} className="flex items-center gap-3 py-2.5">
+                  <Avatar className="h-8 w-8 shrink-0">
+                    {p.avatar_url && (
+                      <AvatarImage src={p.avatar_url} alt={displayName(p)} />
+                    )}
+                    <AvatarFallback className="bg-brand-primary text-white text-xs">
+                      {initials(p)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="flex-1 min-w-0 text-sm font-medium truncate">
+                    {displayName(p)}
+                  </span>
+                  <Switch
+                    checked={assigned.has(p.id)}
+                    disabled={toggling === p.id}
+                    onCheckedChange={(v) => handleToggle(p, v)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/admin/groups/GroupRosterDialog.tsx
+++ b/app/admin/groups/GroupRosterDialog.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Switch } from "@/components/ui/switch";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Dialog,
@@ -12,7 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { Search } from "lucide-react";
+import { ArrowLeft, Plus, Search, X } from "lucide-react";
 import { setGroupMembership } from "@/lib/memberGroups";
 import { displayName, initials } from "@/lib/names";
 import type { MemberGroup, Profile } from "@/lib/types";
@@ -30,9 +30,10 @@ interface GroupRosterDialogProps {
 }
 
 /**
- * Manage a group's roster in one place: every member of the class with a
- * switch to add/remove them from the group. Functional-role booleans are
- * kept in sync via setGroupMembership.
+ * Group roster management, Okta-style: the default view shows only who is
+ * currently in the group (with remove), and an explicit "Add members" mode
+ * searches the rest of the class. Functional-role booleans stay in sync via
+ * setGroupMembership.
  */
 export function GroupRosterDialog({
   group,
@@ -42,8 +43,9 @@ export function GroupRosterDialog({
   const [profiles, setProfiles] = useState<RosterProfile[]>([]);
   const [assigned, setAssigned] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
+  const [mode, setMode] = useState<"roster" | "add">("roster");
   const [query, setQuery] = useState("");
-  const [toggling, setToggling] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
   const supabase = createClient();
 
   useEffect(() => {
@@ -52,6 +54,7 @@ export function GroupRosterDialog({
 
     async function load(groupId: string) {
       setLoading(true);
+      setMode("roster");
       setQuery("");
       const [{ data: members, error: mErr }, { data: rows, error: rErr }] =
         await Promise.all([
@@ -86,35 +89,50 @@ export function GroupRosterDialog({
     };
   }, [group?.id]);
 
-  const filtered = useMemo(() => {
-    if (!query.trim()) return profiles;
+  const roster = useMemo(
+    () => profiles.filter((p) => assigned.has(p.id)),
+    [profiles, assigned],
+  );
+  const candidates = useMemo(
+    () => profiles.filter((p) => !assigned.has(p.id)),
+    [profiles, assigned],
+  );
+
+  const visible = useMemo(() => {
+    const source = mode === "roster" ? roster : candidates;
+    if (!query.trim()) return source;
     const q = query.trim().toLowerCase();
-    return profiles.filter((p) =>
+    return source.filter((p) =>
       [p.first_name, p.last_name, p.preferred_name]
         .filter(Boolean)
         .join(" ")
         .toLowerCase()
         .includes(q),
     );
-  }, [profiles, query]);
+  }, [mode, roster, candidates, query]);
 
-  async function handleToggle(profile: RosterProfile, checked: boolean) {
+  async function handleChange(profile: RosterProfile, member: boolean) {
     if (!group) return;
-    setToggling(profile.id);
+    setBusy(profile.id);
 
-    const errorMessage = await setGroupMembership(profile.id, group, checked);
+    const errorMessage = await setGroupMembership(profile.id, group, member);
     if (errorMessage) {
       toast.error(errorMessage);
-      setToggling(null);
+      setBusy(null);
       return;
     }
 
     const next = new Set(assigned);
-    if (checked) next.add(profile.id);
+    if (member) next.add(profile.id);
     else next.delete(profile.id);
     setAssigned(next);
     onCountChange(group.id, next.size);
-    setToggling(null);
+    setBusy(null);
+  }
+
+  function switchMode(next: "roster" | "add") {
+    setMode(next);
+    setQuery("");
   }
 
   return (
@@ -122,25 +140,52 @@ export function GroupRosterDialog({
       <DialogContent className="max-w-md max-h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
+            {mode === "add" && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => switchMode("roster")}
+                aria-label="Back to members"
+                className="-ml-2 shrink-0"
+              >
+                <ArrowLeft className="h-4 w-4" />
+              </Button>
+            )}
             {group?.color && (
               <span
-                className="inline-block w-3 h-3 rounded-full"
+                className="inline-block w-3 h-3 rounded-full shrink-0"
                 style={{ backgroundColor: group.color }}
               />
             )}
-            {group?.name} — {assigned.size} member{assigned.size !== 1 ? "s" : ""}
+            {mode === "add"
+              ? `Add to ${group?.name}`
+              : `${group?.name} — ${assigned.size} member${assigned.size !== 1 ? "s" : ""}`}
           </DialogTitle>
         </DialogHeader>
 
-        <div className="relative shrink-0">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            type="search"
-            placeholder="Search members..."
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            className="pl-10"
-          />
+        <div className="flex items-center gap-2 shrink-0">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              type="search"
+              placeholder={
+                mode === "roster" ? "Search members..." : "Search people to add..."
+              }
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="pl-10"
+            />
+          </div>
+          {mode === "roster" && (
+            <Button
+              size="sm"
+              onClick={() => switchMode("add")}
+              className="bg-brand-primary hover:bg-brand-primary/90 text-white shrink-0"
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              Add members
+            </Button>
+          )}
         </div>
 
         <div className="overflow-y-auto flex-1 -mx-1 px-1">
@@ -148,13 +193,17 @@ export function GroupRosterDialog({
             <p className="text-sm text-muted-foreground py-4 text-center">
               Loading members...
             </p>
-          ) : filtered.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">
-              No members match your search.
+          ) : visible.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-6 text-center">
+              {query.trim()
+                ? "No one matches your search."
+                : mode === "roster"
+                  ? "No members in this group yet. Use “Add members” to build the roster."
+                  : "Everyone is already in this group."}
             </p>
           ) : (
             <div className="divide-y">
-              {filtered.map((p) => (
+              {visible.map((p) => (
                 <div key={p.id} className="flex items-center gap-3 py-2.5">
                   <Avatar className="h-8 w-8 shrink-0">
                     {p.avatar_url && (
@@ -167,11 +216,28 @@ export function GroupRosterDialog({
                   <span className="flex-1 min-w-0 text-sm font-medium truncate">
                     {displayName(p)}
                   </span>
-                  <Switch
-                    checked={assigned.has(p.id)}
-                    disabled={toggling === p.id}
-                    onCheckedChange={(v) => handleToggle(p, v)}
-                  />
+                  {mode === "roster" ? (
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      disabled={busy === p.id}
+                      onClick={() => handleChange(p, false)}
+                      aria-label={`Remove ${displayName(p)} from ${group?.name}`}
+                      className="text-muted-foreground hover:text-destructive"
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={busy === p.id}
+                      onClick={() => handleChange(p, true)}
+                    >
+                      <Plus className="mr-1 h-3.5 w-3.5" />
+                      Add
+                    </Button>
+                  )}
                 </div>
               ))}
             </div>

--- a/app/admin/groups/IconPicker.tsx
+++ b/app/admin/groups/IconPicker.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { DynamicIcon, iconNames, type IconName } from "lucide-react/dynamic";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ChevronDown, ChevronUp, Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { GroupIcon } from "@/components/directory/GroupIcon";
+
+const NAME_SET = new Set<string>(iconNames);
+
+/** Church-relevant starting points shown before the admin searches */
+const SUGGESTED = [
+  "users",
+  "heart",
+  "hand-helping",
+  "cross",
+  "church",
+  "book-open",
+  "music",
+  "star",
+  "baby",
+  "shield",
+  "bell",
+  "flag",
+  "handshake",
+  "coffee",
+  "utensils",
+  "gift",
+  "sun",
+  "phone",
+  "calendar",
+  "house",
+  "car",
+  "graduation-cap",
+  "sprout",
+  "globe",
+].filter((n) => NAME_SET.has(n)) as IconName[];
+
+const MAX_RESULTS = 96;
+
+function prettyName(name: string): string {
+  return name
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+interface IconPickerProps {
+  value: string;
+  onChange: (name: string) => void;
+}
+
+/**
+ * Searchable picker over the full lucide catalog. Collapsed it shows the
+ * current icon; expanded it shows suggestions, or search results capped at
+ * MAX_RESULTS so we never fetch hundreds of icon chunks at once.
+ */
+export function IconPicker({ value, onChange }: IconPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const { results, total } = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return { results: SUGGESTED, total: SUGGESTED.length };
+    const matches = iconNames.filter((n) => n.includes(q));
+    return { results: matches.slice(0, MAX_RESULTS), total: matches.length };
+  }, [query]);
+
+  function pick(name: IconName) {
+    onChange(name);
+    setOpen(false);
+    setQuery("");
+  }
+
+  return (
+    <div className="space-y-2">
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => setOpen(!open)}
+        className="w-full justify-between font-normal"
+      >
+        <span className="flex items-center gap-2">
+          <GroupIcon name={value} className="h-4 w-4" />
+          {value ? prettyName(value) : "Choose an icon"}
+        </span>
+        {open ? (
+          <ChevronUp className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+        )}
+      </Button>
+
+      {open && (
+        <div className="rounded-lg border p-2 space-y-2">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              type="search"
+              autoFocus
+              placeholder="Search all icons..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="pl-10"
+            />
+          </div>
+
+          {results.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-3 text-center">
+              No icons match &ldquo;{query.trim()}&rdquo;.
+            </p>
+          ) : (
+            <div className="grid grid-cols-8 gap-1 max-h-48 overflow-y-auto">
+              {results.map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  title={prettyName(n)}
+                  aria-label={prettyName(n)}
+                  onClick={() => pick(n)}
+                  className={cn(
+                    "flex h-9 items-center justify-center rounded-md hover:bg-accent transition-colors",
+                    n === value && "bg-accent ring-1 ring-brand-primary",
+                  )}
+                >
+                  <DynamicIcon name={n} className="h-4 w-4" />
+                </button>
+              ))}
+            </div>
+          )}
+
+          <p className="text-xs text-muted-foreground">
+            {query.trim()
+              ? total > MAX_RESULTS
+                ? `Showing ${MAX_RESULTS} of ${total} matches — keep typing to narrow down.`
+                : `${total} match${total !== 1 ? "es" : ""}`
+              : "Suggestions — search to browse all 1,900+ icons."}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/groups/page.tsx
+++ b/app/admin/groups/page.tsx
@@ -15,13 +15,6 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { toast } from "sonner";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -35,34 +28,7 @@ import {
 } from "lucide-react";
 import type { MemberGroup } from "@/lib/types";
 import { GroupRosterDialog } from "./GroupRosterDialog";
-import { GroupIcon } from "@/components/directory/GroupIcon";
-
-/** A curated set of lucide icon names available for group icons */
-const ICON_OPTIONS = [
-  { value: "heart", label: "Heart" },
-  { value: "hand-helping", label: "Hand (Helping)" },
-  { value: "users", label: "Users" },
-  { value: "user", label: "User" },
-  { value: "star", label: "Star" },
-  { value: "cross", label: "Cross" },
-  { value: "book-open", label: "Book" },
-  { value: "music", label: "Music" },
-  { value: "baby", label: "Baby" },
-  { value: "shield", label: "Shield" },
-  { value: "bell", label: "Bell" },
-  { value: "flag", label: "Flag" },
-];
-
-// Labels include the rendered icon so both the trigger and the list preview it
-const ICON_ITEMS = ICON_OPTIONS.map((opt) => ({
-  value: opt.value,
-  label: (
-    <span className="flex items-center gap-2">
-      <GroupIcon name={opt.value} className="h-4 w-4" />
-      {opt.label}
-    </span>
-  ),
-}));
+import { IconPicker } from "./IconPicker";
 
 interface GroupFormState {
   name: string;
@@ -409,49 +375,35 @@ export default function GroupsPage() {
               />
             </div>
 
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="g_color">Color</Label>
-                <div className="flex items-center gap-2">
-                  <input
-                    id="g_color"
-                    type="color"
-                    value={form.color}
-                    onChange={(e) =>
-                      setForm({ ...form, color: e.target.value })
-                    }
-                    className="h-9 w-9 cursor-pointer rounded border border-input"
-                  />
-                  <Input
-                    value={form.color}
-                    onChange={(e) =>
-                      setForm({ ...form, color: e.target.value })
-                    }
-                    placeholder="#2F6BA8"
-                    className="font-mono text-sm"
-                  />
-                </div>
+            <div className="space-y-2">
+              <Label htmlFor="g_color">Color</Label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="g_color"
+                  type="color"
+                  value={form.color}
+                  onChange={(e) =>
+                    setForm({ ...form, color: e.target.value })
+                  }
+                  className="h-9 w-9 cursor-pointer rounded border border-input"
+                />
+                <Input
+                  value={form.color}
+                  onChange={(e) =>
+                    setForm({ ...form, color: e.target.value })
+                  }
+                  placeholder="#2F6BA8"
+                  className="font-mono text-sm w-32"
+                />
               </div>
+            </div>
 
-              <div className="space-y-2">
-                <Label htmlFor="g_icon">Icon</Label>
-                <Select
-                  items={ICON_ITEMS}
-                  value={form.icon}
-                  onValueChange={(v) => setForm({ ...form, icon: v ?? "users" })}
-                >
-                  <SelectTrigger id="g_icon" className="w-full">
-                    <SelectValue placeholder="Select icon" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {ICON_ITEMS.map((item) => (
-                      <SelectItem key={item.value} value={item.value}>
-                        {item.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+            <div className="space-y-2">
+              <Label>Icon</Label>
+              <IconPicker
+                value={form.icon}
+                onChange={(v) => setForm({ ...form, icon: v })}
+              />
             </div>
 
             <div className="flex items-center justify-between rounded-lg border p-3">

--- a/app/admin/groups/page.tsx
+++ b/app/admin/groups/page.tsx
@@ -64,18 +64,11 @@ const ICON_ITEMS = ICON_OPTIONS.map((opt) => ({
   ),
 }));
 
-const ROLE_ITEMS = [
-  { value: "none", label: "None" },
-  { value: "prayer_team", label: "Prayer Team" },
-  { value: "greeter_team", label: "Greeter Team" },
-];
-
 interface GroupFormState {
   name: string;
   description: string;
   color: string;
   icon: string;
-  functional_role: string;
   show_in_directory_filter: boolean;
 }
 
@@ -84,7 +77,6 @@ const EMPTY_FORM: GroupFormState = {
   description: "",
   color: "#2F6BA8",
   icon: "users",
-  functional_role: "none",
   show_in_directory_filter: true,
 };
 
@@ -94,7 +86,6 @@ function fromGroup(g: MemberGroup): GroupFormState {
     description: g.description || "",
     color: g.color || "#2F6BA8",
     icon: g.icon || "users",
-    functional_role: g.functional_role || "none",
     show_in_directory_filter: g.show_in_directory_filter ?? true,
   };
 }
@@ -163,13 +154,13 @@ export default function GroupsPage() {
       return;
     }
 
+    // functional_role is intentionally omitted: the hidden scheduling link on
+    // the seeded groups is preserved as-is until a feature actually uses it.
     const payload = {
       name: form.name.trim(),
       description: form.description.trim() || null,
       color: form.color || null,
       icon: form.icon || null,
-      functional_role:
-        form.functional_role === "none" ? null : form.functional_role,
       show_in_directory_filter: form.show_in_directory_filter,
     };
 
@@ -297,7 +288,11 @@ export default function GroupsPage() {
       ) : (
         <div className="space-y-3">
           {groups.map((group, idx) => (
-            <Card key={group.id}>
+            <Card
+              key={group.id}
+              onClick={() => setRosterGroup(group)}
+              className="cursor-pointer transition-shadow hover:shadow-md"
+            >
               <CardContent className="pt-5 pb-5">
                 <div className="flex items-center gap-4">
                   {/* Color swatch */}
@@ -308,11 +303,6 @@ export default function GroupsPage() {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 flex-wrap">
                       <p className="font-semibold">{group.name}</p>
-                      {group.functional_role && (
-                        <Badge variant="outline" className="text-xs capitalize">
-                          {group.functional_role.replace("_", " ")}
-                        </Badge>
-                      )}
                       {group.show_in_directory_filter && (
                         <Badge variant="secondary" className="text-xs gap-1">
                           <Filter className="h-3 w-3" />
@@ -333,7 +323,10 @@ export default function GroupsPage() {
                       </span>
                     </div>
                   </div>
-                  <div className="flex items-center gap-1 shrink-0">
+                  <div
+                    className="flex items-center gap-1 shrink-0"
+                    onClick={(e) => e.stopPropagation()}
+                  >
                     <Button
                       variant="ghost"
                       size="icon-sm"
@@ -459,32 +452,6 @@ export default function GroupsPage() {
                   </SelectContent>
                 </Select>
               </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="g_role">Functional role</Label>
-              <Select
-                items={ROLE_ITEMS}
-                value={form.functional_role}
-                onValueChange={(v) =>
-                  setForm({ ...form, functional_role: v ?? "none" })
-                }
-              >
-                <SelectTrigger id="g_role">
-                  <SelectValue placeholder="None" />
-                </SelectTrigger>
-                <SelectContent>
-                  {ROLE_ITEMS.map((item) => (
-                    <SelectItem key={item.value} value={item.value}>
-                      {item.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-muted-foreground">
-                Optional. Linking a role means people in this group can be
-                picked when scheduling prayer or greeting for a Sunday.
-              </p>
             </div>
 
             <div className="flex items-center justify-between rounded-lg border p-3">

--- a/app/admin/groups/page.tsx
+++ b/app/admin/groups/page.tsx
@@ -34,6 +34,7 @@ import {
   Filter,
 } from "lucide-react";
 import type { MemberGroup } from "@/lib/types";
+import { GroupRosterDialog } from "./GroupRosterDialog";
 
 /** A curated set of lucide icon names available for group icons */
 const ICON_OPTIONS = [
@@ -85,6 +86,7 @@ export default function GroupsPage() {
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editing, setEditing] = useState<MemberGroup | null>(null);
+  const [rosterGroup, setRosterGroup] = useState<MemberGroup | null>(null);
   const [form, setForm] = useState<GroupFormState>(EMPTY_FORM);
   const [saving, setSaving] = useState(false);
   // member counts per group for delete warning
@@ -335,6 +337,14 @@ export default function GroupsPage() {
                     <Button
                       variant="outline"
                       size="sm"
+                      onClick={() => setRosterGroup(group)}
+                    >
+                      <Users className="mr-1 h-4 w-4" />
+                      Members
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
                       onClick={() => openEdit(group)}
                     >
                       <Pencil className="mr-1 h-4 w-4" />
@@ -347,6 +357,14 @@ export default function GroupsPage() {
           ))}
         </div>
       )}
+
+      <GroupRosterDialog
+        group={rosterGroup}
+        onClose={() => setRosterGroup(null)}
+        onCountChange={(groupId, count) =>
+          setMemberCounts((prev) => ({ ...prev, [groupId]: count }))
+        }
+      />
 
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="max-w-md">

--- a/app/admin/groups/page.tsx
+++ b/app/admin/groups/page.tsx
@@ -35,6 +35,7 @@ import {
 } from "lucide-react";
 import type { MemberGroup } from "@/lib/types";
 import { GroupRosterDialog } from "./GroupRosterDialog";
+import { GroupIcon } from "@/components/directory/GroupIcon";
 
 /** A curated set of lucide icon names available for group icons */
 const ICON_OPTIONS = [
@@ -50,6 +51,23 @@ const ICON_OPTIONS = [
   { value: "shield", label: "Shield" },
   { value: "bell", label: "Bell" },
   { value: "flag", label: "Flag" },
+];
+
+// Labels include the rendered icon so both the trigger and the list preview it
+const ICON_ITEMS = ICON_OPTIONS.map((opt) => ({
+  value: opt.value,
+  label: (
+    <span className="flex items-center gap-2">
+      <GroupIcon name={opt.value} className="h-4 w-4" />
+      {opt.label}
+    </span>
+  ),
+}));
+
+const ROLE_ITEMS = [
+  { value: "none", label: "None" },
+  { value: "prayer_team", label: "Prayer Team" },
+  { value: "greeter_team", label: "Greeter Team" },
 ];
 
 interface GroupFormState {
@@ -425,16 +443,17 @@ export default function GroupsPage() {
               <div className="space-y-2">
                 <Label htmlFor="g_icon">Icon</Label>
                 <Select
+                  items={ICON_ITEMS}
                   value={form.icon}
                   onValueChange={(v) => setForm({ ...form, icon: v ?? "users" })}
                 >
-                  <SelectTrigger id="g_icon">
+                  <SelectTrigger id="g_icon" className="w-full">
                     <SelectValue placeholder="Select icon" />
                   </SelectTrigger>
                   <SelectContent>
-                    {ICON_OPTIONS.map((opt) => (
-                      <SelectItem key={opt.value} value={opt.value}>
-                        {opt.label}
+                    {ICON_ITEMS.map((item) => (
+                      <SelectItem key={item.value} value={item.value}>
+                        {item.label}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -445,6 +464,7 @@ export default function GroupsPage() {
             <div className="space-y-2">
               <Label htmlFor="g_role">Functional role</Label>
               <Select
+                items={ROLE_ITEMS}
                 value={form.functional_role}
                 onValueChange={(v) =>
                   setForm({ ...form, functional_role: v ?? "none" })
@@ -454,13 +474,16 @@ export default function GroupsPage() {
                   <SelectValue placeholder="None" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="none">None</SelectItem>
-                  <SelectItem value="prayer_team">Prayer Team</SelectItem>
-                  <SelectItem value="greeter_team">Greeter Team</SelectItem>
+                  {ROLE_ITEMS.map((item) => (
+                    <SelectItem key={item.value} value={item.value}>
+                      {item.label}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
               <p className="text-xs text-muted-foreground">
-                Functional roles sync with scheduling booleans on the profile.
+                Optional. Linking a role means people in this group can be
+                picked when scheduling prayer or greeting for a Sunday.
               </p>
             </div>
 

--- a/app/directory/page.tsx
+++ b/app/directory/page.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
 import {
   Sheet,
   SheetContent,
@@ -13,94 +12,50 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import {
-  Search,
-  Phone,
-  Mail,
-  MapPin,
-  Calendar,
-  Briefcase,
+  ChevronLeft,
+  ChevronRight,
   Home,
   LayoutList,
-  Users,
-  Download,
+  Search,
+  Tags,
 } from "lucide-react";
 import { formatPhone } from "@/lib/sanitize";
 import { displayName, initials } from "@/lib/names";
 import { BirthdayWidget } from "@/components/directory/BirthdayWidget";
+import { AvatarCluster } from "@/components/directory/AvatarCluster";
+import { GroupBadge } from "@/components/directory/GroupBadge";
+import { GroupIcon } from "@/components/directory/GroupIcon";
+import { ProfileSheetContent } from "@/components/directory/ProfileSheetContent";
+import { HouseholdSheetContent } from "@/components/directory/HouseholdSheetContent";
+import { GroupSheetContent } from "@/components/directory/GroupSheetContent";
+import { formatAnniversary, relLabel } from "@/components/directory/utils";
+import type { DirectoryGroup } from "@/components/directory/types";
 import type {
   DirectoryProfile,
   FamilyDirectoryFull,
-  GroupChip,
-  HouseholdMember,
   HouseholdFamilyMember,
+  HouseholdMember,
 } from "@/lib/types";
 
-const MONTH_NAMES = [
-  "January", "February", "March", "April", "May", "June",
-  "July", "August", "September", "October", "November", "December",
-];
-
-function formatBirthdayShort(month: number, day: number): string {
-  return `${MONTH_NAMES[month - 1]} ${day}`;
-}
-
-function formatAnniversary(iso: string): string {
-  const d = new Date(iso + "T00:00:00");
-  return d.toLocaleDateString("en-US", {
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-  });
-}
-
-/** Resolve the best address to show in the detail sheet */
-function resolveAddress(
-  member: DirectoryProfile,
-  family: FamilyDirectoryFull | null,
-) {
-  const line1 = member.address_line1 ?? family?.address_line1 ?? null;
-  const line2 = member.address_line2 ?? family?.address_line2 ?? null;
-  const city = member.city ?? family?.city ?? null;
-  const state = member.state ?? family?.state ?? null;
-  const postal = member.postal_code ?? family?.postal_code ?? null;
-  if (!line1 && !city) return null;
-  return { line1, line2, city, state, postal };
-}
-
 // ---------------------------------------------------------------------------
-// vCard download helper
-// ---------------------------------------------------------------------------
-function downloadVCard(profileId: string) {
-  window.location.href = `/api/members/${profileId}/vcard`;
-}
-
-// ---------------------------------------------------------------------------
-// Types for the detail sheet subject
+// Types for the detail sheet subject (stack-based so Back works)
 // ---------------------------------------------------------------------------
 type SheetSubject =
   | { kind: "profile"; profile: DirectoryProfile }
-  | { kind: "household"; family: FamilyDirectoryFull };
+  | { kind: "household"; family: FamilyDirectoryFull }
+  | { kind: "group"; group: DirectoryGroup };
+
+type DirectoryView = "households" | "people" | "groups";
 
 // ---------------------------------------------------------------------------
-// Relationship label helper
+// Alphabet section header — sticks below the measured search block
 // ---------------------------------------------------------------------------
-function relLabel(rel: string): string {
-  switch (rel) {
-    case "primary": return "Primary";
-    case "spouse": return "Spouse";
-    case "child": return "Child";
-    case "parent": return "Parent";
-    case "sibling": return "Sibling";
-    default: return "Other";
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Alphabet section header
-// ---------------------------------------------------------------------------
-function AlphaHeader({ letter }: { letter: string }) {
+function AlphaHeader({ letter, top }: { letter: string; top: number }) {
   return (
-    <div className="sticky top-[88px] z-10 bg-background/95 backdrop-blur-sm px-1 py-1">
+    <div
+      className="sticky z-10 bg-background/95 backdrop-blur-sm px-1 py-1"
+      style={{ top }}
+    >
       <p className="text-xs font-bold uppercase text-brand-primary tracking-widest">
         {letter}
       </p>
@@ -109,428 +64,32 @@ function AlphaHeader({ letter }: { letter: string }) {
 }
 
 // ---------------------------------------------------------------------------
-// Avatar cluster — up to 3 faces
+// A–Z jump rail
 // ---------------------------------------------------------------------------
-interface AvatarClusterProps {
-  people: Array<{ avatarUrl: string | null; name: string; initials: string }>;
-}
-
-function AvatarCluster({ people }: AvatarClusterProps) {
-  const displayed = people.slice(0, 3);
+function AlphaRail({
+  letters,
+  onJump,
+}: {
+  letters: string[];
+  onJump: (letter: string) => void;
+}) {
+  if (letters.length < 5) return null;
   return (
-    <div className="flex -space-x-2">
-      {displayed.map((p, i) => (
-        <Avatar
-          key={i}
-          className="h-10 w-10 border-2 border-background"
-        >
-          {p.avatarUrl && (
-            <AvatarImage src={p.avatarUrl} alt={p.name} />
-          )}
-          <AvatarFallback className="bg-brand-primary text-white text-sm">
-            {p.initials}
-          </AvatarFallback>
-        </Avatar>
-      ))}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Group chip
-// ---------------------------------------------------------------------------
-function GroupBadge({ group }: { group: GroupChip }) {
-  return (
-    <span
-      className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium text-white"
-      style={{ backgroundColor: group.color || "#6b7280" }}
+    <nav
+      aria-label="Jump to letter"
+      className="fixed right-0.5 sm:right-2 top-1/2 -translate-y-1/2 z-30 flex flex-col items-center"
     >
-      {group.name}
-    </span>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Profile detail sheet content
-// ---------------------------------------------------------------------------
-interface ProfileSheetProps {
-  profile: DirectoryProfile;
-  family: FamilyDirectoryFull | null;
-}
-
-function ProfileSheetContent({ profile, family }: ProfileSheetProps) {
-  const address = resolveAddress(profile, family);
-  const hasBirthday = profile.birth_month && profile.birth_day;
-
-  return (
-    <div className="px-4 pb-6 space-y-3 overflow-y-auto flex-1">
-      {/* Header */}
-      <div className="flex items-center gap-4 pt-2">
-        <Avatar className="h-20 w-20 shrink-0">
-          {profile.avatar_url && (
-            <AvatarImage src={profile.avatar_url} alt={displayName(profile)} />
-          )}
-          <AvatarFallback className="bg-brand-primary text-white text-2xl">
-            {initials(profile)}
-          </AvatarFallback>
-        </Avatar>
-        <div className="min-w-0">
-          <p className="text-xl font-bold leading-tight">{displayName(profile)}</p>
-          {profile.preferred_name &&
-            profile.first_name &&
-            profile.preferred_name !== profile.first_name && (
-              <p className="text-sm text-muted-foreground">
-                ({profile.first_name} {profile.last_name})
-              </p>
-            )}
-          {profile.relationship && profile.relationship !== "primary" && (
-            <Badge variant="outline" className="text-xs mt-1 capitalize">
-              {relLabel(profile.relationship)}
-            </Badge>
-          )}
-        </div>
-      </div>
-
-      {/* Groups */}
-      {profile.groups && profile.groups.length > 0 && (
-        <div className="flex flex-wrap gap-1">
-          {profile.groups.map((g) => (
-            <GroupBadge key={g.id} group={g} />
-          ))}
-        </div>
-      )}
-
-      {/* Bio */}
-      {profile.bio && (
-        <p className="text-sm italic text-muted-foreground">{profile.bio}</p>
-      )}
-
-      {/* Phones */}
-      {profile.phone_mobile && (
-        <div className="flex items-center gap-3">
-          <Phone className="h-4 w-4 text-muted-foreground shrink-0" />
-          <a
-            href={`tel:${profile.phone_mobile}`}
-            className="text-base text-brand-primary hover:underline"
-          >
-            {formatPhone(profile.phone_mobile)}
-          </a>
-          <span className="text-xs text-muted-foreground">mobile</span>
-        </div>
-      )}
-      {profile.phone_home && (
-        <div className="flex items-center gap-3">
-          <Home className="h-4 w-4 text-muted-foreground shrink-0" />
-          <a
-            href={`tel:${profile.phone_home}`}
-            className="text-base text-brand-primary hover:underline"
-          >
-            {formatPhone(profile.phone_home)}
-          </a>
-          <span className="text-xs text-muted-foreground">home</span>
-        </div>
-      )}
-      {!profile.phone_home && family?.phone_home && (
-        <div className="flex items-center gap-3">
-          <Home className="h-4 w-4 text-muted-foreground shrink-0" />
-          <a
-            href={`tel:${family.phone_home}`}
-            className="text-base text-brand-primary hover:underline"
-          >
-            {formatPhone(family.phone_home)}
-          </a>
-          <span className="text-xs text-muted-foreground">family home</span>
-        </div>
-      )}
-      {profile.phone_work && (
-        <div className="flex items-center gap-3">
-          <Briefcase className="h-4 w-4 text-muted-foreground shrink-0" />
-          <a
-            href={`tel:${profile.phone_work}`}
-            className="text-base text-brand-primary hover:underline"
-          >
-            {formatPhone(profile.phone_work)}
-          </a>
-          <span className="text-xs text-muted-foreground">work</span>
-        </div>
-      )}
-
-      {/* Email */}
-      {profile.email && (
-        <div className="flex items-center gap-3">
-          <Mail className="h-4 w-4 text-muted-foreground shrink-0" />
-          <a
-            href={`mailto:${profile.email}`}
-            className="text-base text-brand-primary hover:underline break-all"
-          >
-            {profile.email}
-          </a>
-        </div>
-      )}
-
-      {/* Address */}
-      {address && (
-        <div className="flex items-start gap-3">
-          <MapPin className="h-4 w-4 text-muted-foreground shrink-0 mt-1" />
-          <div className="text-base">
-            <p>{address.line1}</p>
-            {address.line2 && <p>{address.line2}</p>}
-            <p>
-              {address.city}
-              {address.state && `, ${address.state}`}
-              {address.postal && ` ${address.postal}`}
-            </p>
-          </div>
-        </div>
-      )}
-
-      {/* Birthday */}
-      {hasBirthday && (
-        <div className="flex items-center gap-3">
-          <Calendar className="h-4 w-4 text-muted-foreground shrink-0" />
-          <span className="text-base">
-            🎂{" "}
-            {formatBirthdayShort(profile.birth_month!, profile.birth_day!)}
-            {profile.birth_year ? `, ${profile.birth_year}` : ""}
-          </span>
-        </div>
-      )}
-
-      {/* Occupation */}
-      {(profile.occupation || profile.employer) && (
-        <div className="flex items-start gap-3">
-          <Briefcase className="h-4 w-4 text-muted-foreground shrink-0 mt-1" />
-          <div className="text-base">
-            {profile.occupation && <p>{profile.occupation}</p>}
-            {profile.employer && (
-              <p className="text-sm text-muted-foreground">{profile.employer}</p>
-            )}
-          </div>
-        </div>
-      )}
-
-      {/* Save to Contacts */}
-      <div className="pt-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => downloadVCard(profile.id)}
-          className="gap-2"
+      {letters.map((letter) => (
+        <button
+          key={letter}
+          type="button"
+          onClick={() => onJump(letter)}
+          className="text-[10px] leading-[14px] font-semibold text-brand-primary/70 hover:text-brand-primary px-1.5"
         >
-          <Download className="h-4 w-4" />
-          Save to Contacts
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Household detail sheet content
-// ---------------------------------------------------------------------------
-interface HouseholdSheetProps {
-  family: FamilyDirectoryFull;
-  profileMap: Record<string, DirectoryProfile>;
-}
-
-function HouseholdSheetContent({ family, profileMap }: HouseholdSheetProps) {
-  const hasSpouse =
-    family.members.some((m) => m.relationship === "spouse") ||
-    family.family_members_list.some((fm) => fm.relationship === "spouse");
-
-  // Collect birthdays this month for family members
-  const today = new Date();
-  const currentMonth = today.getMonth() + 1;
-
-  const birthdaysThisMonth = [
-    ...family.members
-      .filter((m) => m.birth_month === currentMonth && m.birth_day)
-      .map((m) => ({
-        name: [m.first_name, m.last_name].filter(Boolean).join(" ") || "(unnamed)",
-        day: m.birth_day!,
-      })),
-    ...family.family_members_list
-      .filter((fm) => fm.birth_month === currentMonth && fm.birth_day)
-      .map((fm) => ({
-        name: [fm.first_name, fm.last_name].filter(Boolean).join(" "),
-        day: fm.birth_day!,
-      })),
-  ].sort((a, b) => a.day - b.day);
-
-  function renderMember(m: HouseholdMember) {
-    const fullProfile = profileMap[m.id];
-    const name =
-      [m.preferred_name || m.first_name, m.last_name]
-        .filter(Boolean)
-        .join(" ") || "(unnamed)";
-    return (
-      <div key={m.id} className="flex items-center gap-3">
-        <Avatar className="h-9 w-9">
-          {m.avatar_url && (
-            <AvatarImage
-              src={m.avatar_url}
-              alt={[m.first_name, m.last_name].filter(Boolean).join(" ")}
-            />
-          )}
-          <AvatarFallback className="bg-brand-primary text-white text-sm">
-            {((m.preferred_name || m.first_name || "?").charAt(0) +
-              (m.last_name || "").charAt(0)
-            ).toUpperCase()}
-          </AvatarFallback>
-        </Avatar>
-        <div className="flex-1 min-w-0">
-          <span className="text-sm font-medium">{name}</span>
-          {m.relationship !== "primary" && (
-            <Badge variant="outline" className="ml-2 text-xs capitalize">
-              {relLabel(m.relationship)}
-            </Badge>
-          )}
-          {!m.is_class_member && (
-            <Badge variant="secondary" className="ml-1 text-xs">
-              not enrolled
-            </Badge>
-          )}
-        </div>
-        {fullProfile?.groups && fullProfile.groups.length > 0 && (
-          <div className="flex gap-1">
-            {fullProfile.groups.slice(0, 2).map((g) => (
-              <span
-                key={g.id}
-                className="inline-block w-2 h-2 rounded-full"
-                style={{ backgroundColor: g.color || "#6b7280" }}
-                title={g.name}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  function renderFamilyMember(fm: HouseholdFamilyMember) {
-    const name = [fm.first_name, fm.last_name].filter(Boolean).join(" ");
-    return (
-      <div key={fm.id} className="flex items-center gap-3">
-        <Avatar className="h-9 w-9">
-          {fm.avatar_url && (
-            <AvatarImage
-              src={fm.avatar_url}
-              alt={[fm.first_name, fm.last_name].filter(Boolean).join(" ")}
-            />
-          )}
-          <AvatarFallback className="bg-muted text-muted-foreground text-sm">
-            {((fm.first_name || "?").charAt(0) + (fm.last_name || "").charAt(0)).toUpperCase()}
-          </AvatarFallback>
-        </Avatar>
-        <div className="flex-1 min-w-0">
-          <span className="text-sm font-medium">{name}</span>
-          <Badge variant="outline" className="ml-2 text-xs capitalize">
-            {relLabel(fm.relationship)}
-          </Badge>
-          {!fm.is_class_member && (
-            <Badge variant="secondary" className="ml-1 text-xs">
-              not enrolled
-            </Badge>
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="px-4 pb-6 space-y-4 overflow-y-auto flex-1">
-      {/* Family name header */}
-      <div className="pt-2">
-        <p className="text-xl font-bold">{family.family_name}</p>
-        {family.address_line1 && (
-          <p className="text-sm text-muted-foreground">
-            {family.address_line1}
-            {family.city && `, ${family.city}`}
-            {family.state && `, ${family.state}`}
-          </p>
-        )}
-      </div>
-
-      {/* Members */}
-      <div className="space-y-2">
-        {family.members.map((m) => renderMember(m))}
-        {family.family_members_list.map((fm) => renderFamilyMember(fm))}
-      </div>
-
-      {/* Family address */}
-      {family.address_line1 && (
-        <div className="flex items-start gap-3">
-          <MapPin className="h-4 w-4 text-muted-foreground shrink-0 mt-1" />
-          <div className="text-sm">
-            <p>{family.address_line1}</p>
-            {family.address_line2 && <p>{family.address_line2}</p>}
-            <p>
-              {family.city}
-              {family.state && `, ${family.state}`}
-              {family.postal_code && ` ${family.postal_code}`}
-            </p>
-          </div>
-        </div>
-      )}
-
-      {/* Family home phone */}
-      {family.phone_home && (
-        <div className="flex items-center gap-3">
-          <Home className="h-4 w-4 text-muted-foreground shrink-0" />
-          <a
-            href={`tel:${family.phone_home}`}
-            className="text-sm text-brand-primary hover:underline"
-          >
-            {formatPhone(family.phone_home)}
-          </a>
-          <span className="text-xs text-muted-foreground">home</span>
-        </div>
-      )}
-
-      {/* Birthdays this month */}
-      {birthdaysThisMonth.length > 0 && (
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
-            Birthdays this month
-          </p>
-          <div className="space-y-0.5">
-            {birthdaysThisMonth.map((b, i) => (
-              <p key={i} className="text-sm">
-                🎂 {b.name} ({MONTH_NAMES[currentMonth - 1]} {b.day})
-              </p>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Anniversary — only if spouse exists */}
-      {family.anniversary && hasSpouse && (
-        <div className="flex items-center gap-2">
-          <span className="text-sm">
-            💍 Anniversary: {formatAnniversary(family.anniversary)}
-          </span>
-        </div>
-      )}
-
-      {/* Save to Contacts — primary member of the household */}
-      {(() => {
-        const primary = family.members.find((m) => m.relationship === "primary");
-        if (!primary) return null;
-        return (
-          <div className="pt-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => downloadVCard(primary.id)}
-              className="gap-2"
-            >
-              <Download className="h-4 w-4" />
-              Save to Contacts
-            </Button>
-          </div>
-        );
-      })()}
-    </div>
+          {letter}
+        </button>
+      ))}
+    </nav>
   );
 }
 
@@ -576,9 +135,18 @@ function HouseholdRow({ family, onOpen }: HouseholdRowProps) {
       onClick={onOpen}
       className="w-full text-left flex items-start gap-4 p-3 rounded-lg hover:bg-brand-bg-light/50 transition-colors"
     >
-      {/* Avatar cluster */}
+      {/* Family photo, falling back to avatar cluster */}
       <div className="shrink-0 pt-0.5">
-        <AvatarCluster people={avatarPeople} />
+        {family.photo_url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={family.photo_url}
+            alt={`${family.family_name} family photo`}
+            className="h-12 w-16 rounded-md object-cover"
+          />
+        ) : (
+          <AvatarCluster people={avatarPeople} />
+        )}
       </div>
 
       {/* Content */}
@@ -615,7 +183,7 @@ function HouseholdRow({ family, onOpen }: HouseholdRowProps) {
                     c.last_name,
                   ]
                     .filter(Boolean)
-                    .join(" "),
+                    .join(", "),
                 )
                 .join(", ")}
             </p>
@@ -664,18 +232,75 @@ function PeopleRow({ member, onOpen }: PeopleRowProps) {
         ) : null}
       </div>
       {member.groups && member.groups.length > 0 && (
-        <div className="flex gap-1 shrink-0">
-          {member.groups.slice(0, 3).map((g) => (
-            <span
-              key={g.id}
-              className="inline-block w-2.5 h-2.5 rounded-full"
-              style={{ backgroundColor: g.color || "#6b7280" }}
-              title={g.name}
-            />
+        <div className="flex gap-1 shrink-0 max-w-[45%] flex-wrap justify-end">
+          {member.groups.slice(0, 2).map((g) => (
+            <GroupBadge key={g.id} group={g} size="xs" />
           ))}
+          {member.groups.length > 2 && (
+            <span className="text-[10px] text-muted-foreground self-center">
+              +{member.groups.length - 2}
+            </span>
+          )}
         </div>
       )}
     </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Group row (for Groups view)
+// ---------------------------------------------------------------------------
+interface GroupRowProps {
+  group: DirectoryGroup;
+  count: number;
+  onOpen: () => void;
+}
+
+function GroupRow({ group, count, onOpen }: GroupRowProps) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="w-full text-left flex items-center gap-4 p-3 rounded-lg hover:bg-brand-bg-light/50 transition-colors"
+    >
+      <div
+        className="h-10 w-10 rounded-full flex items-center justify-center text-white shrink-0"
+        style={{ backgroundColor: group.color || "#6b7280" }}
+      >
+        <GroupIcon name={group.icon} className="h-5 w-5" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="font-semibold">{group.name}</p>
+        {group.description && (
+          <p className="text-sm text-muted-foreground truncate">
+            {group.description}
+          </p>
+        )}
+      </div>
+      <span className="text-sm text-muted-foreground shrink-0">
+        {count} member{count !== 1 ? "s" : ""}
+      </span>
+      <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+function DirectorySkeleton() {
+  return (
+    <div className="mt-6 space-y-3" aria-hidden>
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3 px-3 py-2.5">
+          <div className="h-10 w-10 rounded-full bg-muted animate-pulse" />
+          <div className="flex-1 space-y-2">
+            <div className="h-3.5 w-40 rounded bg-muted animate-pulse" />
+            <div className="h-3 w-28 rounded bg-muted animate-pulse" />
+          </div>
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -685,12 +310,17 @@ function PeopleRow({ member, onOpen }: PeopleRowProps) {
 export default function DirectoryPage() {
   const [members, setMembers] = useState<DirectoryProfile[]>([]);
   const [families, setFamilies] = useState<FamilyDirectoryFull[]>([]);
-  const [allGroups, setAllGroups] = useState<GroupChip[]>([]);
+  const [allGroups, setAllGroups] = useState<DirectoryGroup[]>([]);
   const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState("");
   const [activeGroup, setActiveGroup] = useState<string | null>(null);
-  const [view, setView] = useState<"households" | "people">("households");
-  const [sheetSubject, setSheetSubject] = useState<SheetSubject | null>(null);
+  const [view, setView] = useState<DirectoryView>("households");
+  const [sheetStack, setSheetStack] = useState<SheetSubject[]>([]);
+
+  // Measured height of the sticky search block so A–Z headers stick below it
+  const stickyRef = useRef<HTMLDivElement>(null);
+  const [stickyH, setStickyH] = useState(140);
+
   const supabase = createClient();
 
   useEffect(() => {
@@ -706,8 +336,7 @@ export default function DirectoryPage() {
           .order("family_name", { ascending: true }),
         supabase
           .from("member_groups")
-          .select("id, name, color, icon")
-          .eq("show_in_directory_filter", true)
+          .select("id, name, color, icon, description, show_in_directory_filter")
           .order("display_order"),
       ]);
 
@@ -726,11 +355,34 @@ export default function DirectoryPage() {
 
       setMembers((m || []) as DirectoryProfile[]);
       setFamilies((f || []) as FamilyDirectoryFull[]);
-      setAllGroups((g || []) as GroupChip[]);
+      setAllGroups((g || []) as DirectoryGroup[]);
       setLoading(false);
     }
     load();
   }, []);
+
+  useEffect(() => {
+    const el = stickyRef.current;
+    if (!el) return;
+    const measure = () => setStickyH(el.offsetHeight);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loading]);
+
+  // Sheet stack helpers
+  const sheetSubject = sheetStack[sheetStack.length - 1] ?? null;
+  const pushSheet = (subject: SheetSubject) =>
+    setSheetStack((prev) => [...prev, subject]);
+  const popSheet = () => setSheetStack((prev) => prev.slice(0, -1));
+  const closeSheet = () => setSheetStack([]);
+
+  // Groups shown as filter chips
+  const filterGroups = useMemo(
+    () => allGroups.filter((g) => g.show_in_directory_filter),
+    [allGroups],
+  );
 
   // Build a lookup map: profileId → DirectoryProfile
   const profileMap = useMemo(() => {
@@ -746,6 +398,17 @@ export default function DirectoryPage() {
     return map;
   }, [families]);
 
+  // Roster per group, derived from listed members' group chips
+  const groupRosters = useMemo(() => {
+    const map: Record<string, DirectoryProfile[]> = {};
+    for (const m of members) {
+      for (const g of m.groups || []) {
+        (map[g.id] ??= []).push(m);
+      }
+    }
+    return map;
+  }, [members]);
+
   // Filter members by search + group
   const filteredMembers = useMemo(() => {
     let list = members;
@@ -758,17 +421,38 @@ export default function DirectoryPage() {
 
     if (query.trim()) {
       const q = query.trim().toLowerCase();
+      const qDigits = q.replace(/\D/g, "");
       list = list.filter((m) => {
-        const haystack = [m.first_name, m.last_name, m.preferred_name, m.email]
+        const familyName = m.family_id
+          ? familyMap[m.family_id]?.family_name
+          : null;
+        const haystack = [
+          m.first_name,
+          m.last_name,
+          m.preferred_name,
+          m.email,
+          m.occupation,
+          m.employer,
+          m.city,
+          familyName,
+        ]
           .filter(Boolean)
           .join(" ")
           .toLowerCase();
-        return haystack.includes(q);
+        if (haystack.includes(q)) return true;
+        if (qDigits.length >= 3) {
+          const phones = [m.phone_mobile, m.phone_home, m.phone_work]
+            .filter(Boolean)
+            .join("")
+            .replace(/\D/g, "");
+          if (phones.includes(qDigits)) return true;
+        }
+        return false;
       });
     }
 
     return list;
-  }, [members, query, activeGroup]);
+  }, [members, query, activeGroup, familyMap]);
 
   // Filter families for Households view — show a family if any of its members match
   const filteredFamilies = useMemo(() => {
@@ -839,21 +523,43 @@ export default function DirectoryPage() {
     return sections;
   }, [filteredMembers]);
 
-  // Resolve the family for the detail sheet
+  const sectionLetters = useMemo(() => {
+    if (view === "households") return Object.keys(householdSections).sort();
+    if (view === "people") return Object.keys(peopleSections).sort();
+    return [];
+  }, [view, householdSections, peopleSections]);
+
+  function handleChipClick(groupId: string | null) {
+    const next = groupId === activeGroup ? null : groupId;
+    setActiveGroup(next);
+    // A group filter is a person-level question — households would show
+    // whole families where only one member matches, so switch to People.
+    if (next && view === "households") setView("people");
+  }
+
+  function jumpToLetter(letter: string) {
+    document
+      .getElementById(`dir-section-${letter}`)
+      ?.scrollIntoView({ behavior: "smooth" });
+  }
+
+  // Resolve the family for the profile detail sheet
   const sheetFamily =
     sheetSubject?.kind === "profile" && sheetSubject.profile.family_id
       ? (familyMap[sheetSubject.profile.family_id] ?? null)
-      : sheetSubject?.kind === "household"
-        ? sheetSubject.family
-        : null;
+      : null;
 
-  if (loading) {
-    return (
-      <div className="container mx-auto px-4 py-12">
-        <p className="text-xl text-muted-foreground">Loading directory...</p>
-      </div>
-    );
-  }
+  const sheetTitle =
+    sheetSubject?.kind === "profile"
+      ? displayName(sheetSubject.profile)
+      : sheetSubject?.kind === "household"
+        ? sheetSubject.family.family_name
+        : sheetSubject?.kind === "group"
+          ? sheetSubject.group.name
+          : "";
+
+  const householdCount =
+    Object.values(householdSections).reduce((n, s) => n + s.length, 0);
 
   return (
     <div className="container mx-auto px-4 py-12 max-w-4xl">
@@ -864,211 +570,281 @@ export default function DirectoryPage() {
         Browse and connect with other members in your class.
       </p>
 
-      {/* Birthday / Anniversary Widget */}
-      <BirthdayWidget members={members} families={families} />
+      {loading ? (
+        <DirectorySkeleton />
+      ) : (
+        <>
+          {/* Birthday / Anniversary Widget */}
+          <BirthdayWidget members={members} families={families} />
 
-      {/* Sticky search + filter area */}
-      <div className="sticky top-0 z-20 bg-background/95 backdrop-blur-sm pb-3 pt-1">
-        {/* Search bar */}
-        <div className="relative mb-3">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            type="search"
-            placeholder="Search by name or email..."
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            className="pl-10 text-base py-5"
-          />
-        </div>
+          {/* Sticky search + filter area */}
+          <div
+            ref={stickyRef}
+            className="sticky top-0 z-20 bg-background/95 backdrop-blur-sm pb-3 pt-1"
+          >
+            {/* Search bar */}
+            <div className="relative mb-3">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                type="search"
+                placeholder="Search name, phone, city, occupation..."
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                className="pl-10 text-base py-5"
+              />
+            </div>
 
-        {/* Group filter chips */}
-        {allGroups.length > 0 && (
-          <div className="flex gap-2 overflow-x-auto pb-1 no-scrollbar">
-            <button
-              type="button"
-              onClick={() => setActiveGroup(null)}
-              className={`shrink-0 px-3 py-1 rounded-full text-sm font-medium border transition-colors ${
-                activeGroup === null
-                  ? "bg-brand-primary text-white border-brand-primary"
-                  : "border-border text-muted-foreground hover:border-brand-primary"
-              }`}
-            >
-              All
-            </button>
-            {allGroups.map((g) => (
-              <button
-                key={g.id}
-                type="button"
-                onClick={() =>
-                  setActiveGroup(activeGroup === g.id ? null : g.id)
-                }
-                className={`shrink-0 px-3 py-1 rounded-full text-sm font-medium border transition-colors ${
-                  activeGroup === g.id
-                    ? "text-white border-transparent"
-                    : "border-border text-muted-foreground hover:border-current"
-                }`}
-                style={
-                  activeGroup === g.id
-                    ? { backgroundColor: g.color || "#6b7280" }
-                    : {}
+            {/* Group filter chips (not shown in Groups view) */}
+            {filterGroups.length > 0 && view !== "groups" && (
+              <div className="flex gap-2 overflow-x-auto pb-1 no-scrollbar">
+                <button
+                  type="button"
+                  onClick={() => handleChipClick(null)}
+                  className={`shrink-0 px-3 py-1 rounded-full text-sm font-medium border transition-colors ${
+                    activeGroup === null
+                      ? "bg-brand-primary text-white border-brand-primary"
+                      : "border-border text-muted-foreground hover:border-brand-primary"
+                  }`}
+                >
+                  All
+                </button>
+                {filterGroups.map((g) => (
+                  <button
+                    key={g.id}
+                    type="button"
+                    onClick={() => handleChipClick(g.id)}
+                    className={`shrink-0 px-3 py-1 rounded-full text-sm font-medium border transition-colors inline-flex items-center gap-1 ${
+                      activeGroup === g.id
+                        ? "text-white border-transparent"
+                        : "border-border text-muted-foreground hover:border-current"
+                    }`}
+                    style={
+                      activeGroup === g.id
+                        ? { backgroundColor: g.color || "#6b7280" }
+                        : {}
+                    }
+                  >
+                    <GroupIcon name={g.icon} className="h-3.5 w-3.5" />
+                    {g.name}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* View toggle */}
+            <div className="flex gap-2 mt-3">
+              <Button
+                variant={view === "households" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setView("households")}
+                className={
+                  view === "households"
+                    ? "bg-brand-primary text-white hover:bg-brand-primary/90"
+                    : ""
                 }
               >
-                {g.name}
-              </button>
-            ))}
+                <Home className="mr-1 h-4 w-4" />
+                Households ({householdCount})
+              </Button>
+              <Button
+                variant={view === "people" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setView("people")}
+                className={
+                  view === "people"
+                    ? "bg-brand-primary text-white hover:bg-brand-primary/90"
+                    : ""
+                }
+              >
+                <LayoutList className="mr-1 h-4 w-4" />
+                People ({filteredMembers.length})
+              </Button>
+              <Button
+                variant={view === "groups" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setView("groups")}
+                className={
+                  view === "groups"
+                    ? "bg-brand-primary text-white hover:bg-brand-primary/90"
+                    : ""
+                }
+              >
+                <Tags className="mr-1 h-4 w-4" />
+                Groups ({allGroups.length})
+              </Button>
+            </div>
           </div>
-        )}
 
-        {/* View toggle */}
-        <div className="flex gap-2 mt-3">
-          <Button
-            variant={view === "households" ? "default" : "outline"}
-            size="sm"
-            onClick={() => setView("households")}
-            className={
-              view === "households"
-                ? "bg-brand-primary text-white hover:bg-brand-primary/90"
-                : ""
-            }
-          >
-            <Home className="mr-1 h-4 w-4" />
-            Households
-          </Button>
-          <Button
-            variant={view === "people" ? "default" : "outline"}
-            size="sm"
-            onClick={() => setView("people")}
-            className={
-              view === "people"
-                ? "bg-brand-primary text-white hover:bg-brand-primary/90"
-                : ""
-            }
-          >
-            <LayoutList className="mr-1 h-4 w-4" />
-            People ({filteredMembers.length})
-          </Button>
-        </div>
-      </div>
+          {/* A–Z jump rail */}
+          {view !== "groups" && (
+            <AlphaRail letters={sectionLetters} onJump={jumpToLetter} />
+          )}
 
-      {/* ============================================================
-          HOUSEHOLDS VIEW
-          ============================================================ */}
-      {view === "households" && (
-        <div className="mt-4">
-          {Object.keys(householdSections).length === 0 ? (
-            <p className="text-base text-muted-foreground text-center py-8">
-              No members match your search.
-            </p>
-          ) : (
-            Object.keys(householdSections)
-              .sort()
-              .map((letter) => (
-                <div key={letter}>
-                  <AlphaHeader letter={letter} />
-                  <div className="divide-y">
-                    {householdSections[letter].map((entry) => {
-                      if (entry.kind === "family") {
-                        return (
-                          <HouseholdRow
-                            key={`fam-${entry.family.id}`}
-                            family={entry.family}
+          {/* ============================================================
+              HOUSEHOLDS VIEW
+              ============================================================ */}
+          {view === "households" && (
+            <div className="mt-4">
+              {Object.keys(householdSections).length === 0 ? (
+                <p className="text-base text-muted-foreground text-center py-8">
+                  No members match your search.
+                </p>
+              ) : (
+                Object.keys(householdSections)
+                  .sort()
+                  .map((letter) => (
+                    <div
+                      key={letter}
+                      id={`dir-section-${letter}`}
+                      style={{ scrollMarginTop: stickyH + 8 }}
+                    >
+                      <AlphaHeader letter={letter} top={stickyH} />
+                      <div className="divide-y">
+                        {householdSections[letter].map((entry) => {
+                          if (entry.kind === "family") {
+                            return (
+                              <HouseholdRow
+                                key={`fam-${entry.family.id}`}
+                                family={entry.family}
+                                onOpen={() =>
+                                  pushSheet({
+                                    kind: "household",
+                                    family: entry.family,
+                                  })
+                                }
+                              />
+                            );
+                          } else {
+                            return (
+                              <div
+                                key={`solo-${entry.member.id}`}
+                                className="py-0.5"
+                              >
+                                <PeopleRow
+                                  member={entry.member}
+                                  onOpen={() =>
+                                    pushSheet({
+                                      kind: "profile",
+                                      profile: entry.member,
+                                    })
+                                  }
+                                />
+                              </div>
+                            );
+                          }
+                        })}
+                      </div>
+                    </div>
+                  ))
+              )}
+            </div>
+          )}
+
+          {/* ============================================================
+              PEOPLE VIEW
+              ============================================================ */}
+          {view === "people" && (
+            <div className="mt-4">
+              {Object.keys(peopleSections).length === 0 ? (
+                <p className="text-base text-muted-foreground text-center py-8">
+                  No members match your search.
+                </p>
+              ) : (
+                Object.keys(peopleSections)
+                  .sort()
+                  .map((letter) => (
+                    <div
+                      key={letter}
+                      id={`dir-section-${letter}`}
+                      style={{ scrollMarginTop: stickyH + 8 }}
+                    >
+                      <AlphaHeader letter={letter} top={stickyH} />
+                      <div className="divide-y">
+                        {peopleSections[letter].map((m) => (
+                          <PeopleRow
+                            key={m.id}
+                            member={m}
                             onOpen={() =>
-                              setSheetSubject({
-                                kind: "household",
-                                family: entry.family,
-                              })
+                              pushSheet({ kind: "profile", profile: m })
                             }
                           />
-                        );
-                      } else {
-                        return (
-                          <div
-                            key={`solo-${entry.member.id}`}
-                            className="py-0.5"
-                          >
-                            <PeopleRow
-                              member={entry.member}
-                              onOpen={() =>
-                                setSheetSubject({
-                                  kind: "profile",
-                                  profile: entry.member,
-                                })
-                              }
-                            />
-                          </div>
-                        );
-                      }
-                    })}
-                  </div>
-                </div>
-              ))
+                        ))}
+                      </div>
+                    </div>
+                  ))
+              )}
+            </div>
           )}
-        </div>
+
+          {/* ============================================================
+              GROUPS VIEW
+              ============================================================ */}
+          {view === "groups" && (
+            <div className="mt-4">
+              {allGroups.length === 0 ? (
+                <p className="text-base text-muted-foreground text-center py-8">
+                  No groups have been created yet.
+                </p>
+              ) : (
+                <div className="divide-y">
+                  {allGroups.map((g) => (
+                    <GroupRow
+                      key={g.id}
+                      group={g}
+                      count={(groupRosters[g.id] || []).length}
+                      onOpen={() => pushSheet({ kind: "group", group: g })}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </>
       )}
 
       {/* ============================================================
-          PEOPLE VIEW
+          DETAIL SHEET (stack-based: household → member, group → member)
           ============================================================ */}
-      {view === "people" && (
-        <div className="mt-4">
-          {Object.keys(peopleSections).length === 0 ? (
-            <p className="text-base text-muted-foreground text-center py-8">
-              No members match your search.
-            </p>
-          ) : (
-            Object.keys(peopleSections)
-              .sort()
-              .map((letter) => (
-                <div key={letter}>
-                  <AlphaHeader letter={letter} />
-                  <div className="divide-y">
-                    {peopleSections[letter].map((m) => (
-                      <PeopleRow
-                        key={m.id}
-                        member={m}
-                        onOpen={() =>
-                          setSheetSubject({ kind: "profile", profile: m })
-                        }
-                      />
-                    ))}
-                  </div>
-                </div>
-              ))
-          )}
-        </div>
-      )}
-
-      {/* ============================================================
-          DETAIL SHEET
-          ============================================================ */}
-      <Sheet
-        open={!!sheetSubject}
-        onOpenChange={(o) => !o && setSheetSubject(null)}
-      >
+      <Sheet open={!!sheetSubject} onOpenChange={(o) => !o && closeSheet()}>
         <SheetContent
           side="right"
           className="w-full sm:max-w-md flex flex-col overflow-hidden p-0"
         >
           <SheetHeader className="px-4 pt-4 pb-3 border-b shrink-0">
-            <SheetTitle>
-              {sheetSubject?.kind === "profile"
-                ? displayName(sheetSubject.profile)
-                : sheetSubject?.kind === "household"
-                  ? sheetSubject.family.family_name
-                  : ""}
-            </SheetTitle>
+            <div className="flex items-center gap-2">
+              {sheetStack.length > 1 && (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={popSheet}
+                  aria-label="Back"
+                  className="-ml-2 shrink-0"
+                >
+                  <ChevronLeft className="h-5 w-5" />
+                </Button>
+              )}
+              <SheetTitle className="truncate">{sheetTitle}</SheetTitle>
+            </div>
           </SheetHeader>
 
           {sheetSubject?.kind === "profile" && (
             <ProfileSheetContent
               profile={sheetSubject.profile}
-              family={sheetFamily as FamilyDirectoryFull | null}
+              family={sheetFamily}
             />
           )}
           {sheetSubject?.kind === "household" && (
             <HouseholdSheetContent
               family={sheetSubject.family}
               profileMap={profileMap}
+              onOpenProfile={(p) => pushSheet({ kind: "profile", profile: p })}
+            />
+          )}
+          {sheetSubject?.kind === "group" && (
+            <GroupSheetContent
+              group={sheetSubject.group}
+              members={groupRosters[sheetSubject.group.id] || []}
+              onOpenProfile={(p) => pushSheet({ kind: "profile", profile: p })}
             />
           )}
         </SheetContent>

--- a/app/directory/page.tsx
+++ b/app/directory/page.tsx
@@ -11,11 +11,13 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
+import Link from "next/link";
 import {
   ChevronLeft,
   ChevronRight,
   Home,
   LayoutList,
+  Printer,
   Search,
   Tags,
 } from "lucide-react";
@@ -671,6 +673,16 @@ export default function DirectoryPage() {
               >
                 <Tags className="mr-1 h-4 w-4" />
                 Groups ({allGroups.length})
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                nativeButton={false}
+                render={<Link href="/directory/print" />}
+                aria-label="Printable directory"
+                className="ml-auto text-muted-foreground"
+              >
+                <Printer className="h-4 w-4" />
               </Button>
             </div>
           </div>

--- a/app/directory/print/page.tsx
+++ b/app/directory/print/page.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft, Printer } from "lucide-react";
+import { formatPhone } from "@/lib/sanitize";
+import { displayName } from "@/lib/names";
+import { siteConfig } from "@/lib/config";
+import { MONTH_NAMES, relLabel } from "@/components/directory/utils";
+import type {
+  DirectoryProfile,
+  FamilyDirectoryFull,
+} from "@/lib/types";
+
+type Entry =
+  | { kind: "family"; family: FamilyDirectoryFull }
+  | { kind: "solo"; member: DirectoryProfile };
+
+function entrySortKey(entry: Entry): string {
+  return entry.kind === "family"
+    ? entry.family.family_name
+    : entry.member.last_name || entry.member.first_name || "";
+}
+
+function formatAddress(a: {
+  address_line1: string | null;
+  address_line2: string | null;
+  city: string | null;
+  state: string | null;
+  postal_code: string | null;
+}): string | null {
+  if (!a.address_line1 && !a.city) return null;
+  const line = [
+    a.address_line1,
+    a.address_line2,
+    [a.city, a.state].filter(Boolean).join(", ") +
+      (a.postal_code ? ` ${a.postal_code}` : ""),
+  ]
+    .filter(Boolean)
+    .join(", ");
+  return line || null;
+}
+
+function MemberLine({ profile }: { profile: DirectoryProfile }) {
+  const contact = [
+    profile.phone_mobile && `${formatPhone(profile.phone_mobile)} (m)`,
+    profile.phone_work && `${formatPhone(profile.phone_work)} (w)`,
+    profile.email,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <p className="text-sm leading-snug">
+      <span className="font-medium">{displayName(profile)}</span>
+      {profile.relationship !== "primary" && (
+        <span className="text-neutral-500"> · {relLabel(profile.relationship)}</span>
+      )}
+      {profile.birth_month && profile.birth_day && (
+        <span className="text-neutral-500">
+          {" "}· 🎂 {MONTH_NAMES[profile.birth_month - 1].slice(0, 3)}{" "}
+          {profile.birth_day}
+        </span>
+      )}
+      {contact && <span className="text-neutral-600"> — {contact}</span>}
+    </p>
+  );
+}
+
+export default function DirectoryPrintPage() {
+  const [members, setMembers] = useState<DirectoryProfile[]>([]);
+  const [families, setFamilies] = useState<FamilyDirectoryFull[]>([]);
+  const [loading, setLoading] = useState(true);
+  const supabase = createClient();
+
+  useEffect(() => {
+    async function load() {
+      const [{ data: m }, { data: f }] = await Promise.all([
+        supabase
+          .from("profiles_directory")
+          .select("*")
+          .order("last_name", { ascending: true }),
+        supabase
+          .from("families_directory_full")
+          .select("*")
+          .order("family_name", { ascending: true }),
+      ]);
+      setMembers((m || []) as DirectoryProfile[]);
+      setFamilies((f || []) as FamilyDirectoryFull[]);
+      setLoading(false);
+    }
+    load();
+  }, []);
+
+  const profileMap = useMemo(() => {
+    const map: Record<string, DirectoryProfile> = {};
+    members.forEach((m) => { map[m.id] = m; });
+    return map;
+  }, [members]);
+
+  const entries = useMemo<Entry[]>(() => {
+    const solos = members.filter((m) => !m.family_id);
+    const list: Entry[] = [
+      ...families
+        .filter((f) => f.members.length > 0 || f.family_members_list.length > 0)
+        .map((f) => ({ kind: "family" as const, family: f })),
+      ...solos.map((m) => ({ kind: "solo" as const, member: m })),
+    ];
+    list.sort((a, b) => entrySortKey(a).localeCompare(entrySortKey(b)));
+    return list;
+  }, [members, families]);
+
+  // Birthdays by month appendix
+  const birthdaysByMonth = useMemo(() => {
+    const byMonth: Record<number, { name: string; day: number }[]> = {};
+    for (const m of members) {
+      if (!m.birth_month || !m.birth_day) continue;
+      (byMonth[m.birth_month] ??= []).push({
+        name: displayName(m),
+        day: m.birth_day,
+      });
+    }
+    for (const family of families) {
+      for (const fm of family.family_members_list) {
+        if (!fm.birth_month || !fm.birth_day) continue;
+        (byMonth[fm.birth_month] ??= []).push({
+          name: [fm.first_name, fm.last_name].filter(Boolean).join(" "),
+          day: fm.birth_day,
+        });
+      }
+    }
+    Object.values(byMonth).forEach((list) => list.sort((a, b) => a.day - b.day));
+    return byMonth;
+  }, [members, families]);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto px-4 py-12">
+        <p className="text-xl text-muted-foreground">Preparing directory...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-6 py-8 max-w-3xl bg-white text-black">
+      {/* Toolbar — hidden when printing */}
+      <div className="flex items-center justify-between mb-8 print:hidden">
+        <Button
+          variant="ghost"
+          size="sm"
+          nativeButton={false}
+          render={<Link href="/directory" />}
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to directory
+        </Button>
+        <Button
+          onClick={() => window.print()}
+          className="bg-brand-primary hover:bg-brand-primary/90 text-white"
+        >
+          <Printer className="mr-2 h-4 w-4" />
+          Print / Save as PDF
+        </Button>
+      </div>
+
+      {/* Title page header */}
+      <div className="text-center mb-8 border-b pb-6">
+        <h1 className="text-3xl font-bold">{siteConfig.name}</h1>
+        <p className="text-lg mt-1">Member Directory</p>
+        <p className="text-sm text-neutral-500 mt-1">
+          {new Date().toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}
+        </p>
+      </div>
+
+      {/* Household / member listing */}
+      <div className="space-y-5">
+        {entries.map((entry) => {
+          if (entry.kind === "family") {
+            const f = entry.family;
+            const address = formatAddress(f);
+            return (
+              <div
+                key={`fam-${f.id}`}
+                className="break-inside-avoid border-b border-neutral-200 pb-4 flex gap-4"
+              >
+                {f.photo_url && (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={f.photo_url}
+                    alt={`${f.family_name} family photo`}
+                    className="h-24 w-32 object-cover rounded shrink-0"
+                  />
+                )}
+                <div className="min-w-0">
+                  <p className="text-lg font-bold">{f.family_name}</p>
+                  {address && (
+                    <p className="text-sm text-neutral-600">{address}</p>
+                  )}
+                  {f.phone_home && (
+                    <p className="text-sm text-neutral-600">
+                      {formatPhone(f.phone_home)} (home)
+                    </p>
+                  )}
+                  <div className="mt-1.5 space-y-0.5">
+                    {f.members.map((m) => {
+                      const full = profileMap[m.id];
+                      if (full) return <MemberLine key={m.id} profile={full} />;
+                      return (
+                        <p key={m.id} className="text-sm">
+                          {[m.preferred_name || m.first_name, m.last_name]
+                            .filter(Boolean)
+                            .join(" ")}
+                        </p>
+                      );
+                    })}
+                    {f.family_members_list.map((fm) => (
+                      <p key={fm.id} className="text-sm leading-snug">
+                        <span className="font-medium">
+                          {[fm.first_name, fm.last_name].filter(Boolean).join(" ")}
+                        </span>
+                        <span className="text-neutral-500">
+                          {" "}· {relLabel(fm.relationship)}
+                        </span>
+                        {fm.birth_month && fm.birth_day && (
+                          <span className="text-neutral-500">
+                            {" "}· 🎂 {MONTH_NAMES[fm.birth_month - 1].slice(0, 3)}{" "}
+                            {fm.birth_day}
+                          </span>
+                        )}
+                      </p>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            );
+          }
+
+          const m = entry.member;
+          const address = formatAddress(m);
+          return (
+            <div
+              key={`solo-${m.id}`}
+              className="break-inside-avoid border-b border-neutral-200 pb-4"
+            >
+              <MemberLine profile={m} />
+              {address && (
+                <p className="text-sm text-neutral-600">{address}</p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Birthdays by month */}
+      <div className="mt-10 break-before-page">
+        <h2 className="text-xl font-bold mb-4">Birthdays by Month</h2>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-4">
+          {MONTH_NAMES.map((monthName, i) => {
+            const list = birthdaysByMonth[i + 1] || [];
+            if (list.length === 0) return null;
+            return (
+              <div key={monthName} className="break-inside-avoid">
+                <p className="font-semibold text-sm mb-1">{monthName}</p>
+                {list.map((b, j) => (
+                  <p key={j} className="text-xs leading-snug">
+                    {b.day} — {b.name}
+                  </p>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { ProfileForm } from "@/components/profile/ProfileForm";
+import { DirectoryPreview } from "@/components/profile/DirectoryPreview";
 import { siteConfig } from "@/lib/config";
 import type { Profile, FamilyUnit } from "@/lib/types";
 
@@ -39,10 +40,14 @@ export default async function ProfilePage() {
       <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-2">
         My Profile
       </h1>
-      <p className="text-base text-muted-foreground mb-8">
+      <p className="text-base text-muted-foreground mb-4">
         Your contact info for the member directory. Privacy controls let you
         hide specific fields from other members.
       </p>
+
+      <div className="mb-8">
+        <DirectoryPreview />
+      </div>
 
       <ProfileForm profile={profile} families={families} isAdmin={false} />
     </div>

--- a/app/profile/setup/SetupWizard.tsx
+++ b/app/profile/setup/SetupWizard.tsx
@@ -1322,25 +1322,15 @@ export function SetupWizard({ profile, userEmail }: SetupWizardProps) {
             <ChevronRight className="h-4 w-4" />
           </Button>
         ) : (
-          <div className="flex gap-3">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleComplete}
-              disabled={saving}
-            >
-              {saving ? "Saving..." : "Skip & Finish"}
-            </Button>
-            <Button
-              type="button"
-              onClick={handleComplete}
-              disabled={saving}
-              className="bg-brand-primary hover:bg-brand-primary/90 text-white flex items-center gap-2"
-            >
-              {saving ? "Saving..." : "Complete Setup"}
-              {!saving && <Check className="h-4 w-4" />}
-            </Button>
-          </div>
+          <Button
+            type="button"
+            onClick={handleComplete}
+            disabled={saving}
+            className="bg-brand-primary hover:bg-brand-primary/90 text-white flex items-center gap-2"
+          >
+            {saving ? "Saving..." : "Complete Setup"}
+            {!saving && <Check className="h-4 w-4" />}
+          </Button>
         )}
       </div>
     </div>

--- a/components/directory/AvatarCluster.tsx
+++ b/components/directory/AvatarCluster.tsx
@@ -1,0 +1,22 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+interface AvatarClusterProps {
+  people: Array<{ avatarUrl: string | null; name: string; initials: string }>;
+}
+
+/** Up to 3 overlapping avatars for a household row */
+export function AvatarCluster({ people }: AvatarClusterProps) {
+  const displayed = people.slice(0, 3);
+  return (
+    <div className="flex -space-x-2">
+      {displayed.map((p, i) => (
+        <Avatar key={i} className="h-10 w-10 border-2 border-background">
+          {p.avatarUrl && <AvatarImage src={p.avatarUrl} alt={p.name} />}
+          <AvatarFallback className="bg-brand-primary text-white text-sm">
+            {p.initials}
+          </AvatarFallback>
+        </Avatar>
+      ))}
+    </div>
+  );
+}

--- a/components/directory/BirthdayWidget.tsx
+++ b/components/directory/BirthdayWidget.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp } from "lucide-react";
 import { displayName, initials } from "@/lib/names";
 import type { DirectoryProfile, FamilyDirectoryFull } from "@/lib/types";
 
@@ -57,6 +57,8 @@ export function BirthdayWidget({ members, families }: BirthdayWidgetProps) {
 
   const [includeNonClassMembers, setIncludeNonClassMembers] = useState(false);
   const [collapsed, setCollapsed] = useState<boolean | null>(null); // null = auto
+  // 1-12 when browsing a specific month; null = default upcoming view
+  const [browseMonth, setBrowseMonth] = useState<number | null>(null);
 
   const entries = useMemo<BirthdayEntry[]>(() => {
     const result: BirthdayEntry[] = [];
@@ -145,6 +147,23 @@ export function BirthdayWidget({ members, families }: BirthdayWidgetProps) {
       .sort((a, b) => a.day - b.day);
   }, [filtered, currentMonth]);
 
+  // Full list for a browsed month
+  const browsedEntries = useMemo(() => {
+    if (browseMonth === null) return [];
+    return filtered
+      .filter((e) => e.month === browseMonth)
+      .sort((a, b) => a.day - b.day);
+  }, [filtered, browseMonth]);
+
+  function stepMonth(delta: number) {
+    const base = browseMonth ?? currentMonth;
+    let next = base + delta;
+    if (next < 1) next = 12;
+    if (next > 12) next = 1;
+    setBrowseMonth(next === currentMonth ? null : next);
+    setCollapsed(false);
+  }
+
   const hasEvents = thisWeek.length > 0 || thisMonth.length > 0;
 
   // Auto-expand if there are events this week, auto-collapse otherwise.
@@ -202,6 +221,61 @@ export function BirthdayWidget({ members, families }: BirthdayWidgetProps) {
 
         {!isCollapsed && (
           <div className="space-y-4">
+            {/* Month navigator */}
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => stepMonth(-1)}
+                aria-label="Previous month"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <span className="text-sm font-medium min-w-28 text-center">
+                {browseMonth === null
+                  ? "Upcoming"
+                  : MONTH_NAMES[browseMonth - 1]}
+              </span>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => stepMonth(1)}
+                aria-label="Next month"
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+              {browseMonth !== null && (
+                <button
+                  type="button"
+                  onClick={() => setBrowseMonth(null)}
+                  className="text-xs text-brand-primary hover:underline ml-2"
+                >
+                  Back to upcoming
+                </button>
+              )}
+            </div>
+
+            {browseMonth !== null ? (
+              browsedEntries.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No birthdays or anniversaries in{" "}
+                  {MONTH_NAMES[browseMonth - 1]}.
+                </p>
+              ) : (
+                <div className="flex flex-wrap gap-x-4 gap-y-1">
+                  {browsedEntries.map((entry) => (
+                    <span key={entry.key} className="text-sm text-muted-foreground">
+                      {entry.type === "anniversary" ? "💍" : "🎂"}{" "}
+                      <span className="font-medium text-foreground">
+                        {entry.name}
+                      </span>{" "}
+                      ({MONTH_NAMES[entry.month - 1]} {entry.day})
+                    </span>
+                  ))}
+                </div>
+              )
+            ) : (
+              <>
             {thisWeek.length > 0 && (
               <div>
                 <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
@@ -263,6 +337,8 @@ export function BirthdayWidget({ members, families }: BirthdayWidgetProps) {
               <p className="text-sm text-muted-foreground">
                 No birthdays or anniversaries this month.
               </p>
+            )}
+              </>
             )}
           </div>
         )}

--- a/components/directory/GroupBadge.tsx
+++ b/components/directory/GroupBadge.tsx
@@ -1,0 +1,24 @@
+import { GroupIcon } from "@/components/directory/GroupIcon";
+import type { GroupChip } from "@/lib/types";
+
+interface GroupBadgeProps {
+  group: GroupChip;
+  size?: "xs" | "sm";
+}
+
+/** Colored group chip with the group's icon and name */
+export function GroupBadge({ group, size = "sm" }: GroupBadgeProps) {
+  const sizing =
+    size === "xs"
+      ? "px-1.5 py-px text-[10px] gap-0.5"
+      : "px-2 py-0.5 text-xs gap-1";
+  return (
+    <span
+      className={`inline-flex items-center rounded-full font-medium text-white ${sizing}`}
+      style={{ backgroundColor: group.color || "#6b7280" }}
+    >
+      <GroupIcon name={group.icon} className={size === "xs" ? "h-2.5 w-2.5" : "h-3 w-3"} />
+      {group.name}
+    </span>
+  );
+}

--- a/components/directory/GroupIcon.tsx
+++ b/components/directory/GroupIcon.tsx
@@ -1,0 +1,43 @@
+import {
+  Baby,
+  Bell,
+  BookOpen,
+  Cross,
+  Flag,
+  HandHelping,
+  Heart,
+  Music,
+  Shield,
+  Star,
+  User,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
+
+/** Icon names offered in the admin group editor, mapped to components */
+const ICONS: Record<string, LucideIcon> = {
+  heart: Heart,
+  "hand-helping": HandHelping,
+  users: Users,
+  user: User,
+  star: Star,
+  cross: Cross,
+  "book-open": BookOpen,
+  music: Music,
+  baby: Baby,
+  shield: Shield,
+  bell: Bell,
+  flag: Flag,
+};
+
+interface GroupIconProps {
+  name: string | null | undefined;
+  className?: string;
+}
+
+/** Renders the lucide icon an admin picked for a group, or nothing */
+export function GroupIcon({ name, className }: GroupIconProps) {
+  const Icon = name ? ICONS[name] : undefined;
+  if (!Icon) return null;
+  return <Icon className={className} />;
+}

--- a/components/directory/GroupIcon.tsx
+++ b/components/directory/GroupIcon.tsx
@@ -1,43 +1,18 @@
-import {
-  Baby,
-  Bell,
-  BookOpen,
-  Cross,
-  Flag,
-  HandHelping,
-  Heart,
-  Music,
-  Shield,
-  Star,
-  User,
-  Users,
-  type LucideIcon,
-} from "lucide-react";
+"use client";
 
-/** Icon names offered in the admin group editor, mapped to components */
-const ICONS: Record<string, LucideIcon> = {
-  heart: Heart,
-  "hand-helping": HandHelping,
-  users: Users,
-  user: User,
-  star: Star,
-  cross: Cross,
-  "book-open": BookOpen,
-  music: Music,
-  baby: Baby,
-  shield: Shield,
-  bell: Bell,
-  flag: Flag,
-};
+import { DynamicIcon, type IconName } from "lucide-react/dynamic";
 
 interface GroupIconProps {
   name: string | null | undefined;
   className?: string;
 }
 
-/** Renders the lucide icon an admin picked for a group, or nothing */
+/**
+ * Renders the lucide icon an admin picked for a group, or nothing.
+ * Icons are lazy-loaded by name, so any of the ~1,950 lucide icons work;
+ * unknown names render nothing (DynamicIcon logs and returns null).
+ */
 export function GroupIcon({ name, className }: GroupIconProps) {
-  const Icon = name ? ICONS[name] : undefined;
-  if (!Icon) return null;
-  return <Icon className={className} />;
+  if (!name) return null;
+  return <DynamicIcon name={name as IconName} className={className} />;
 }

--- a/components/directory/GroupSheetContent.tsx
+++ b/components/directory/GroupSheetContent.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { ChevronRight } from "lucide-react";
+import { formatPhone } from "@/lib/sanitize";
+import { displayName, initials } from "@/lib/names";
+import { GroupIcon } from "@/components/directory/GroupIcon";
+import type { DirectoryProfile } from "@/lib/types";
+import type { DirectoryGroup } from "@/components/directory/types";
+
+interface GroupSheetContentProps {
+  group: DirectoryGroup;
+  members: DirectoryProfile[];
+  onOpenProfile: (profile: DirectoryProfile) => void;
+}
+
+/** Roster view for a member group inside the directory detail sheet */
+export function GroupSheetContent({
+  group,
+  members,
+  onOpenProfile,
+}: GroupSheetContentProps) {
+  return (
+    <div className="px-4 pb-6 space-y-4 overflow-y-auto flex-1">
+      {/* Group header */}
+      <div className="flex items-center gap-3 pt-2">
+        <div
+          className="h-12 w-12 rounded-full flex items-center justify-center text-white shrink-0"
+          style={{ backgroundColor: group.color || "#6b7280" }}
+        >
+          <GroupIcon name={group.icon} className="h-6 w-6" />
+        </div>
+        <div className="min-w-0">
+          <p className="text-xl font-bold leading-tight">{group.name}</p>
+          <p className="text-sm text-muted-foreground">
+            {members.length} member{members.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+      </div>
+
+      {group.description && (
+        <p className="text-sm text-muted-foreground">{group.description}</p>
+      )}
+
+      {/* Roster */}
+      {members.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4 text-center">
+          No members in this group yet.
+        </p>
+      ) : (
+        <div className="divide-y">
+          {members.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              onClick={() => onOpenProfile(m)}
+              className="w-full text-left flex items-center gap-3 py-2.5 hover:bg-brand-bg-light/50 transition-colors rounded-lg -mx-2 px-2"
+            >
+              <Avatar className="h-9 w-9 shrink-0">
+                {m.avatar_url && (
+                  <AvatarImage src={m.avatar_url} alt={displayName(m)} />
+                )}
+                <AvatarFallback className="bg-brand-primary text-white text-sm">
+                  {initials(m)}
+                </AvatarFallback>
+              </Avatar>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">{displayName(m)}</p>
+                {m.phone_mobile && (
+                  <p className="text-xs text-muted-foreground">
+                    {formatPhone(m.phone_mobile)}
+                  </p>
+                )}
+              </div>
+              <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/directory/HouseholdSheetContent.tsx
+++ b/components/directory/HouseholdSheetContent.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ChevronRight, Download, Home, MapPin } from "lucide-react";
+import { formatPhone } from "@/lib/sanitize";
+import { GroupBadge } from "@/components/directory/GroupBadge";
+import {
+  MONTH_NAMES,
+  downloadVCard,
+  formatAnniversary,
+  relLabel,
+} from "@/components/directory/utils";
+import type {
+  DirectoryProfile,
+  FamilyDirectoryFull,
+  HouseholdFamilyMember,
+  HouseholdMember,
+} from "@/lib/types";
+
+interface HouseholdSheetContentProps {
+  family: FamilyDirectoryFull;
+  profileMap: Record<string, DirectoryProfile>;
+  /** Open a member's profile detail (enrolled members only) */
+  onOpenProfile?: (profile: DirectoryProfile) => void;
+}
+
+export function HouseholdSheetContent({
+  family,
+  profileMap,
+  onOpenProfile,
+}: HouseholdSheetContentProps) {
+  const hasSpouse =
+    family.members.some((m) => m.relationship === "spouse") ||
+    family.family_members_list.some((fm) => fm.relationship === "spouse");
+
+  const today = new Date();
+  const currentMonth = today.getMonth() + 1;
+
+  const birthdaysThisMonth = [
+    ...family.members
+      .filter((m) => m.birth_month === currentMonth && m.birth_day)
+      .map((m) => ({
+        name: [m.first_name, m.last_name].filter(Boolean).join(" ") || "(unnamed)",
+        day: m.birth_day!,
+      })),
+    ...family.family_members_list
+      .filter((fm) => fm.birth_month === currentMonth && fm.birth_day)
+      .map((fm) => ({
+        name: [fm.first_name, fm.last_name].filter(Boolean).join(" "),
+        day: fm.birth_day!,
+      })),
+  ].sort((a, b) => a.day - b.day);
+
+  function renderMember(m: HouseholdMember) {
+    const fullProfile = profileMap[m.id];
+    const name =
+      [m.preferred_name || m.first_name, m.last_name]
+        .filter(Boolean)
+        .join(" ") || "(unnamed)";
+    const canOpen = !!fullProfile && !!onOpenProfile;
+
+    const inner = (
+      <>
+        <Avatar className="h-9 w-9">
+          {m.avatar_url && (
+            <AvatarImage
+              src={m.avatar_url}
+              alt={[m.first_name, m.last_name].filter(Boolean).join(" ")}
+            />
+          )}
+          <AvatarFallback className="bg-brand-primary text-white text-sm">
+            {((m.preferred_name || m.first_name || "?").charAt(0) +
+              (m.last_name || "").charAt(0)
+            ).toUpperCase()}
+          </AvatarFallback>
+        </Avatar>
+        <div className="flex-1 min-w-0 text-left">
+          <span className="text-sm font-medium">{name}</span>
+          {m.relationship !== "primary" && (
+            <Badge variant="outline" className="ml-2 text-xs capitalize">
+              {relLabel(m.relationship)}
+            </Badge>
+          )}
+          {!m.is_class_member && (
+            <Badge variant="secondary" className="ml-1 text-xs">
+              not enrolled
+            </Badge>
+          )}
+          {fullProfile?.phone_mobile && (
+            <p className="text-xs text-muted-foreground">
+              {formatPhone(fullProfile.phone_mobile)}
+            </p>
+          )}
+        </div>
+        {fullProfile?.groups && fullProfile.groups.length > 0 && (
+          <div className="hidden sm:flex gap-1 shrink-0">
+            {fullProfile.groups.slice(0, 2).map((g) => (
+              <GroupBadge key={g.id} group={g} size="xs" />
+            ))}
+          </div>
+        )}
+        {canOpen && (
+          <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+        )}
+      </>
+    );
+
+    if (canOpen) {
+      return (
+        <button
+          key={m.id}
+          type="button"
+          onClick={() => onOpenProfile!(fullProfile)}
+          className="w-full flex items-center gap-3 rounded-lg -mx-2 px-2 py-1.5 hover:bg-brand-bg-light/50 transition-colors"
+        >
+          {inner}
+        </button>
+      );
+    }
+    return (
+      <div key={m.id} className="flex items-center gap-3 px-0 py-1.5">
+        {inner}
+      </div>
+    );
+  }
+
+  function renderFamilyMember(fm: HouseholdFamilyMember) {
+    const name = [fm.first_name, fm.last_name].filter(Boolean).join(" ");
+    return (
+      <div key={fm.id} className="flex items-center gap-3 py-1.5">
+        <Avatar className="h-9 w-9">
+          {fm.avatar_url && (
+            <AvatarImage
+              src={fm.avatar_url}
+              alt={[fm.first_name, fm.last_name].filter(Boolean).join(" ")}
+            />
+          )}
+          <AvatarFallback className="bg-muted text-muted-foreground text-sm">
+            {((fm.first_name || "?").charAt(0) + (fm.last_name || "").charAt(0)).toUpperCase()}
+          </AvatarFallback>
+        </Avatar>
+        <div className="flex-1 min-w-0">
+          <span className="text-sm font-medium">{name}</span>
+          <Badge variant="outline" className="ml-2 text-xs capitalize">
+            {relLabel(fm.relationship)}
+          </Badge>
+          {!fm.is_class_member && (
+            <Badge variant="secondary" className="ml-1 text-xs">
+              not enrolled
+            </Badge>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 pb-6 space-y-4 overflow-y-auto flex-1">
+      {/* Family name header */}
+      <div className="pt-2">
+        {family.photo_url && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={family.photo_url}
+            alt={`${family.family_name} family photo`}
+            className="w-full aspect-[4/3] object-cover rounded-lg mb-3"
+          />
+        )}
+        <p className="text-xl font-bold">{family.family_name}</p>
+        {family.address_line1 && (
+          <p className="text-sm text-muted-foreground">
+            {family.address_line1}
+            {family.city && `, ${family.city}`}
+            {family.state && `, ${family.state}`}
+          </p>
+        )}
+      </div>
+
+      {/* Members */}
+      <div className="space-y-1">
+        {family.members.map((m) => renderMember(m))}
+        {family.family_members_list.map((fm) => renderFamilyMember(fm))}
+      </div>
+
+      {/* Family address */}
+      {family.address_line1 && (
+        <div className="flex items-start gap-3">
+          <MapPin className="h-4 w-4 text-muted-foreground shrink-0 mt-1" />
+          <div className="text-sm">
+            <p>{family.address_line1}</p>
+            {family.address_line2 && <p>{family.address_line2}</p>}
+            <p>
+              {family.city}
+              {family.state && `, ${family.state}`}
+              {family.postal_code && ` ${family.postal_code}`}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Family home phone */}
+      {family.phone_home && (
+        <div className="flex items-center gap-3">
+          <Home className="h-4 w-4 text-muted-foreground shrink-0" />
+          <a
+            href={`tel:${family.phone_home}`}
+            className="text-sm text-brand-primary hover:underline"
+          >
+            {formatPhone(family.phone_home)}
+          </a>
+          <span className="text-xs text-muted-foreground">home</span>
+        </div>
+      )}
+
+      {/* Birthdays this month */}
+      {birthdaysThisMonth.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
+            Birthdays this month
+          </p>
+          <div className="space-y-0.5">
+            {birthdaysThisMonth.map((b, i) => (
+              <p key={i} className="text-sm">
+                🎂 {b.name} ({MONTH_NAMES[currentMonth - 1]} {b.day})
+              </p>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Anniversary — only if spouse exists */}
+      {family.anniversary && hasSpouse && (
+        <div className="flex items-center gap-2">
+          <span className="text-sm">
+            💍 Anniversary: {formatAnniversary(family.anniversary)}
+          </span>
+        </div>
+      )}
+
+      {/* Save to Contacts — primary member of the household */}
+      {(() => {
+        const primary = family.members.find((m) => m.relationship === "primary");
+        if (!primary) return null;
+        return (
+          <div className="pt-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => downloadVCard(primary.id)}
+              className="gap-2"
+            >
+              <Download className="h-4 w-4" />
+              Save to Contacts
+            </Button>
+          </div>
+        );
+      })()}
+    </div>
+  );
+}

--- a/components/directory/ProfileSheetContent.tsx
+++ b/components/directory/ProfileSheetContent.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Briefcase,
+  Calendar,
+  Download,
+  Home,
+  Mail,
+  MapPin,
+  MessageSquare,
+  Phone,
+} from "lucide-react";
+import { formatPhone } from "@/lib/sanitize";
+import { displayName, initials } from "@/lib/names";
+import { GroupBadge } from "@/components/directory/GroupBadge";
+import {
+  downloadVCard,
+  formatBirthdayShort,
+  relLabel,
+  resolveAddress,
+} from "@/components/directory/utils";
+import type { DirectoryProfile, FamilyDirectoryFull } from "@/lib/types";
+
+interface ProfileSheetContentProps {
+  profile: DirectoryProfile;
+  family: FamilyDirectoryFull | null;
+}
+
+export function ProfileSheetContent({
+  profile,
+  family,
+}: ProfileSheetContentProps) {
+  const address = resolveAddress(profile, family);
+  const hasBirthday = profile.birth_month && profile.birth_day;
+
+  return (
+    <div className="px-4 pb-6 space-y-3 overflow-y-auto flex-1">
+      {/* Header */}
+      <div className="flex items-center gap-4 pt-2">
+        <Avatar className="h-20 w-20 shrink-0">
+          {profile.avatar_url && (
+            <AvatarImage src={profile.avatar_url} alt={displayName(profile)} />
+          )}
+          <AvatarFallback className="bg-brand-primary text-white text-2xl">
+            {initials(profile)}
+          </AvatarFallback>
+        </Avatar>
+        <div className="min-w-0">
+          <p className="text-xl font-bold leading-tight">{displayName(profile)}</p>
+          {profile.preferred_name &&
+            profile.first_name &&
+            profile.preferred_name !== profile.first_name && (
+              <p className="text-sm text-muted-foreground">
+                ({profile.first_name} {profile.last_name})
+              </p>
+            )}
+          {profile.relationship && profile.relationship !== "primary" && (
+            <Badge variant="outline" className="text-xs mt-1 capitalize">
+              {relLabel(profile.relationship)}
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {/* Groups */}
+      {profile.groups && profile.groups.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {profile.groups.map((g) => (
+            <GroupBadge key={g.id} group={g} />
+          ))}
+        </div>
+      )}
+
+      {/* Bio */}
+      {profile.bio && (
+        <p className="text-sm italic text-muted-foreground">{profile.bio}</p>
+      )}
+
+      {/* Phones */}
+      {profile.phone_mobile && (
+        <div className="flex items-center gap-3">
+          <Phone className="h-4 w-4 text-muted-foreground shrink-0" />
+          <a
+            href={`tel:${profile.phone_mobile}`}
+            className="text-base text-brand-primary hover:underline"
+          >
+            {formatPhone(profile.phone_mobile)}
+          </a>
+          <span className="text-xs text-muted-foreground">mobile</span>
+          <a
+            href={`sms:${profile.phone_mobile}`}
+            className="ml-auto text-brand-primary hover:text-brand-primary/80"
+            aria-label={`Text ${displayName(profile)}`}
+          >
+            <MessageSquare className="h-4 w-4" />
+          </a>
+        </div>
+      )}
+      {profile.phone_home && (
+        <div className="flex items-center gap-3">
+          <Home className="h-4 w-4 text-muted-foreground shrink-0" />
+          <a
+            href={`tel:${profile.phone_home}`}
+            className="text-base text-brand-primary hover:underline"
+          >
+            {formatPhone(profile.phone_home)}
+          </a>
+          <span className="text-xs text-muted-foreground">home</span>
+        </div>
+      )}
+      {!profile.phone_home && family?.phone_home && (
+        <div className="flex items-center gap-3">
+          <Home className="h-4 w-4 text-muted-foreground shrink-0" />
+          <a
+            href={`tel:${family.phone_home}`}
+            className="text-base text-brand-primary hover:underline"
+          >
+            {formatPhone(family.phone_home)}
+          </a>
+          <span className="text-xs text-muted-foreground">family home</span>
+        </div>
+      )}
+      {profile.phone_work && (
+        <div className="flex items-center gap-3">
+          <Briefcase className="h-4 w-4 text-muted-foreground shrink-0" />
+          <a
+            href={`tel:${profile.phone_work}`}
+            className="text-base text-brand-primary hover:underline"
+          >
+            {formatPhone(profile.phone_work)}
+          </a>
+          <span className="text-xs text-muted-foreground">work</span>
+        </div>
+      )}
+
+      {/* Email */}
+      {profile.email && (
+        <div className="flex items-center gap-3">
+          <Mail className="h-4 w-4 text-muted-foreground shrink-0" />
+          <a
+            href={`mailto:${profile.email}`}
+            className="text-base text-brand-primary hover:underline break-all"
+          >
+            {profile.email}
+          </a>
+        </div>
+      )}
+
+      {/* Address */}
+      {address && (
+        <div className="flex items-start gap-3">
+          <MapPin className="h-4 w-4 text-muted-foreground shrink-0 mt-1" />
+          <div className="text-base">
+            <p>{address.line1}</p>
+            {address.line2 && <p>{address.line2}</p>}
+            <p>
+              {address.city}
+              {address.state && `, ${address.state}`}
+              {address.postal && ` ${address.postal}`}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Birthday */}
+      {hasBirthday && (
+        <div className="flex items-center gap-3">
+          <Calendar className="h-4 w-4 text-muted-foreground shrink-0" />
+          <span className="text-base">
+            🎂 {formatBirthdayShort(profile.birth_month!, profile.birth_day!)}
+            {profile.birth_year ? `, ${profile.birth_year}` : ""}
+          </span>
+        </div>
+      )}
+
+      {/* Occupation */}
+      {(profile.occupation || profile.employer) && (
+        <div className="flex items-start gap-3">
+          <Briefcase className="h-4 w-4 text-muted-foreground shrink-0 mt-1" />
+          <div className="text-base">
+            {profile.occupation && <p>{profile.occupation}</p>}
+            {profile.employer && (
+              <p className="text-sm text-muted-foreground">{profile.employer}</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Save to Contacts */}
+      <div className="pt-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => downloadVCard(profile.id)}
+          className="gap-2"
+        >
+          <Download className="h-4 w-4" />
+          Save to Contacts
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/directory/types.ts
+++ b/components/directory/types.ts
@@ -1,0 +1,7 @@
+import type { GroupChip } from "@/lib/types";
+
+/** Group row loaded for the directory page (chips + Groups view) */
+export interface DirectoryGroup extends GroupChip {
+  description: string | null;
+  show_in_directory_filter: boolean;
+}

--- a/components/directory/utils.ts
+++ b/components/directory/utils.ts
@@ -1,0 +1,48 @@
+import type { DirectoryProfile, FamilyDirectoryFull } from "@/lib/types";
+
+export const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+export function formatBirthdayShort(month: number, day: number): string {
+  return `${MONTH_NAMES[month - 1]} ${day}`;
+}
+
+export function formatAnniversary(iso: string): string {
+  const d = new Date(iso + "T00:00:00");
+  return d.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function relLabel(rel: string): string {
+  switch (rel) {
+    case "primary": return "Primary";
+    case "spouse": return "Spouse";
+    case "child": return "Child";
+    case "parent": return "Parent";
+    case "sibling": return "Sibling";
+    default: return "Other";
+  }
+}
+
+/** Resolve the best address to show in the detail sheet */
+export function resolveAddress(
+  member: DirectoryProfile,
+  family: FamilyDirectoryFull | null,
+) {
+  const line1 = member.address_line1 ?? family?.address_line1 ?? null;
+  const line2 = member.address_line2 ?? family?.address_line2 ?? null;
+  const city = member.city ?? family?.city ?? null;
+  const state = member.state ?? family?.state ?? null;
+  const postal = member.postal_code ?? family?.postal_code ?? null;
+  if (!line1 && !city) return null;
+  return { line1, line2, city, state, postal };
+}
+
+export function downloadVCard(profileId: string) {
+  window.location.href = `/api/members/${profileId}/vcard`;
+}

--- a/components/profile/DirectoryPreview.tsx
+++ b/components/profile/DirectoryPreview.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Eye, EyeOff } from "lucide-react";
+import { toast } from "sonner";
+import { ProfileSheetContent } from "@/components/directory/ProfileSheetContent";
+import type {
+  DirectoryProfile,
+  FamilyDirectoryFull,
+  GroupChip,
+  Profile,
+} from "@/lib/types";
+
+/**
+ * Apply the same privacy masking as the profiles_directory SQL view so the
+ * preview shows exactly what other members see.
+ */
+function maskProfile(p: Profile, groups: GroupChip[]): DirectoryProfile {
+  return {
+    id: p.id,
+    first_name: p.first_name,
+    last_name: p.last_name,
+    preferred_name: p.preferred_name,
+    avatar_url: p.avatar_url,
+    role: p.role,
+    relationship: p.relationship,
+    bio: p.bio,
+    family_id: p.family_id,
+    email: p.hide_email ? null : p.email,
+    phone_mobile: p.hide_phone_mobile ? null : p.phone_mobile,
+    phone_home: p.hide_phone_home ? null : p.phone_home,
+    phone_work: p.hide_phone_work ? null : p.phone_work,
+    address_line1: p.hide_address ? null : p.address_line1,
+    address_line2: p.hide_address ? null : p.address_line2,
+    city: p.hide_address ? null : p.city,
+    state: p.hide_address ? null : p.state,
+    postal_code: p.hide_address ? null : p.postal_code,
+    birth_month: p.hide_birthday ? null : p.birth_month,
+    birth_day: p.hide_birthday ? null : p.birth_day,
+    birth_year: p.hide_birthday || p.hide_birth_year ? null : p.birth_year,
+    anniversary: p.hide_anniversary ? null : p.anniversary,
+    occupation: p.hide_occupation ? null : p.occupation,
+    employer: p.hide_occupation ? null : p.employer,
+    groups,
+    created_at: p.created_at,
+  };
+}
+
+/**
+ * "How others see me" — opens a sheet rendering the exact directory profile
+ * card with the member's privacy settings applied.
+ */
+export function DirectoryPreview() {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [entry, setEntry] = useState<DirectoryProfile | null>(null);
+  const [unlisted, setUnlisted] = useState(false);
+  const [family, setFamily] = useState<FamilyDirectoryFull | null>(null);
+  const supabase = createClient();
+
+  async function openPreview() {
+    setLoading(true);
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+
+    // Fetch fresh so the preview reflects the latest saved profile
+    const [{ data: profile, error }, { data: groupRows }] = await Promise.all([
+      supabase.from("profiles").select("*").eq("id", user.id).single<Profile>(),
+      supabase
+        .from("profile_groups")
+        .select("member_groups(id, name, color, icon, display_order)")
+        .eq("profile_id", user.id),
+    ]);
+
+    if (error || !profile) {
+      toast.error("Failed to load your profile.");
+      setLoading(false);
+      return;
+    }
+
+    const groups = (groupRows || [])
+      .map((r) => r.member_groups as unknown as (GroupChip & { display_order: number }) | null)
+      .filter((g): g is GroupChip & { display_order: number } => !!g)
+      .sort((a, b) => a.display_order - b.display_order);
+
+    let familyRow: FamilyDirectoryFull | null = null;
+    if (profile.family_id) {
+      const { data: f } = await supabase
+        .from("families_directory_full")
+        .select("*")
+        .eq("id", profile.family_id)
+        .maybeSingle<FamilyDirectoryFull>();
+      familyRow = f ?? null;
+    }
+
+    setUnlisted(profile.is_unlisted);
+    setEntry(profile.is_unlisted ? null : maskProfile(profile, groups));
+    setFamily(familyRow);
+    setLoading(false);
+    setOpen(true);
+  }
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={openPreview}
+        disabled={loading}
+        className="gap-2"
+      >
+        <Eye className="h-4 w-4" />
+        {loading ? "Loading..." : "Preview my directory entry"}
+      </Button>
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent
+          side="right"
+          className="w-full sm:max-w-md flex flex-col overflow-hidden p-0"
+        >
+          <SheetHeader className="px-4 pt-4 pb-3 border-b shrink-0">
+            <SheetTitle>How others see you</SheetTitle>
+          </SheetHeader>
+
+          {unlisted ? (
+            <div className="px-4 py-8 text-center space-y-2">
+              <EyeOff className="h-8 w-8 mx-auto text-muted-foreground" />
+              <p className="font-medium">You&apos;re hidden from the directory</p>
+              <p className="text-sm text-muted-foreground">
+                Turn off &ldquo;Hide from directory&rdquo; in your privacy
+                settings to appear to other members.
+              </p>
+            </div>
+          ) : (
+            entry && <ProfileSheetContent profile={entry} family={family} />
+          )}
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/components/profile/MemberGroupsSection.tsx
+++ b/components/profile/MemberGroupsSection.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
+import { setGroupMembership } from "@/lib/memberGroups";
 import type { MemberGroup } from "@/lib/types";
 
 interface MemberGroupsSectionProps {
@@ -57,87 +58,20 @@ export function MemberGroupsSection({ profileId }: MemberGroupsSectionProps) {
   async function handleToggle(group: MemberGroup, checked: boolean) {
     setToggling(group.id);
 
-    if (checked) {
-      // Assign member to group
-      const { error } = await supabase.from("profile_groups").insert({
-        profile_id: profileId,
-        group_id: group.id,
-      });
-      if (error) {
-        toast.error(`Failed to add to ${group.name}.`);
-        setToggling(null);
-        return;
-      }
-
-      // Sync functional role boolean if applicable
-      if (group.functional_role === "prayer_team") {
-        const { error: roleErr } = await supabase
-          .from("profiles")
-          .update({ is_prayer_team: true })
-          .eq("id", profileId);
-        if (roleErr) {
-          toast.error(`Added to ${group.name} but failed to sync role.`);
-          setToggling(null);
-          return;
-        }
-      } else if (group.functional_role === "greeter_team") {
-        const { error: roleErr } = await supabase
-          .from("profiles")
-          .update({ is_greeter_team: true })
-          .eq("id", profileId);
-        if (roleErr) {
-          toast.error(`Added to ${group.name} but failed to sync role.`);
-          setToggling(null);
-          return;
-        }
-      }
-
-      setAssigned((prev) => new Set([...prev, group.id]));
-      toast.success(`Added to ${group.name}.`);
-    } else {
-      // Remove member from group
-      const { error } = await supabase
-        .from("profile_groups")
-        .delete()
-        .eq("profile_id", profileId)
-        .eq("group_id", group.id);
-      if (error) {
-        toast.error(`Failed to remove from ${group.name}.`);
-        setToggling(null);
-        return;
-      }
-
-      // Sync functional role boolean if applicable
-      if (group.functional_role === "prayer_team") {
-        const { error: roleErr } = await supabase
-          .from("profiles")
-          .update({ is_prayer_team: false })
-          .eq("id", profileId);
-        if (roleErr) {
-          toast.error(`Removed from ${group.name} but failed to sync role.`);
-          setToggling(null);
-          return;
-        }
-      } else if (group.functional_role === "greeter_team") {
-        const { error: roleErr } = await supabase
-          .from("profiles")
-          .update({ is_greeter_team: false })
-          .eq("id", profileId);
-        if (roleErr) {
-          toast.error(`Removed from ${group.name} but failed to sync role.`);
-          setToggling(null);
-          return;
-        }
-      }
-
-      setAssigned((prev) => {
-        const next = new Set(prev);
-        next.delete(group.id);
-        return next;
-      });
-      toast.success(`Removed from ${group.name}.`);
+    const errorMessage = await setGroupMembership(profileId, group, checked);
+    if (errorMessage) {
+      toast.error(errorMessage);
+      setToggling(null);
+      return;
     }
 
+    setAssigned((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(group.id);
+      else next.delete(group.id);
+      return next;
+    });
+    toast.success(checked ? `Added to ${group.name}.` : `Removed from ${group.name}.`);
     setToggling(null);
   }
 

--- a/components/profile/ProfileForm.tsx
+++ b/components/profile/ProfileForm.tsx
@@ -73,6 +73,7 @@ interface FormState {
   hide_email: boolean;
   hide_address: boolean;
   hide_birthday: boolean;
+  hide_birth_year: boolean;
   hide_anniversary: boolean;
   hide_occupation: boolean;
 }
@@ -106,6 +107,7 @@ function initialState(profile: Profile): FormState {
     hide_email: profile.hide_email ?? false,
     hide_address: profile.hide_address ?? false,
     hide_birthday: profile.hide_birthday ?? false,
+    hide_birth_year: profile.hide_birth_year ?? false,
     hide_anniversary: profile.hide_anniversary ?? false,
     hide_occupation: profile.hide_occupation ?? false,
   };
@@ -289,6 +291,7 @@ export function ProfileForm({
       hide_email: state.hide_email,
       hide_address: state.hide_address,
       hide_birthday: state.hide_birthday,
+      hide_birth_year: state.hide_birth_year,
       hide_anniversary: state.hide_anniversary,
       hide_occupation: state.hide_occupation,
     };
@@ -808,6 +811,10 @@ export function ProfileForm({
                 { key: "hide_phone_work" as const, label: "Hide work phone" },
                 { key: "hide_address" as const, label: "Hide address" },
                 { key: "hide_birthday" as const, label: "Hide birthday" },
+                {
+                  key: "hide_birth_year" as const,
+                  label: "Hide birth year (show month/day only)",
+                },
                 { key: "hide_anniversary" as const, label: "Hide anniversary" },
                 { key: "hide_occupation" as const, label: "Hide occupation / employer" },
               ].map(({ key, label }) => (

--- a/lib/memberGroups.ts
+++ b/lib/memberGroups.ts
@@ -1,0 +1,55 @@
+import { createClient } from "@/lib/supabase/client";
+import type { MemberGroup } from "@/lib/types";
+
+/** Map a functional role to its denormalized boolean column on profiles */
+const ROLE_COLUMNS: Record<
+  NonNullable<MemberGroup["functional_role"]>,
+  "is_prayer_team" | "is_greeter_team"
+> = {
+  prayer_team: "is_prayer_team",
+  greeter_team: "is_greeter_team",
+};
+
+/**
+ * Add or remove a member from a group, keeping the functional-role boolean
+ * on profiles in sync when the group has one.
+ *
+ * @returns an error message to show the user, or null on success
+ */
+export async function setGroupMembership(
+  profileId: string,
+  group: MemberGroup,
+  member: boolean,
+): Promise<string | null> {
+  const supabase = createClient();
+
+  if (member) {
+    const { error } = await supabase.from("profile_groups").insert({
+      profile_id: profileId,
+      group_id: group.id,
+    });
+    if (error) return `Failed to add to ${group.name}.`;
+  } else {
+    const { error } = await supabase
+      .from("profile_groups")
+      .delete()
+      .eq("profile_id", profileId)
+      .eq("group_id", group.id);
+    if (error) return `Failed to remove from ${group.name}.`;
+  }
+
+  if (group.functional_role) {
+    const column = ROLE_COLUMNS[group.functional_role];
+    const { error } = await supabase
+      .from("profiles")
+      .update({ [column]: member })
+      .eq("id", profileId);
+    if (error) {
+      return member
+        ? `Added to ${group.name} but failed to sync role.`
+        : `Removed from ${group.name} but failed to sync role.`;
+    }
+  }
+
+  return null;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -52,6 +52,7 @@ export interface Profile {
 export interface FamilyUnit {
   id: string;
   family_name: string;
+  photo_url: string | null;
   address_line1: string | null;
   address_line2: string | null;
   city: string | null;
@@ -102,6 +103,7 @@ export interface DirectoryProfile {
 export interface DirectoryFamily {
   id: string;
   family_name: string;
+  photo_url: string | null;
   address_line1: string | null;
   address_line2: string | null;
   city: string | null;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -279,6 +279,7 @@ export interface HouseholdFamilyMember {
 export interface FamilyDirectoryFull {
   id: string;
   family_name: string;
+  photo_url: string | null;
   address_line1: string | null;
   address_line2: string | null;
   city: string | null;

--- a/lib/uploadImage.ts
+++ b/lib/uploadImage.ts
@@ -1,7 +1,7 @@
 import imageCompression from "browser-image-compression";
 import { createClient } from "@/lib/supabase/client";
 
-export type ImageUploadType = "avatar" | "event";
+export type ImageUploadType = "avatar" | "event" | "family";
 
 interface UploadConfig {
   bucket: "avatars" | "event-images";
@@ -23,6 +23,13 @@ const CONFIG: Record<ImageUploadType, UploadConfig> = {
     bucket: "event-images",
     maxWidthOrHeight: 1200,
     maxSizeMB: 1,
+  },
+  // Family portraits live in the avatars bucket under families/<familyId>/
+  // (see 20260704000001_family_photos.sql for the admin storage policies)
+  family: {
+    bucket: "avatars",
+    maxWidthOrHeight: 1000,
+    maxSizeMB: 0.5,
   },
 };
 

--- a/supabase/migrations/20260704000000_fix_birth_year_privacy.sql
+++ b/supabase/migrations/20260704000000_fix_birth_year_privacy.sql
@@ -1,0 +1,121 @@
+-- Fix inverted birth-year privacy logic in directory views.
+--
+-- The previous condition `hide_birthday and not hide_birth_year` exposed the
+-- birth year whenever hide_birth_year was true (alone or with hide_birthday),
+-- defeating the "show month/day but hide my year" setting. The year must be
+-- hidden when EITHER flag is set.
+
+drop view if exists public.profiles_directory;
+
+create view public.profiles_directory
+with (security_invoker = true) as
+select
+  p.id,
+  p.first_name,
+  p.last_name,
+  p.preferred_name,
+  p.avatar_url,
+  p.role,
+  p.relationship,
+  p.bio,
+  p.family_id,
+  p.created_at,
+  case when p.hide_email then null else p.email end as email,
+  case when p.hide_phone_mobile then null else p.phone_mobile end as phone_mobile,
+  case when p.hide_phone_home then null else p.phone_home end as phone_home,
+  case when p.hide_phone_work then null else p.phone_work end as phone_work,
+  case when p.hide_address then null else p.address_line1 end as address_line1,
+  case when p.hide_address then null else p.address_line2 end as address_line2,
+  case when p.hide_address then null else p.city end as city,
+  case when p.hide_address then null else p.state end as state,
+  case when p.hide_address then null else p.postal_code end as postal_code,
+  case when p.hide_birthday then null else p.birth_month end as birth_month,
+  case when p.hide_birthday then null else p.birth_day end as birth_day,
+  case when p.hide_birthday or p.hide_birth_year then null else p.birth_year end as birth_year,
+  case when p.hide_anniversary then null else p.anniversary end as anniversary,
+  case when p.hide_occupation then null else p.occupation end as occupation,
+  case when p.hide_occupation then null else p.employer end as employer,
+  coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'id', mg.id,
+        'name', mg.name,
+        'color', mg.color,
+        'icon', mg.icon
+      ) order by mg.display_order
+    ) filter (where mg.id is not null),
+    '[]'::jsonb
+  ) as groups
+from public.profiles p
+left join public.profile_groups pg on p.id = pg.profile_id
+left join public.member_groups mg on pg.group_id = mg.id
+where p.is_unlisted = false and p.role in ('member', 'content_editor', 'admin')
+group by p.id;
+
+grant select on public.profiles_directory to authenticated;
+
+drop view if exists public.families_directory_full;
+
+create view public.families_directory_full
+with (security_invoker = true) as
+select
+  f.id,
+  f.family_name,
+  case when f.hide_address then null else f.address_line1 end as address_line1,
+  case when f.hide_address then null else f.address_line2 end as address_line2,
+  case when f.hide_address then null else f.city end as city,
+  case when f.hide_address then null else f.state end as state,
+  case when f.hide_address then null else f.postal_code end as postal_code,
+  case when f.hide_phone_home then null else f.phone_home end as phone_home,
+  f.anniversary,
+  f.created_at,
+  f.updated_at,
+  coalesce(
+    (
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', p.id,
+          'first_name', p.first_name,
+          'last_name', p.last_name,
+          'preferred_name', p.preferred_name,
+          'avatar_url', p.avatar_url,
+          'relationship', p.relationship,
+          'is_class_member', true,
+          'phone_mobile', case when p.hide_phone_mobile then null else p.phone_mobile end,
+          'birth_month', case when p.hide_birthday then null else p.birth_month end,
+          'birth_day', case when p.hide_birthday then null else p.birth_day end,
+          'birth_year', case when p.hide_birthday or p.hide_birth_year then null else p.birth_year end
+        ) order by p.relationship asc
+      )
+      from public.profiles p
+      where p.family_id = f.id
+        and p.is_unlisted = false
+        and p.role in ('member', 'content_editor', 'admin')
+    ),
+    '[]'::jsonb
+  ) as members,
+  coalesce(
+    (
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', fm.id,
+          'first_name', fm.first_name,
+          'last_name', fm.last_name,
+          'preferred_name', fm.preferred_name,
+          'avatar_url', fm.avatar_url,
+          'relationship', fm.relationship,
+          'is_class_member', fm.is_class_member,
+          'birth_month', fm.birth_month,
+          'birth_day', fm.birth_day,
+          'birth_year', fm.birth_year,
+          'claimed_profile_id', fm.claimed_profile_id
+        ) order by fm.relationship asc
+      )
+      from public.family_members fm
+      where fm.family_id = f.id
+    ),
+    '[]'::jsonb
+  ) as family_members_list
+from public.family_units f;
+
+grant select on public.families_directory_full to authenticated;

--- a/supabase/migrations/20260704000001_family_photos.sql
+++ b/supabase/migrations/20260704000001_family_photos.sql
@@ -1,0 +1,128 @@
+-- Family portrait photos for the directory (Instant Church Directory parity).
+-- Admins upload one photo per household; it shows on household rows and the
+-- household detail sheet, falling back to member avatar clusters.
+
+alter table public.family_units
+  add column if not exists photo_url text;
+
+-- ==================
+-- RECREATE: families_directory with photo_url
+-- ==================
+drop view if exists public.families_directory;
+
+create view public.families_directory
+with (security_invoker = true) as
+select
+  f.id,
+  f.family_name,
+  f.photo_url,
+  case when f.hide_address then null else f.address_line1 end as address_line1,
+  case when f.hide_address then null else f.address_line2 end as address_line2,
+  case when f.hide_address then null else f.city end as city,
+  case when f.hide_address then null else f.state end as state,
+  case when f.hide_address then null else f.postal_code end as postal_code,
+  case when f.hide_phone_home then null else f.phone_home end as phone_home,
+  f.anniversary,
+  f.created_at,
+  f.updated_at
+from public.family_units f;
+
+grant select on public.families_directory to authenticated;
+
+-- ==================
+-- RECREATE: families_directory_full with photo_url
+-- (definition from 20260704000000_fix_birth_year_privacy plus photo_url)
+-- ==================
+drop view if exists public.families_directory_full;
+
+create view public.families_directory_full
+with (security_invoker = true) as
+select
+  f.id,
+  f.family_name,
+  f.photo_url,
+  case when f.hide_address then null else f.address_line1 end as address_line1,
+  case when f.hide_address then null else f.address_line2 end as address_line2,
+  case when f.hide_address then null else f.city end as city,
+  case when f.hide_address then null else f.state end as state,
+  case when f.hide_address then null else f.postal_code end as postal_code,
+  case when f.hide_phone_home then null else f.phone_home end as phone_home,
+  f.anniversary,
+  f.created_at,
+  f.updated_at,
+  coalesce(
+    (
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', p.id,
+          'first_name', p.first_name,
+          'last_name', p.last_name,
+          'preferred_name', p.preferred_name,
+          'avatar_url', p.avatar_url,
+          'relationship', p.relationship,
+          'is_class_member', true,
+          'phone_mobile', case when p.hide_phone_mobile then null else p.phone_mobile end,
+          'birth_month', case when p.hide_birthday then null else p.birth_month end,
+          'birth_day', case when p.hide_birthday then null else p.birth_day end,
+          'birth_year', case when p.hide_birthday or p.hide_birth_year then null else p.birth_year end
+        ) order by p.relationship asc
+      )
+      from public.profiles p
+      where p.family_id = f.id
+        and p.is_unlisted = false
+        and p.role in ('member', 'content_editor', 'admin')
+    ),
+    '[]'::jsonb
+  ) as members,
+  coalesce(
+    (
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', fm.id,
+          'first_name', fm.first_name,
+          'last_name', fm.last_name,
+          'preferred_name', fm.preferred_name,
+          'avatar_url', fm.avatar_url,
+          'relationship', fm.relationship,
+          'is_class_member', fm.is_class_member,
+          'birth_month', fm.birth_month,
+          'birth_day', fm.birth_day,
+          'birth_year', fm.birth_year,
+          'claimed_profile_id', fm.claimed_profile_id
+        ) order by fm.relationship asc
+      )
+      from public.family_members fm
+      where fm.family_id = f.id
+    ),
+    '[]'::jsonb
+  ) as family_members_list
+from public.family_units f;
+
+grant select on public.families_directory_full to authenticated;
+
+-- ==================
+-- STORAGE: admins manage family photos under avatars/families/<familyId>/
+-- ==================
+create policy "Admins can upload family photos"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'avatars'
+    and public.is_admin()
+    and (storage.foldername(name))[1] = 'families'
+  );
+
+create policy "Admins can update family photos"
+  on storage.objects for update
+  using (
+    bucket_id = 'avatars'
+    and public.is_admin()
+    and (storage.foldername(name))[1] = 'families'
+  );
+
+create policy "Admins can delete family photos"
+  on storage.objects for delete
+  using (
+    bucket_id = 'avatars'
+    and public.is_admin()
+    and (storage.foldername(name))[1] = 'families'
+  );


### PR DESCRIPTION
## Summary

Directory deep-dive UX work (11 commits):

- **Directory rebuild**: Groups view, sheet-stack navigation, A–Z rail, group chips
- **Family portrait photos** on household cards (migration `20260704000001`) with admin upload
- **Printable directory** at `/directory/print` with birthdays-by-month appendix
- **Birthday widget**: browse birthdays by month
- **Profile**: preview your own directory entry with privacy rules applied
- **Admin groups**: manage rosters from the groups page (current-members-first roster dialog), simplified group cards/dialog, searchable icon picker over the full lucide catalog
- **Privacy fix**: hide birth year when either privacy flag is set (migration `20260704000000`)

Both migrations applied and verified on local Supabase; remote migrations run via CI as usual.

## Notes

- `member_groups.functional_role` is intentionally not surfaced in the admin group dialog; it will be surfaced by the upcoming serving-schedule feature instead.
- `npx eslint` is currently broken on main (ESLint 10 vs eslint-config-next incompatibility); verification used `tsc --noEmit` + `next build`.

https://claude.ai/code/session_01MAK4wMMCwtiGAx3dYV7AwH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added family photo support in the admin family editor, including upload, replace, and remove actions.
  * Introduced roster management and icon selection tools for groups.
  * Added directory preview, printable directory view, group badges, avatar clusters, and profile/household detail sheets.
  * Added a quick month-browsing view for birthdays and an A–Z jump rail in the directory.
* **Bug Fixes**
  * Improved directory search and filtering, including better phone matching and richer field search.
  * Updated setup flow to finish with a single primary completion action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->