### PR TITLE
fix(directory): address review findings from directory UX release

### DIFF
--- a/app/admin/families/page.tsx
+++ b/app/admin/families/page.tsx
@@ -143,6 +143,7 @@ export default function FamiliesPage() {
   // Family photo state (edit mode only — the path needs the family id)
   const [photoUrl, setPhotoUrl] = useState<string | null>(null);
   const [uploadingPhoto, setUploadingPhoto] = useState(false);
+  const [removingPhoto, setRemovingPhoto] = useState(false);
   const photoInputRef = useRef<HTMLInputElement>(null);
 
   const supabase = createClient();
@@ -336,20 +337,31 @@ export default function FamiliesPage() {
 
   async function handlePhotoRemove() {
     if (!editing) return;
-    const { error } = await supabase
-      .from("family_units")
-      .update({ photo_url: null })
-      .eq("id", editing.id);
-    if (error) {
-      toast.error("Failed to remove family photo.");
-      return;
+    setRemovingPhoto(true);
+    try {
+      // Delete the file first — removing a missing object doesn't error, so
+      // a retry after a failed DB update stays safe.
+      const { error: storageError } = await supabase.storage
+        .from("avatars")
+        .remove([`families/${editing.id}/photo.jpg`]);
+      if (storageError) {
+        toast.error("Failed to remove family photo.");
+        return;
+      }
+      const { error } = await supabase
+        .from("family_units")
+        .update({ photo_url: null })
+        .eq("id", editing.id);
+      if (error) {
+        toast.error("Failed to remove family photo.");
+        return;
+      }
+      setPhotoUrl(null);
+      toast.success("Family photo removed.");
+      loadFamilies();
+    } finally {
+      setRemovingPhoto(false);
     }
-    await supabase.storage
-      .from("avatars")
-      .remove([`families/${editing.id}/photo.jpg`]);
-    setPhotoUrl(null);
-    toast.success("Family photo removed.");
-    loadFamilies();
   }
 
   function startAddMember() {
@@ -569,7 +581,7 @@ export default function FamiliesPage() {
                         type="button"
                         variant="secondary"
                         size="sm"
-                        disabled={uploadingPhoto}
+                        disabled={uploadingPhoto || removingPhoto}
                         onClick={() => photoInputRef.current?.click()}
                       >
                         <Camera className="mr-1 h-4 w-4" />
@@ -579,6 +591,7 @@ export default function FamiliesPage() {
                         type="button"
                         variant="secondary"
                         size="sm"
+                        disabled={uploadingPhoto || removingPhoto}
                         onClick={handlePhotoRemove}
                       >
                         <Trash2 className="h-4 w-4" />

--- a/app/admin/groups/GroupRosterDialog.tsx
+++ b/app/admin/groups/GroupRosterDialog.tsx
@@ -42,7 +42,9 @@ export function GroupRosterDialog({
 }: GroupRosterDialogProps) {
   const [profiles, setProfiles] = useState<RosterProfile[]>([]);
   const [assigned, setAssigned] = useState<Set<string>>(new Set());
-  const [loading, setLoading] = useState(true);
+  // Which group the current profiles/assigned belong to — anything else is
+  // stale data from a previously opened group and must render as loading.
+  const [loadedGroupId, setLoadedGroupId] = useState<string | null>(null);
   const [mode, setMode] = useState<"roster" | "add">("roster");
   const [query, setQuery] = useState("");
   const [busy, setBusy] = useState<string | null>(null);
@@ -53,7 +55,6 @@ export function GroupRosterDialog({
     let cancelled = false;
 
     async function load(groupId: string) {
-      setLoading(true);
       setMode("roster");
       setQuery("");
       const [{ data: members, error: mErr }, { data: rows, error: rErr }] =
@@ -73,14 +74,13 @@ export function GroupRosterDialog({
       if (cancelled) return;
       if (mErr || rErr) {
         toast.error("Failed to load roster.");
-        setLoading(false);
         return;
       }
       setProfiles((members || []) as RosterProfile[]);
       setAssigned(
         new Set((rows || []).map((r: { profile_id: string }) => r.profile_id)),
       );
-      setLoading(false);
+      setLoadedGroupId(groupId);
     }
 
     load(group.id);
@@ -88,6 +88,8 @@ export function GroupRosterDialog({
       cancelled = true;
     };
   }, [group?.id]);
+
+  const loading = !group || loadedGroupId !== group.id;
 
   const roster = useMemo(
     () => profiles.filter((p) => assigned.has(p.id)),
@@ -159,7 +161,9 @@ export function GroupRosterDialog({
             )}
             {mode === "add"
               ? `Add to ${group?.name}`
-              : `${group?.name} — ${assigned.size} member${assigned.size !== 1 ? "s" : ""}`}
+              : loading
+                ? group?.name
+                : `${group?.name} — ${assigned.size} member${assigned.size !== 1 ? "s" : ""}`}
           </DialogTitle>
         </DialogHeader>
 

--- a/app/admin/groups/IconPicker.tsx
+++ b/app/admin/groups/IconPicker.tsx
@@ -80,6 +80,7 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
         type="button"
         variant="outline"
         onClick={() => setOpen(!open)}
+        aria-expanded={open}
         className="w-full justify-between font-normal"
       >
         <span className="flex items-center gap-2">
@@ -119,6 +120,7 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
                   type="button"
                   title={prettyName(n)}
                   aria-label={prettyName(n)}
+                  aria-pressed={n === value}
                   onClick={() => pick(n)}
                   className={cn(
                     "flex h-9 items-center justify-center rounded-md hover:bg-accent transition-colors",

--- a/app/directory/page.tsx
+++ b/app/directory/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Sheet,
@@ -21,6 +21,7 @@ import {
   Search,
   Tags,
 } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { formatPhone } from "@/lib/sanitize";
 import { displayName, initials } from "@/lib/names";
 import { BirthdayWidget } from "@/components/directory/BirthdayWidget";
@@ -674,16 +675,16 @@ export default function DirectoryPage() {
                 <Tags className="mr-1 h-4 w-4" />
                 Groups ({allGroups.length})
               </Button>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                nativeButton={false}
-                render={<Link href="/directory/print" />}
+              <Link
+                href="/directory/print"
                 aria-label="Printable directory"
-                className="ml-auto text-muted-foreground"
+                className={cn(
+                  buttonVariants({ variant: "ghost", size: "icon-sm" }),
+                  "ml-auto text-muted-foreground",
+                )}
               >
                 <Printer className="h-4 w-4" />
-              </Button>
+              </Link>
             </div>
           </div>
 

--- a/app/directory/print/page.tsx
+++ b/app/directory/print/page.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { ArrowLeft, Printer } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { formatPhone } from "@/lib/sanitize";
 import { displayName } from "@/lib/names";
 import { siteConfig } from "@/lib/config";
@@ -32,11 +33,11 @@ function formatAddress(a: {
   postal_code: string | null;
 }): string | null {
   if (!a.address_line1 && !a.city) return null;
+  const cityState = [a.city, a.state].filter(Boolean).join(", ");
   const line = [
     a.address_line1,
     a.address_line2,
-    [a.city, a.state].filter(Boolean).join(", ") +
-      (a.postal_code ? ` ${a.postal_code}` : ""),
+    [cityState, a.postal_code].filter(Boolean).join(" "),
   ]
     .filter(Boolean)
     .join(", ");
@@ -73,11 +74,15 @@ export default function DirectoryPrintPage() {
   const [members, setMembers] = useState<DirectoryProfile[]>([]);
   const [families, setFamilies] = useState<FamilyDirectoryFull[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const supabase = createClient();
 
   useEffect(() => {
     async function load() {
-      const [{ data: m }, { data: f }] = await Promise.all([
+      const [
+        { data: m, error: mErr },
+        { data: f, error: fErr },
+      ] = await Promise.all([
         supabase
           .from("profiles_directory")
           .select("*")
@@ -87,6 +92,12 @@ export default function DirectoryPrintPage() {
           .select("*")
           .order("family_name", { ascending: true }),
       ]);
+      if (mErr || fErr) {
+        console.error("Failed to load directory:", mErr || fErr);
+        setLoadError(true);
+        setLoading(false);
+        return;
+      }
       setMembers((m || []) as DirectoryProfile[]);
       setFamilies((f || []) as FamilyDirectoryFull[]);
       setLoading(false);
@@ -143,19 +154,34 @@ export default function DirectoryPrintPage() {
     );
   }
 
+  if (loadError) {
+    return (
+      <div className="container mx-auto px-4 py-12 space-y-4">
+        <p className="text-xl text-muted-foreground">
+          Couldn&apos;t load the directory. Please try again.
+        </p>
+        <Link
+          href="/directory"
+          className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to directory
+        </Link>
+      </div>
+    );
+  }
+
   return (
     <div className="container mx-auto px-6 py-8 max-w-3xl bg-white text-black">
       {/* Toolbar — hidden when printing */}
       <div className="flex items-center justify-between mb-8 print:hidden">
-        <Button
-          variant="ghost"
-          size="sm"
-          nativeButton={false}
-          render={<Link href="/directory" />}
+        <Link
+          href="/directory"
+          className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}
         >
           <ArrowLeft className="mr-2 h-4 w-4" />
           Back to directory
-        </Button>
+        </Link>
         <Button
           onClick={() => window.print()}
           className="bg-brand-primary hover:bg-brand-primary/90 text-white"

--- a/app/profile/setup/SetupWizard.tsx
+++ b/app/profile/setup/SetupWizard.tsx
@@ -782,7 +782,6 @@ export function SetupWizard({ profile, userEmail }: SetupWizardProps) {
                   placeholder="Year"
                   value={birthYear}
                   onChange={(e) => setBirthYear(e.target.value)}
-                  disabled={hideBirthYear}
                   className="text-base py-5"
                 />
               </div>
@@ -791,10 +790,7 @@ export function SetupWizard({ profile, userEmail }: SetupWizardProps) {
                   <Switch
                     id="hide_birth_year"
                     checked={hideBirthYear}
-                    onCheckedChange={(v) => {
-                      setHideBirthYear(v);
-                      if (v) setBirthYear("");
-                    }}
+                    onCheckedChange={setHideBirthYear}
                   />
                   <Label
                     htmlFor="hide_birth_year"

--- a/components/directory/AvatarCluster.tsx
+++ b/components/directory/AvatarCluster.tsx
@@ -4,9 +4,10 @@ interface AvatarClusterProps {
   people: Array<{ avatarUrl: string | null; name: string; initials: string }>;
 }
 
-/** Up to 3 overlapping avatars for a household row */
+/** Up to 3 overlapping avatars for a household row, with a +N overflow badge */
 export function AvatarCluster({ people }: AvatarClusterProps) {
   const displayed = people.slice(0, 3);
+  const overflow = people.length - displayed.length;
   return (
     <div className="flex -space-x-2">
       {displayed.map((p, i) => (
@@ -17,6 +18,16 @@ export function AvatarCluster({ people }: AvatarClusterProps) {
           </AvatarFallback>
         </Avatar>
       ))}
+      {overflow > 0 && (
+        <Avatar
+          className="h-10 w-10 border-2 border-background"
+          aria-label={`${overflow} more household member${overflow !== 1 ? "s" : ""}`}
+        >
+          <AvatarFallback className="bg-muted text-muted-foreground text-sm">
+            +{overflow}
+          </AvatarFallback>
+        </Avatar>
+      )}
     </div>
   );
 }

--- a/components/directory/BirthdayWidget.tsx
+++ b/components/directory/BirthdayWidget.tsx
@@ -43,6 +43,21 @@ function formatDaysUntil(days: number): string {
   return `in ${days} days`;
 }
 
+/** Compact wrapped chips — shared by the browsed-month and This Month views */
+function EntryChips({ entries }: { entries: BirthdayEntry[] }) {
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-1">
+      {entries.map((entry) => (
+        <span key={entry.key} className="text-sm text-muted-foreground">
+          {entry.type === "anniversary" ? "💍" : "🎂"}{" "}
+          <span className="font-medium text-foreground">{entry.name}</span>{" "}
+          ({MONTH_NAMES[entry.month - 1]} {entry.day})
+        </span>
+      ))}
+    </div>
+  );
+}
+
 interface BirthdayWidgetProps {
   members: DirectoryProfile[];
   families: FamilyDirectoryFull[];
@@ -262,17 +277,7 @@ export function BirthdayWidget({ members, families }: BirthdayWidgetProps) {
                   {MONTH_NAMES[browseMonth - 1]}.
                 </p>
               ) : (
-                <div className="flex flex-wrap gap-x-4 gap-y-1">
-                  {browsedEntries.map((entry) => (
-                    <span key={entry.key} className="text-sm text-muted-foreground">
-                      {entry.type === "anniversary" ? "💍" : "🎂"}{" "}
-                      <span className="font-medium text-foreground">
-                        {entry.name}
-                      </span>{" "}
-                      ({MONTH_NAMES[entry.month - 1]} {entry.day})
-                    </span>
-                  ))}
-                </div>
+                <EntryChips entries={browsedEntries} />
               )
             ) : (
               <>
@@ -319,17 +324,7 @@ export function BirthdayWidget({ members, families }: BirthdayWidgetProps) {
                 <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
                   This Month
                 </p>
-                <div className="flex flex-wrap gap-x-4 gap-y-1">
-                  {thisMonth.map((entry) => (
-                    <span key={entry.key} className="text-sm text-muted-foreground">
-                      {entry.type === "anniversary" ? "💍" : "🎂"}{" "}
-                      <span className="font-medium text-foreground">
-                        {entry.name}
-                      </span>{" "}
-                      ({MONTH_NAMES[entry.month - 1]} {entry.day})
-                    </span>
-                  ))}
-                </div>
+                <EntryChips entries={thisMonth} />
               </div>
             )}
 

--- a/components/profile/DirectoryPreview.tsx
+++ b/components/profile/DirectoryPreview.tsx
@@ -97,7 +97,8 @@ export function DirectoryPreview() {
       .sort((a, b) => a.display_order - b.display_order);
 
     let familyRow: FamilyDirectoryFull | null = null;
-    if (profile.family_id) {
+    // Unlisted profiles render the hidden state — no family card to fetch
+    if (!profile.is_unlisted && profile.family_id) {
       const { data: f } = await supabase
         .from("families_directory_full")
         .select("*")

--- a/lib/memberGroups.ts
+++ b/lib/memberGroups.ts
@@ -45,9 +45,22 @@ export async function setGroupMembership(
       .update({ [column]: member })
       .eq("id", profileId);
     if (error) {
+      // Roll back the membership change so the roster and the denormalized
+      // role flag never disagree.
+      if (member) {
+        await supabase
+          .from("profile_groups")
+          .delete()
+          .eq("profile_id", profileId)
+          .eq("group_id", group.id);
+      } else {
+        await supabase
+          .from("profile_groups")
+          .insert({ profile_id: profileId, group_id: group.id });
+      }
       return member
-        ? `Added to ${group.name} but failed to sync role.`
-        : `Removed from ${group.name} but failed to sync role.`;
+        ? `Failed to add to ${group.name}.`
+        : `Failed to remove from ${group.name}.`;
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #173 — verified each code-review finding against current code, fixed the valid ones, and skipped one with rationale.

### Fixes

- **Families admin — photo removal**: the storage `.remove()` result is now checked. Order is storage delete first, then DB update (removing a missing object doesn't error, so retries after a failed DB update stay safe). Success state/toast only fire after both succeed, and Replace/Remove are disabled while any photo operation is in flight.
- **Group roster dialog — stale state**: loading is now derived from a `loadedGroupId` check instead of a boolean, so reopening the dialog with a different group can never flash or act on the previous group's roster. The stale member count in the dialog title is guarded too.
- **Directory + print pages — link semantics**: Base UI's `useButton` unconditionally merges `role="button"` onto non-native elements, so `Button render={<Link/>}` overrode anchor semantics. Both nav controls now render `Link` styled with `buttonVariants`.
- **Print page — error handling**: both directory queries now check their `error`; failures log and render a retryable error screen instead of silently printing an empty roster.
- **Print page — `formatAddress`**: ZIP joins conditionally, removing the stray space when city/state are missing.
- **`setGroupMembership` — write drift**: if the denormalized role-flag sync fails, the `profile_groups` insert/delete is rolled back and the whole operation reports as failed. (A true transaction needs a new Postgres RPC/migration; compensation keeps this client-side and minimal.)
- **Setup wizard — birth year**: no longer clears `birth_year` when hiding it, matching ProfileForm — the `profiles_directory` view masks it. Clearing also hid the toggle itself (it only renders when a year is present), stranding `hide_birth_year` on.
- **Birthday widget**: extracted shared `EntryChips` for the duplicated chip markup.
- **Icon picker**: `aria-expanded` on the trigger, `aria-pressed` on options.
- **Avatar cluster**: "+N" overflow badge for households larger than 3.
- **Directory preview**: skips the family fetch for unlisted profiles.

### Skipped

- *Shared masking helper for `maskProfile`*: the "duplication" is with the `profiles_directory` SQL view — there's no TS artifact to share code with short of codegen; the doc comment on `maskProfile` already records the coupling.

## Validation

- `tsc --noEmit` — clean
- `next lint` — 0 errors, 0 warnings
- `npm run build` — succeeds

https://claude.ai/code/session_01MAK4wMMCwtiGAx3dYV7AwH