### PR TITLE
feat(serving): add Sunday serving scheduling

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,7 +19,6 @@ reviews:
     - "!.next/**"
     - "!package-lock.json"
     - "!CHANGELOG.md"
-    - "!supabase/migrations/**"
     - "!public/**"
     - "!next-env.d.ts"
 

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,13 @@ NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your-api-key-here
 # App Config
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
+# Serving signups
+# Secret for HMAC-signed email action links (generate: openssl rand -hex 32)
+SERVING_LINK_SECRET=change-me
+# Default email link behavior: 'signed' (act without login) or 'login'
+# (require sign-in). The admin Site Settings toggle overrides this.
+# SERVING_LINK_MODE=signed
+
 # Branding (all optional — defaults to Incouragers values)
 # NEXT_PUBLIC_APP_NAME=Incouragers
 # NEXT_PUBLIC_APP_DESCRIPTION=A welcoming community of faith, growing together in God's Word.

--- a/app/admin/groups/GroupRosterDialog.tsx
+++ b/app/admin/groups/GroupRosterDialog.tsx
@@ -12,7 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { ArrowLeft, Plus, Search, X } from "lucide-react";
+import { ArrowLeft, Plus, Search, Star, X } from "lucide-react";
 import { setGroupMembership } from "@/lib/memberGroups";
 import { displayName, initials } from "@/lib/names";
 import type { MemberGroup, Profile } from "@/lib/types";
@@ -42,6 +42,7 @@ export function GroupRosterDialog({
 }: GroupRosterDialogProps) {
   const [profiles, setProfiles] = useState<RosterProfile[]>([]);
   const [assigned, setAssigned] = useState<Set<string>>(new Set());
+  const [leaders, setLeaders] = useState<Set<string>>(new Set());
   // Which group the current profiles/assigned belong to — anything else is
   // stale data from a previously opened group and must render as loading.
   const [loadedGroupId, setLoadedGroupId] = useState<string | null>(null);
@@ -67,7 +68,7 @@ export function GroupRosterDialog({
             .order("first_name", { ascending: true }),
           supabase
             .from("profile_groups")
-            .select("profile_id")
+            .select("profile_id, is_leader")
             .eq("group_id", groupId),
         ]);
 
@@ -76,9 +77,11 @@ export function GroupRosterDialog({
         toast.error("Failed to load roster.");
         return;
       }
+      const memberRows = (rows || []) as { profile_id: string; is_leader: boolean }[];
       setProfiles((members || []) as RosterProfile[]);
-      setAssigned(
-        new Set((rows || []).map((r: { profile_id: string }) => r.profile_id)),
+      setAssigned(new Set(memberRows.map((r) => r.profile_id)));
+      setLeaders(
+        new Set(memberRows.filter((r) => r.is_leader).map((r) => r.profile_id)),
       );
       setLoadedGroupId(groupId);
     }
@@ -128,7 +131,35 @@ export function GroupRosterDialog({
     if (member) next.add(profile.id);
     else next.delete(profile.id);
     setAssigned(next);
+    if (!member && leaders.has(profile.id)) {
+      const nextLeaders = new Set(leaders);
+      nextLeaders.delete(profile.id);
+      setLeaders(nextLeaders);
+    }
     onCountChange(group.id, next.size);
+    setBusy(null);
+  }
+
+  async function handleLeaderChange(profile: RosterProfile, leader: boolean) {
+    if (!group) return;
+    setBusy(profile.id);
+
+    const { error } = await supabase
+      .from("profile_groups")
+      .update({ is_leader: leader })
+      .eq("profile_id", profile.id)
+      .eq("group_id", group.id);
+
+    if (error) {
+      toast.error("Failed to update leader.");
+      setBusy(null);
+      return;
+    }
+
+    const next = new Set(leaders);
+    if (leader) next.add(profile.id);
+    else next.delete(profile.id);
+    setLeaders(next);
     setBusy(null);
   }
 
@@ -219,18 +250,46 @@ export function GroupRosterDialog({
                   </Avatar>
                   <span className="flex-1 min-w-0 text-sm font-medium truncate">
                     {displayName(p)}
+                    {leaders.has(p.id) && (
+                      <span className="ml-2 text-xs font-medium uppercase tracking-wider text-brand-accent">
+                        Leader
+                      </span>
+                    )}
                   </span>
                   {mode === "roster" ? (
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      disabled={busy === p.id}
-                      onClick={() => handleChange(p, false)}
-                      aria-label={`Remove ${displayName(p)} from ${group?.name}`}
-                      className="text-muted-foreground hover:text-destructive"
-                    >
-                      <X className="h-4 w-4" />
-                    </Button>
+                    <>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        disabled={busy === p.id}
+                        onClick={() => handleLeaderChange(p, !leaders.has(p.id))}
+                        aria-label={
+                          leaders.has(p.id)
+                            ? `Remove ${displayName(p)} as leader of ${group?.name}`
+                            : `Make ${displayName(p)} a leader of ${group?.name}`
+                        }
+                        className={
+                          leaders.has(p.id)
+                            ? "text-brand-accent hover:text-muted-foreground"
+                            : "text-muted-foreground hover:text-brand-accent"
+                        }
+                      >
+                        <Star
+                          className="h-4 w-4"
+                          fill={leaders.has(p.id) ? "currentColor" : "none"}
+                        />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        disabled={busy === p.id}
+                        onClick={() => handleChange(p, false)}
+                        aria-label={`Remove ${displayName(p)} from ${group?.name}`}
+                        className="text-muted-foreground hover:text-destructive"
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </>
                   ) : (
                     <Button
                       variant="outline"

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -21,6 +21,7 @@ const SETTINGS_LABELS: Record<string, string> = {
   zoom_meeting_time: "Zoom Meeting Time",
   weekly_prayer_call_url: "Weekly Prayer Call URL",
   weekly_prayer_call_time: "Weekly Prayer Call Time",
+  serving_link_mode: "Serving Email Link Mode",
 };
 
 export default function SettingsPage() {
@@ -92,15 +93,29 @@ export default function SettingsPage() {
             {Object.entries(SETTINGS_LABELS).map(([key, label]) => (
               <div key={key} className="space-y-2">
                 <Label htmlFor={key} className="text-lg">{label}</Label>
-                <Input
-                  id={key}
-                  value={settings[key] || ""}
-                  onChange={(e) =>
-                    setSettings((prev) => ({ ...prev, [key]: e.target.value }))
-                  }
-                  placeholder={`Enter ${label.toLowerCase()}`}
-                  className="text-lg py-6"
-                />
+                {key === "serving_link_mode" ? (
+                  <select
+                    id={key}
+                    value={settings[key] || "signed"}
+                    onChange={(e) =>
+                      setSettings((prev) => ({ ...prev, [key]: e.target.value }))
+                    }
+                    className="w-full rounded-md border border-input bg-background px-3 py-4 text-lg focus:outline-none focus:ring-2 focus:ring-brand-primary"
+                  >
+                    <option value="signed">Signed links — members act without logging in (recommended)</option>
+                    <option value="login">Login required — links redirect to the login page first</option>
+                  </select>
+                ) : (
+                  <Input
+                    id={key}
+                    value={settings[key] || ""}
+                    onChange={(e) =>
+                      setSettings((prev) => ({ ...prev, [key]: e.target.value }))
+                    }
+                    placeholder={`Enter ${label.toLowerCase()}`}
+                    className="text-lg py-6"
+                  />
+                )}
               </div>
             ))}
 

--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -1,5 +1,5 @@
 import { createServiceClient } from "@/lib/supabase/server";
-import { generateMultiEventICS } from "@/lib/ics-utils";
+import { generateCombinedICS, type ServingICSInput } from "@/lib/ics-utils";
 import type { Event } from "@/lib/types";
 
 export async function GET(request: Request) {
@@ -17,7 +17,7 @@ export async function GET(request: Request) {
 
   const { data: sub } = await supabase
     .from("calendar_subscription_tokens")
-    .select("id")
+    .select("id, user_id")
     .eq("token", token)
     .single();
 
@@ -44,18 +44,34 @@ export async function GET(request: Request) {
     query = query.eq("calendar_id", calendarId);
   }
 
-  const { data: events, error } = await query;
+  const [{ data: events, error: eventsError }, { data: myServings }] =
+    await Promise.all([
+      query,
+      // Serving signups where this user is an attendee (inner join filters results)
+      supabase
+        .from("serving_signups")
+        .select("id, service_date, member_groups(name), serving_signup_attendees!inner(profile_id)")
+        .eq("serving_signup_attendees.profile_id", sub.user_id)
+        .gte("service_date", thirtyDaysAgo.slice(0, 10))
+        .order("service_date", { ascending: true }),
+    ]);
 
-  if (error) {
-    console.error("Failed to fetch events for calendar feed:", error);
+  if (eventsError) {
+    console.error("Failed to fetch events for calendar feed:", eventsError);
     return new Response("Failed to fetch events", { status: 500 });
   }
 
   const typedEvents = (events ?? []) as Event[];
 
+  const servingSignups: ServingICSInput[] = (myServings ?? []).map((s) => {
+    const mg = s.member_groups as unknown as { name: string } | Array<{ name: string }> | null;
+    const teamName = (Array.isArray(mg) ? mg[0]?.name : mg?.name) ?? "Serving";
+    return { signupId: s.id as string, serviceDate: s.service_date as string, teamName };
+  });
+
   let icsString: string;
   try {
-    icsString = generateMultiEventICS(typedEvents);
+    icsString = generateCombinedICS(typedEvents, servingSignups);
   } catch (err) {
     console.error("ICS generation failed:", err);
     return new Response("Failed to generate calendar feed", { status: 500 });

--- a/app/api/serving/broadcast/route.ts
+++ b/app/api/serving/broadcast/route.ts
@@ -1,0 +1,158 @@
+import { NextResponse } from "next/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { siteConfig } from "@/lib/config";
+import { displayName } from "@/lib/names";
+import { getServingLinkMode } from "@/lib/serving/config";
+import { createServingToken } from "@/lib/serving/links";
+import { upcomingSundays } from "@/lib/serving/sundays";
+import { sendServingBroadcastEmail } from "@/lib/email/serving";
+
+/**
+ * Leader "Email the team" broadcast: emails every team member the Sundays
+ * that still need someone, each with its own one-tap action link.
+ */
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const groupId: string | undefined = body?.groupId;
+  const message: string | undefined =
+    typeof body?.message === "string" ? body.message.trim().slice(0, 1000) : undefined;
+
+  if (!groupId) {
+    return NextResponse.json({ error: "Missing groupId" }, { status: 400 });
+  }
+
+  const [{ data: profile }, { data: membership }, { data: group }, { data: settings }] =
+    await Promise.all([
+      supabase
+        .from("profiles")
+        .select("id, first_name, last_name, preferred_name, role")
+        .eq("id", user.id)
+        .single(),
+      supabase
+        .from("profile_groups")
+        .select("is_leader")
+        .eq("profile_id", user.id)
+        .eq("group_id", groupId)
+        .maybeSingle(),
+      supabase.from("member_groups").select("id, name").eq("id", groupId).single(),
+      supabase
+        .from("serving_team_settings")
+        .select("enabled, window_weeks")
+        .eq("group_id", groupId)
+        .maybeSingle(),
+    ]);
+
+  const isLeader = membership?.is_leader === true;
+  const isAdmin = profile?.role === "admin";
+  if (!profile || (!isLeader && !isAdmin)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (!group || !settings?.enabled) {
+    return NextResponse.json(
+      { error: "Serving signups are not enabled for this team" },
+      { status: 404 }
+    );
+  }
+
+  // Open Sundays are recomputed here — the email must reflect the truth at
+  // send time, not what the leader's page showed when it loaded
+  const sundays = upcomingSundays(settings.window_weeks);
+  const { data: signups } = await supabase
+    .from("serving_signups")
+    .select("service_date")
+    .eq("group_id", groupId)
+    .gte("service_date", sundays[0])
+    .lte("service_date", sundays[sundays.length - 1]);
+
+  const covered = new Set((signups ?? []).map((s) => s.service_date));
+  const openDates = sundays.filter((d) => !covered.has(d));
+
+  if (openDates.length === 0) {
+    return NextResponse.json(
+      { error: "Every upcoming Sunday is covered — nothing to ask for!" },
+      { status: 400 }
+    );
+  }
+
+  const service = await createServiceClient();
+  const linkMode = await getServingLinkMode(supabase);
+
+  const { data: memberRows } = await service
+    .from("profile_groups")
+    .select("profiles(id, first_name, last_name, preferred_name, email, role)")
+    .eq("group_id", groupId);
+
+  const members = (memberRows ?? [])
+    .map(
+      (r) =>
+        r.profiles as unknown as {
+          id: string;
+          first_name: string | null;
+          last_name: string | null;
+          preferred_name: string | null;
+          email: string | null;
+          role: string;
+        } | null
+    )
+    .filter((p): p is NonNullable<typeof p> => !!p?.email && p.role !== "pending");
+
+  if (members.length === 0) {
+    return NextResponse.json(
+      { error: "No team members with email addresses to send to" },
+      { status: 400 }
+    );
+  }
+
+  const fromName = displayName(profile);
+  let sent = 0;
+  for (const member of members) {
+    const dates = openDates.map((date) => ({
+      date,
+      url:
+        linkMode === "signed"
+          ? `${siteConfig.url}/serving/go?token=${createServingToken({
+              a: "signup",
+              g: groupId,
+              d: date,
+              p: member.id,
+            })}`
+          : `${siteConfig.url}/serving/${groupId}`,
+    }));
+
+    try {
+      await sendServingBroadcastEmail({
+        to: member.email!,
+        name: member.preferred_name || member.first_name || "Friend",
+        teamName: group.name,
+        fromName,
+        message,
+        openDates: dates,
+      });
+      sent++;
+    } catch (err) {
+      console.error(`Serving broadcast to ${member.id} failed:`, err);
+    }
+  }
+
+  const { error: logError } = await supabase.from("serving_broadcasts").insert({
+    group_id: groupId,
+    sent_by: user.id,
+    subject: `${group.name}: Sundays that still need someone`,
+    open_dates: openDates,
+    recipient_count: sent,
+  });
+  if (logError) {
+    console.error("Failed to log serving broadcast:", logError);
+  }
+
+  return NextResponse.json({ sent, openDates });
+}

--- a/app/api/serving/broadcast/route.ts
+++ b/app/api/serving/broadcast/route.ts
@@ -139,7 +139,7 @@ export async function POST(request: Request) {
       });
       sent++;
     } catch (err) {
-      console.error(`Serving broadcast to ${member.id} failed:`, err);
+      console.error("Serving broadcast failed for member:", member.id, err);
     }
   }
 

--- a/app/api/serving/link-action/route.ts
+++ b/app/api/serving/link-action/route.ts
@@ -1,0 +1,214 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/server";
+import { displayName } from "@/lib/names";
+import { getServingLinkMode } from "@/lib/serving/config";
+import { verifyServingToken } from "@/lib/serving/links";
+import { isValidServiceDate } from "@/lib/serving/sundays";
+import {
+  notifyLeadersOfCancel,
+  resolveSignupLabel,
+  sendSignupConfirmation,
+  type NamedProfile,
+} from "@/lib/serving/server";
+
+/**
+ * Executes a signed serving-email action (signup or cancel) without a login
+ * session. The HMAC token is the authorization; the /serving/go page collects
+ * an explicit button press first so mail scanners never trigger actions.
+ */
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const token: string | undefined = body?.token;
+  const includeSpouse: boolean = body?.includeSpouse === true;
+
+  if (!token) {
+    return NextResponse.json({ error: "Missing token" }, { status: 400 });
+  }
+
+  const payload = verifyServingToken(token);
+  if (!payload) {
+    return NextResponse.json(
+      { error: "This link is no longer valid — please use the site instead" },
+      { status: 400 }
+    );
+  }
+
+  const service = await createServiceClient();
+
+  const linkMode = await getServingLinkMode(service);
+  if (linkMode === "login") {
+    return NextResponse.json({ error: "login_required" }, { status: 403 });
+  }
+
+  const [{ data: profile }, { data: group }, { data: settings }] =
+    await Promise.all([
+      service
+        .from("profiles")
+        .select("id, first_name, last_name, preferred_name, family_id, email, role")
+        .eq("id", payload.p)
+        .maybeSingle(),
+      service
+        .from("member_groups")
+        .select("id, name")
+        .eq("id", payload.g)
+        .maybeSingle(),
+      service
+        .from("serving_team_settings")
+        .select("enabled")
+        .eq("group_id", payload.g)
+        .maybeSingle(),
+    ]);
+
+  if (!profile || profile.role === "pending" || !group || !settings?.enabled) {
+    return NextResponse.json(
+      { error: "This link is no longer valid — please use the site instead" },
+      { status: 400 }
+    );
+  }
+
+  if (payload.a === "signup") {
+    if (!isValidServiceDate(payload.d)) {
+      return NextResponse.json(
+        { error: "That Sunday has already passed" },
+        { status: 400 }
+      );
+    }
+
+    // The link acts for a specific member — they must be on the team
+    const { data: membership } = await service
+      .from("profile_groups")
+      .select("profile_id")
+      .eq("profile_id", profile.id)
+      .eq("group_id", payload.g)
+      .maybeSingle();
+    if (!membership) {
+      return NextResponse.json(
+        { error: "You're no longer on this team — please use the site instead" },
+        { status: 403 }
+      );
+    }
+
+    const attendees: NamedProfile[] = [profile];
+    if (includeSpouse && profile.family_id) {
+      const { data: spouse } = await service
+        .from("profiles")
+        .select("id, first_name, last_name, preferred_name")
+        .eq("family_id", profile.family_id)
+        .in("relationship", ["primary", "spouse"])
+        .neq("id", profile.id)
+        .limit(1)
+        .maybeSingle();
+      if (spouse) attendees.push(spouse);
+    }
+
+    const { data: signup, error: signupError } = await service
+      .from("serving_signups")
+      .insert({
+        group_id: payload.g,
+        service_date: payload.d,
+        family_id: profile.family_id,
+        created_by: profile.id,
+      })
+      .select()
+      .single();
+
+    if (signupError || !signup) {
+      if (signupError?.code === "23505") {
+        return NextResponse.json(
+          { error: "Someone just signed up for that Sunday — thank you anyway!" },
+          { status: 409 }
+        );
+      }
+      console.error("Signed-link signup insert failed:", signupError);
+      return NextResponse.json({ error: "Failed to sign up" }, { status: 500 });
+    }
+
+    const { error: attendeeError } = await service
+      .from("serving_signup_attendees")
+      .insert(attendees.map((a) => ({ signup_id: signup.id, profile_id: a.id })));
+    if (attendeeError) {
+      console.error("Signed-link attendee insert failed:", attendeeError);
+      await service.from("serving_signups").delete().eq("id", signup.id);
+      return NextResponse.json({ error: "Failed to sign up" }, { status: 500 });
+    }
+
+    if (profile.email) {
+      try {
+        await sendSignupConfirmation(service, {
+          signupId: signup.id,
+          groupId: payload.g,
+          groupName: group.name,
+          serviceDate: payload.d,
+          attendees,
+          familyId: profile.family_id,
+          recipient: {
+            id: profile.id,
+            email: profile.email,
+            name: displayName(profile),
+          },
+        });
+      } catch (err) {
+        console.error("Serving confirmation email failed:", err);
+      }
+    }
+
+    return NextResponse.json({ success: true, action: "signup" });
+  }
+
+  // Cancel: the member must be the signup's creator or one of its attendees
+  const { data: signup } = await service
+    .from("serving_signups")
+    .select(
+      "id, family_id, created_by, serving_signup_attendees(profiles(id, first_name, last_name, preferred_name))"
+    )
+    .eq("group_id", payload.g)
+    .eq("service_date", payload.d)
+    .maybeSingle();
+
+  if (!signup) {
+    return NextResponse.json(
+      { error: "That signup was already cancelled" },
+      { status: 404 }
+    );
+  }
+
+  const attendeeProfiles = (signup.serving_signup_attendees ?? [])
+    .map((a: { profiles: unknown }) => a.profiles)
+    .filter(Boolean) as NamedProfile[];
+  const involved =
+    signup.created_by === profile.id ||
+    attendeeProfiles.some((a) => a.id === profile.id);
+  if (!involved) {
+    return NextResponse.json(
+      { error: "This Sunday is covered by someone else now" },
+      { status: 403 }
+    );
+  }
+
+  const { error: deleteError } = await service
+    .from("serving_signups")
+    .delete()
+    .eq("id", signup.id);
+  if (deleteError) {
+    console.error("Signed-link cancel failed:", deleteError);
+    return NextResponse.json({ error: "Failed to cancel" }, { status: 500 });
+  }
+
+  try {
+    await notifyLeadersOfCancel(service, {
+      groupId: payload.g,
+      groupName: group.name,
+      serviceDate: payload.d,
+      memberLabel: await resolveSignupLabel(
+        service,
+        attendeeProfiles,
+        signup.family_id
+      ),
+      excludeProfileId: profile.id,
+    });
+  } catch (err) {
+    console.error("Serving cancel notice failed:", err);
+  }
+
+  return NextResponse.json({ success: true, action: "cancel" });
+}

--- a/app/api/serving/signups/route.ts
+++ b/app/api/serving/signups/route.ts
@@ -1,0 +1,208 @@
+import { NextResponse } from "next/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { displayName } from "@/lib/names";
+import { isValidServiceDate } from "@/lib/serving/sundays";
+import {
+  notifyLeadersOfCancel,
+  resolveSignupLabel,
+  sendSignupConfirmation,
+  type NamedProfile,
+} from "@/lib/serving/server";
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const groupId: string | undefined = body?.groupId;
+  const serviceDate: string | undefined = body?.serviceDate;
+  const attendeeIds: string[] = Array.isArray(body?.attendeeProfileIds)
+    ? [...new Set(body.attendeeProfileIds as string[])]
+    : [];
+
+  if (!groupId || !serviceDate || attendeeIds.length === 0) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  }
+  if (!isValidServiceDate(serviceDate)) {
+    return NextResponse.json(
+      { error: "Signups are for upcoming Sundays only" },
+      { status: 400 }
+    );
+  }
+
+  // Team must exist and have serving signups enabled
+  const [{ data: group }, { data: settings }, { data: profile }] =
+    await Promise.all([
+      supabase.from("member_groups").select("id, name").eq("id", groupId).single(),
+      supabase
+        .from("serving_team_settings")
+        .select("enabled")
+        .eq("group_id", groupId)
+        .maybeSingle(),
+      supabase
+        .from("profiles")
+        .select("id, first_name, last_name, preferred_name, family_id")
+        .eq("id", user.id)
+        .single(),
+    ]);
+
+  if (!group || !settings?.enabled || !profile) {
+    return NextResponse.json(
+      { error: "Serving signups are not enabled for this team" },
+      { status: 404 }
+    );
+  }
+
+  // Attendees are the signer and optionally their spouse (same household)
+  const { data: attendees } = await supabase
+    .from("profiles")
+    .select("id, first_name, last_name, preferred_name, family_id, relationship")
+    .in("id", attendeeIds);
+
+  if (!attendees || attendees.length !== attendeeIds.length) {
+    return NextResponse.json({ error: "Unknown attendee" }, { status: 400 });
+  }
+  for (const a of attendees) {
+    const isSelf = a.id === user.id;
+    const isSpouse =
+      profile.family_id !== null &&
+      a.family_id === profile.family_id &&
+      ["primary", "spouse"].includes(a.relationship);
+    if (!isSelf && !isSpouse) {
+      return NextResponse.json(
+        { error: "Attendees must be you or your spouse" },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Insert the signup — the unique (group_id, service_date) constraint is the
+  // race guard when two members tap "I'll do it" for the same Sunday
+  const { data: signup, error: signupError } = await supabase
+    .from("serving_signups")
+    .insert({
+      group_id: groupId,
+      service_date: serviceDate,
+      family_id: profile.family_id,
+      created_by: user.id,
+    })
+    .select()
+    .single();
+
+  if (signupError || !signup) {
+    if (signupError?.code === "23505") {
+      return NextResponse.json(
+        { error: "Someone just signed up for that Sunday — thank you anyway!" },
+        { status: 409 }
+      );
+    }
+    console.error("Serving signup insert failed:", signupError);
+    return NextResponse.json({ error: "Failed to sign up" }, { status: 500 });
+  }
+
+  const { error: attendeeError } = await supabase
+    .from("serving_signup_attendees")
+    .insert(attendeeIds.map((id) => ({ signup_id: signup.id, profile_id: id })));
+
+  if (attendeeError) {
+    console.error("Serving attendee insert failed:", attendeeError);
+    await supabase.from("serving_signups").delete().eq("id", signup.id);
+    return NextResponse.json({ error: "Failed to sign up" }, { status: 500 });
+  }
+
+  if (user.email) {
+    try {
+      await sendSignupConfirmation(supabase, {
+        signupId: signup.id,
+        groupId,
+        groupName: group.name,
+        serviceDate,
+        attendees,
+        familyId: profile.family_id,
+        recipient: { id: user.id, email: user.email, name: displayName(profile) },
+      });
+    } catch (err) {
+      console.error("Serving confirmation email failed:", err);
+    }
+  }
+
+  return NextResponse.json({ signup });
+}
+
+export async function DELETE(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const signupId: string | undefined = body?.signupId;
+  if (!signupId) {
+    return NextResponse.json({ error: "Missing signupId" }, { status: 400 });
+  }
+
+  // Capture details before deleting so leaders can be told who freed the slot
+  const { data: signup } = await supabase
+    .from("serving_signups")
+    .select(
+      "id, group_id, service_date, family_id, created_by, member_groups(name), serving_signup_attendees(profiles(id, first_name, last_name, preferred_name))"
+    )
+    .eq("id", signupId)
+    .maybeSingle();
+
+  if (!signup) {
+    return NextResponse.json({ error: "Signup not found" }, { status: 404 });
+  }
+
+  // RLS allows deletes only by the signup owner, a leader of the group, or an
+  // admin — an empty result means the caller is none of those
+  const { data: deleted, error } = await supabase
+    .from("serving_signups")
+    .delete()
+    .eq("id", signupId)
+    .select();
+
+  if (error) {
+    console.error("Serving signup delete failed:", error);
+    return NextResponse.json({ error: "Failed to cancel" }, { status: 500 });
+  }
+  if (!deleted || deleted.length === 0) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const service = await createServiceClient();
+    const groupName =
+      (signup.member_groups as unknown as { name: string } | null)?.name ??
+      "your team";
+    const attendeeProfiles = (signup.serving_signup_attendees ?? [])
+      .map((a: { profiles: unknown }) => a.profiles)
+      .filter(Boolean) as NamedProfile[];
+
+    await notifyLeadersOfCancel(service, {
+      groupId: signup.group_id,
+      groupName,
+      serviceDate: signup.service_date,
+      memberLabel: await resolveSignupLabel(
+        service,
+        attendeeProfiles,
+        signup.family_id
+      ),
+      excludeProfileId: user.id,
+    });
+  } catch (err) {
+    console.error("Serving cancel notice failed:", err);
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,9 +1,10 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
-import { Calendar, Play, Users, Bell, Heart } from "lucide-react";
+import { Calendar, Play, Users, Bell, Heart, HandHelping } from "lucide-react";
 import Link from "next/link";
 import { siteConfig } from "@/lib/config";
+import { formatServiceDate } from "@/lib/serving/sundays";
 import { RsvpSegmented } from "./RsvpSegmented";
 import type { Rsvp } from "@/lib/types";
 
@@ -211,6 +212,22 @@ export default async function DashboardPage() {
     .limit(3);
 
   const hasLectures = lectures && lectures.length > 0;
+
+  // Upcoming serving commitments for this member (inner join filters to user's rows)
+  const { data: myServings } = await supabase
+    .from("serving_signups")
+    .select("id, service_date, group_id, member_groups(id, name), serving_signup_attendees!inner(profile_id)")
+    .eq("serving_signup_attendees.profile_id", profile.id)
+    .gte("service_date", now.slice(0, 10))
+    .order("service_date", { ascending: true })
+    .limit(3);
+
+  const upcomingServings = (myServings ?? []) as Array<{
+    id: string;
+    service_date: string;
+    group_id: string;
+    member_groups: { id: string; name: string } | Array<{ id: string; name: string }> | null;
+  }>;
 
   // ── render ─────────────────────────────────────────────────────────────────
   return (
@@ -466,6 +483,41 @@ export default async function DashboardPage() {
           )}
         </div>
       </section>
+
+      {/* ── Your turn to serve ───────────────────────────────────────────── */}
+      {upcomingServings.length > 0 && (
+        <section className="px-4 pb-6 md:px-14">
+          <div className="rounded-2xl border border-border bg-card p-5">
+            <div className="flex items-center gap-2 mb-3">
+              <HandHelping className="h-5 w-5 text-brand-primary" />
+              <h2 className="font-sans text-sm font-semibold text-foreground uppercase tracking-wider">
+                Your turn to serve
+              </h2>
+            </div>
+            <div className="space-y-2">
+              {upcomingServings.map((s) => (
+                <Link
+                  key={s.id}
+                  href={`/serving/${s.group_id}`}
+                  className="flex items-center justify-between gap-4 py-2 border-t border-border first:border-0 hover:text-brand-primary transition-colors"
+                >
+                  <div>
+                    <div className="font-sans text-sm font-semibold text-foreground">
+                      {(Array.isArray(s.member_groups) ? s.member_groups[0]?.name : s.member_groups?.name) ?? "Serving team"}
+                    </div>
+                    <div className="font-sans text-xs text-muted-foreground mt-0.5">
+                      {formatServiceDate(s.service_date)}
+                    </div>
+                  </div>
+                  <span className="font-sans text-xs font-semibold text-brand-primary shrink-0">
+                    View →
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* ── Bottom: Announcements + Continue Listening ───────────────────── */}
       <section

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Calendar, Play, Users, Bell, Heart, HandHelping } from "lucide-react";
 import Link from "next/link";
 import { siteConfig } from "@/lib/config";
-import { formatServiceDate } from "@/lib/serving/sundays";
+import { formatServiceDate, toDateString } from "@/lib/serving/sundays";
 import { RsvpSegmented } from "./RsvpSegmented";
 import type { Rsvp } from "@/lib/types";
 
@@ -218,7 +218,7 @@ export default async function DashboardPage() {
     .from("serving_signups")
     .select("id, service_date, group_id, member_groups(id, name), serving_signup_attendees!inner(profile_id)")
     .eq("serving_signup_attendees.profile_id", profile.id)
-    .gte("service_date", now.slice(0, 10))
+    .gte("service_date", toDateString(new Date()))
     .order("service_date", { ascending: true })
     .limit(3);
 

--- a/app/serving/[groupId]/page.tsx
+++ b/app/serving/[groupId]/page.tsx
@@ -69,10 +69,17 @@ export default async function ServingSchedulePage({
   const isMember = !!membership;
   const isLeader = membership?.is_leader === true;
 
-  const { count: memberCount } = await supabase
+  const { data: memberRows } = await supabase
     .from("profile_groups")
-    .select("profile_id", { count: "exact", head: true })
+    .select("profiles(email, role)")
     .eq("group_id", groupId);
+  const memberCount = (memberRows ?? []).filter((row) => {
+    const member = row.profiles as unknown as {
+      email: string | null;
+      role: string;
+    } | null;
+    return !!member?.email && member.role !== "pending";
+  }).length;
 
   const sundays = upcomingSundays(settings?.window_weeks ?? 8);
 

--- a/app/serving/[groupId]/page.tsx
+++ b/app/serving/[groupId]/page.tsx
@@ -10,6 +10,7 @@ import {
   type ScheduleEntry,
 } from "@/components/serving/ServingSchedule";
 import { EmailTeamButton } from "@/components/serving/EmailTeamButton";
+import { ServingSettingsDialog } from "@/components/serving/ServingSettingsDialog";
 
 export const metadata = { title: `Serving | ${siteConfig.name}` };
 
@@ -168,14 +169,30 @@ export default async function ServingSchedulePage({
         </p>
       )}
 
-      {(isLeader || isAdmin) && settings?.enabled && (
-        <div className="flex items-center gap-2 mb-6">
-          <EmailTeamButton
-            groupId={groupId}
-            teamName={group.name}
-            openDates={sundays.filter((d) => !entries[d])}
-            memberCount={memberCount ?? 0}
-          />
+      {(isLeader || isAdmin) && (
+        <div className="flex flex-wrap items-center gap-2 mb-6">
+          {settings?.enabled && (
+            <EmailTeamButton
+              groupId={groupId}
+              teamName={group.name}
+              openDates={sundays.filter((d) => !entries[d])}
+              memberCount={memberCount ?? 0}
+            />
+          )}
+          {isAdmin && (
+            <ServingSettingsDialog
+              groupId={groupId}
+              settings={
+                settings
+                  ? {
+                      enabled: settings.enabled ?? false,
+                      reminder_days: settings.reminder_days ?? [4, 5],
+                      window_weeks: settings.window_weeks ?? 8,
+                    }
+                  : null
+              }
+            />
+          )}
         </div>
       )}
 

--- a/app/serving/[groupId]/page.tsx
+++ b/app/serving/[groupId]/page.tsx
@@ -1,0 +1,194 @@
+import { createClient } from "@/lib/supabase/server";
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { siteConfig } from "@/lib/config";
+import { signupDisplayName } from "@/lib/serving/display";
+import { upcomingSundays } from "@/lib/serving/sundays";
+import {
+  ServingSchedule,
+  type ScheduleEntry,
+} from "@/components/serving/ServingSchedule";
+import { EmailTeamButton } from "@/components/serving/EmailTeamButton";
+
+export const metadata = { title: `Serving | ${siteConfig.name}` };
+
+interface AttendeeProfile {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  preferred_name: string | null;
+}
+
+export default async function ServingSchedulePage({
+  params,
+}: {
+  params: Promise<{ groupId: string }>;
+}) {
+  const { groupId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const [{ data: profile }, { data: group }, { data: settings }] =
+    await Promise.all([
+      supabase
+        .from("profiles")
+        .select("id, role, family_id, first_name, last_name, preferred_name")
+        .eq("id", user.id)
+        .single(),
+      supabase
+        .from("member_groups")
+        .select("id, name, description, color")
+        .eq("id", groupId)
+        .maybeSingle(),
+      supabase
+        .from("serving_team_settings")
+        .select("*")
+        .eq("group_id", groupId)
+        .maybeSingle(),
+    ]);
+
+  if (!profile || profile.role === "pending") redirect("/dashboard");
+  if (!group) notFound();
+
+  const isAdmin = profile.role === "admin";
+  if (!settings?.enabled && !isAdmin) redirect("/serving");
+
+  const { data: membership } = await supabase
+    .from("profile_groups")
+    .select("is_leader")
+    .eq("profile_id", user.id)
+    .eq("group_id", groupId)
+    .maybeSingle();
+
+  const isMember = !!membership;
+  const isLeader = membership?.is_leader === true;
+
+  const { count: memberCount } = await supabase
+    .from("profile_groups")
+    .select("profile_id", { count: "exact", head: true })
+    .eq("group_id", groupId);
+
+  const sundays = upcomingSundays(settings?.window_weeks ?? 8);
+
+  const { data: signups } = await supabase
+    .from("serving_signups")
+    .select(
+      "id, service_date, created_by, family_id, serving_signup_attendees(profiles(id, first_name, last_name, preferred_name))"
+    )
+    .eq("group_id", groupId)
+    .gte("service_date", sundays[0])
+    .lte("service_date", sundays[sundays.length - 1]);
+
+  // Household names for couple signups
+  const familyIds = [
+    ...new Set(
+      (signups ?? [])
+        .filter((s) => (s.serving_signup_attendees?.length ?? 0) > 1 && s.family_id)
+        .map((s) => s.family_id as string)
+    ),
+  ];
+  const familyNames = new Map<string, string>();
+  if (familyIds.length > 0) {
+    const { data: families } = await supabase
+      .from("family_units")
+      .select("id, family_name")
+      .in("id", familyIds);
+    for (const f of families ?? []) familyNames.set(f.id, f.family_name);
+  }
+
+  const entries: Record<string, ScheduleEntry> = {};
+  for (const s of signups ?? []) {
+    const attendees = (s.serving_signup_attendees ?? [])
+      .map((a) => a.profiles as unknown as AttendeeProfile)
+      .filter(Boolean);
+    entries[s.service_date] = {
+      id: s.id,
+      date: s.service_date,
+      createdBy: s.created_by,
+      attendeeIds: attendees.map((a) => a.id),
+      label: signupDisplayName(
+        attendees,
+        s.family_id ? (familyNames.get(s.family_id) ?? null) : null
+      ),
+    };
+  }
+
+  // Spouse option for the attendee picker ("just me" / "me & spouse")
+  let spouse: { id: string; name: string } | null = null;
+  if (profile.family_id) {
+    const { data: spouseRow } = await supabase
+      .from("profiles")
+      .select("id, first_name, last_name, preferred_name")
+      .eq("family_id", profile.family_id)
+      .in("relationship", ["primary", "spouse"])
+      .neq("id", user.id)
+      .limit(1)
+      .maybeSingle();
+    if (spouseRow) {
+      spouse = {
+        id: spouseRow.id,
+        name: spouseRow.preferred_name || spouseRow.first_name || "spouse",
+      };
+    }
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-2xl">
+      <Link
+        href="/serving"
+        className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground mb-6"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        All serving teams
+      </Link>
+
+      <div className="flex items-center gap-3 mb-2">
+        <span
+          className="inline-block w-4 h-4 rounded-full shrink-0"
+          style={{ backgroundColor: group.color ?? "#2F6BA8" }}
+        />
+        <h1 className="text-3xl md:text-4xl font-bold text-brand-primary">
+          {group.name}
+        </h1>
+      </div>
+      <p className="text-lg text-muted-foreground mb-8">
+        {group.description ||
+          "Pick a Sunday below — one signup covers the whole morning."}
+      </p>
+
+      {!settings?.enabled && isAdmin && (
+        <p className="text-sm text-brand-accent mb-6">
+          Serving signups are not enabled for this team yet — enable them from
+          the Serving page.
+        </p>
+      )}
+
+      {(isLeader || isAdmin) && settings?.enabled && (
+        <div className="flex items-center gap-2 mb-6">
+          <EmailTeamButton
+            groupId={groupId}
+            teamName={group.name}
+            openDates={sundays.filter((d) => !entries[d])}
+            memberCount={memberCount ?? 0}
+          />
+        </div>
+      )}
+
+      <ServingSchedule
+        groupId={groupId}
+        teamName={group.name}
+        sundays={sundays}
+        entries={entries}
+        userId={user.id}
+        spouse={spouse}
+        canSignUp={isMember || isLeader || isAdmin}
+        canManage={isLeader || isAdmin}
+      />
+    </div>
+  );
+}

--- a/app/serving/go/page.tsx
+++ b/app/serving/go/page.tsx
@@ -65,17 +65,28 @@ export default async function ServingLinkPage({
     );
   }
 
-  const [{ data: profile }, { data: group }, { data: signup }] =
+  const [{ data: profile }, { data: group }, { data: settings }, { data: membership }, { data: signup }] =
     await Promise.all([
       service
         .from("profiles")
-        .select("id, first_name, preferred_name, family_id")
+        .select("id, first_name, preferred_name, family_id, role")
         .eq("id", payload.p)
         .maybeSingle(),
       service
         .from("member_groups")
         .select("id, name")
         .eq("id", payload.g)
+        .maybeSingle(),
+      service
+        .from("serving_team_settings")
+        .select("enabled")
+        .eq("group_id", payload.g)
+        .maybeSingle(),
+      service
+        .from("profile_groups")
+        .select("profile_id")
+        .eq("profile_id", payload.p)
+        .eq("group_id", payload.g)
         .maybeSingle(),
       service
         .from("serving_signups")
@@ -87,7 +98,7 @@ export default async function ServingLinkPage({
         .maybeSingle(),
     ]);
 
-  if (!profile || !group) {
+  if (!profile || profile.role === "pending" || !group || !settings?.enabled) {
     return (
       <Message
         title="This link has expired"
@@ -100,6 +111,14 @@ export default async function ServingLinkPage({
   const firstName = profile.preferred_name || profile.first_name || "Friend";
 
   if (payload.a === "signup") {
+    if (!membership) {
+      return (
+        <Message
+          title="You're no longer on this team"
+          body="This signup link is for a team you're not currently part of. Check the serving page for teams available to you."
+        />
+      );
+    }
     if (!isValidServiceDate(payload.d)) {
       return (
         <Message

--- a/app/serving/go/page.tsx
+++ b/app/serving/go/page.tsx
@@ -1,0 +1,190 @@
+import Link from "next/link";
+import { createServiceClient } from "@/lib/supabase/server";
+import { Card, CardContent } from "@/components/ui/card";
+import { siteConfig } from "@/lib/config";
+import { getServingLinkMode } from "@/lib/serving/config";
+import { verifyServingToken } from "@/lib/serving/links";
+import { formatServiceDate, isValidServiceDate } from "@/lib/serving/sundays";
+import { signupDisplayName } from "@/lib/serving/display";
+import { LinkActionConfirm } from "@/components/serving/LinkActionConfirm";
+
+export const metadata = { title: `Serving | ${siteConfig.name}` };
+
+/**
+ * Landing page for signed serving-email links. Works without a login when
+ * link mode is 'signed'. The link itself never performs the action — this
+ * page asks for one explicit button press first, so email scanners that
+ * prefetch URLs can't sign anyone up or cancel anything.
+ */
+
+function Message({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="container mx-auto px-4 py-20 max-w-lg text-center">
+      <Card className="p-8">
+        <CardContent className="pt-6">
+          <h1 className="font-serif text-3xl text-brand-primary mb-4">{title}</h1>
+          <p className="text-lg text-muted-foreground">{body}</p>
+          <Link
+            href="/serving"
+            className="inline-block mt-6 text-brand-primary hover:underline text-lg"
+          >
+            Go to the serving page
+          </Link>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default async function ServingLinkPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ token?: string }>;
+}) {
+  const { token } = await searchParams;
+  const payload = token ? verifyServingToken(token) : null;
+
+  if (!token || !payload) {
+    return (
+      <Message
+        title="This link has expired"
+        body="No problem — you can sign in to the site and manage your serving Sundays there."
+      />
+    );
+  }
+
+  const service = await createServiceClient();
+
+  const linkMode = await getServingLinkMode(service);
+  if (linkMode === "login") {
+    return (
+      <Message
+        title="Please sign in"
+        body="Email links on this site require signing in first. Head to the serving page and we'll take you through login."
+      />
+    );
+  }
+
+  const [{ data: profile }, { data: group }, { data: signup }] =
+    await Promise.all([
+      service
+        .from("profiles")
+        .select("id, first_name, preferred_name, family_id")
+        .eq("id", payload.p)
+        .maybeSingle(),
+      service
+        .from("member_groups")
+        .select("id, name")
+        .eq("id", payload.g)
+        .maybeSingle(),
+      service
+        .from("serving_signups")
+        .select(
+          "id, family_id, created_by, serving_signup_attendees(profiles(id, first_name, last_name, preferred_name))"
+        )
+        .eq("group_id", payload.g)
+        .eq("service_date", payload.d)
+        .maybeSingle(),
+    ]);
+
+  if (!profile || !group) {
+    return (
+      <Message
+        title="This link has expired"
+        body="No problem — you can sign in to the site and manage your serving Sundays there."
+      />
+    );
+  }
+
+  const dateLabel = formatServiceDate(payload.d);
+  const firstName = profile.preferred_name || profile.first_name || "Friend";
+
+  if (payload.a === "signup") {
+    if (!isValidServiceDate(payload.d)) {
+      return (
+        <Message
+          title="That Sunday has passed"
+          body="This link pointed at a Sunday that's already behind us. Check the serving page for the upcoming schedule."
+        />
+      );
+    }
+    if (signup) {
+      const attendees = (signup.serving_signup_attendees ?? [])
+        .map((a) => a.profiles as unknown as {
+          id: string;
+          first_name: string | null;
+          last_name: string | null;
+          preferred_name: string | null;
+        })
+        .filter(Boolean);
+      let familyName: string | null = null;
+      if (attendees.length > 1 && signup.family_id) {
+        const { data: family } = await service
+          .from("family_units")
+          .select("family_name")
+          .eq("id", signup.family_id)
+          .single();
+        familyName = family?.family_name ?? null;
+      }
+      return (
+        <Message
+          title="That Sunday is covered"
+          body={`${signupDisplayName(attendees, familyName)} already has ${dateLabel} — thank you for offering! Check the serving page for other open Sundays.`}
+        />
+      );
+    }
+
+    // Offer the spouse option when the member has one on file
+    let spouseName: string | null = null;
+    if (profile.family_id) {
+      const { data: spouse } = await service
+        .from("profiles")
+        .select("id, first_name, preferred_name")
+        .eq("family_id", profile.family_id)
+        .in("relationship", ["primary", "spouse"])
+        .neq("id", profile.id)
+        .limit(1)
+        .maybeSingle();
+      spouseName = spouse ? spouse.preferred_name || spouse.first_name : null;
+    }
+
+    return (
+      <LinkActionConfirm
+        token={token}
+        action="signup"
+        firstName={firstName}
+        teamName={group.name}
+        dateLabel={dateLabel}
+        spouseName={spouseName}
+      />
+    );
+  }
+
+  // Cancel link
+  const isInvolved =
+    !!signup &&
+    (signup.created_by === profile.id ||
+      (signup.serving_signup_attendees ?? []).some(
+        (a) => (a.profiles as unknown as { id: string } | null)?.id === profile.id
+      ));
+
+  if (!signup || !isInvolved) {
+    return (
+      <Message
+        title="Nothing to cancel"
+        body={`You're not signed up for ${dateLabel} — it may have been cancelled already.`}
+      />
+    );
+  }
+
+  return (
+    <LinkActionConfirm
+      token={token}
+      action="cancel"
+      firstName={firstName}
+      teamName={group.name}
+      dateLabel={dateLabel}
+      spouseName={null}
+    />
+  );
+}

--- a/app/serving/page.tsx
+++ b/app/serving/page.tsx
@@ -1,0 +1,144 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { ChevronRight } from "lucide-react";
+import { siteConfig } from "@/lib/config";
+import { toDateString, upcomingSundays } from "@/lib/serving/sundays";
+import { AdminServingSetup } from "@/components/serving/AdminServingSetup";
+import type { MemberGroup, ServingTeamSettings } from "@/lib/types";
+
+export const metadata = { title: `Serving | ${siteConfig.name}` };
+
+type SettingsWithGroup = ServingTeamSettings & {
+  member_groups: Pick<MemberGroup, "id" | "name" | "description" | "color"> | null;
+};
+
+export default async function ServingPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile || profile.role === "pending") redirect("/dashboard");
+  const isAdmin = profile.role === "admin";
+
+  const [{ data: settingsRows }, { data: memberships }] = await Promise.all([
+    supabase
+      .from("serving_team_settings")
+      .select("*, member_groups(id, name, description, color)")
+      .eq("enabled", true),
+    supabase
+      .from("profile_groups")
+      .select("group_id, is_leader")
+      .eq("profile_id", user.id),
+  ]);
+
+  const teams = ((settingsRows ?? []) as SettingsWithGroup[]).filter(
+    (s) => s.member_groups
+  );
+  const membershipMap = new Map(
+    (memberships ?? []).map((m) => [m.group_id, m.is_leader as boolean])
+  );
+
+  // Coverage counts for each team's upcoming window
+  const today = toDateString(new Date());
+  const coverage = new Map<string, number>();
+  if (teams.length > 0) {
+    const { data: signups } = await supabase
+      .from("serving_signups")
+      .select("group_id, service_date")
+      .in(
+        "group_id",
+        teams.map((t) => t.group_id)
+      )
+      .gte("service_date", today);
+
+    for (const team of teams) {
+      const window = new Set(upcomingSundays(team.window_weeks));
+      coverage.set(
+        team.group_id,
+        (signups ?? []).filter(
+          (s) => s.group_id === team.group_id && window.has(s.service_date)
+        ).length
+      );
+    }
+  }
+
+  // Teams admins could still turn on
+  let candidateGroups: Pick<MemberGroup, "id" | "name" | "color">[] = [];
+  if (isAdmin) {
+    const { data: allGroups } = await supabase
+      .from("member_groups")
+      .select("id, name, color")
+      .order("display_order");
+    const enabledIds = new Set(teams.map((t) => t.group_id));
+    candidateGroups = (allGroups ?? []).filter((g) => !enabledIds.has(g.id));
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-3xl">
+      <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-2">
+        Serving
+      </h1>
+      <p className="text-lg text-muted-foreground mb-10">
+        Take a Sunday to serve — sign up in one tap and we&apos;ll remind you
+        when it&apos;s close.
+      </p>
+
+      {teams.length > 0 ? (
+        <div className="space-y-4">
+          {teams.map((team) => {
+            const group = team.member_groups!;
+            const covered = coverage.get(team.group_id) ?? 0;
+            const isLeader = membershipMap.get(team.group_id) === true;
+            const isMember = membershipMap.has(team.group_id);
+            return (
+              <Link key={team.group_id} href={`/serving/${team.group_id}`}>
+                <Card className="mb-4 hover:border-brand-primary/50 transition-colors">
+                  <CardContent className="py-5 flex items-center gap-4">
+                    <span
+                      className="inline-block w-4 h-4 rounded-full shrink-0"
+                      style={{ backgroundColor: group.color ?? "#2F6BA8" }}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xl font-semibold flex items-center gap-2">
+                        {group.name}
+                        {isLeader && (
+                          <span className="text-xs font-medium uppercase tracking-wider text-brand-accent border border-brand-accent/40 rounded px-1.5 py-0.5">
+                            Leader
+                          </span>
+                        )}
+                      </p>
+                      <p className="text-muted-foreground">
+                        {covered} of the next {team.window_weeks} Sundays covered
+                        {isMember && !isLeader ? " · You're on this team" : ""}
+                      </p>
+                    </div>
+                    <ChevronRight className="h-6 w-6 text-muted-foreground shrink-0" />
+                  </CardContent>
+                </Card>
+              </Link>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="text-xl text-muted-foreground">
+          No serving teams are set up yet.
+        </p>
+      )}
+
+      {isAdmin && candidateGroups.length > 0 && (
+        <AdminServingSetup groups={candidateGroups} />
+      )}
+    </div>
+  );
+}

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -17,6 +17,7 @@ const SIDEBAR_ROUTES = [
   "/pages",
   "/admin",
   "/directory",
+  "/serving",
   "/profile",
 ];
 

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   ChevronLeft,
   ChevronRight,
   MailPlus,
+  HandHelping,
 } from "lucide-react";
 import { useState, useEffect } from "react";
 import type { Profile } from "@/lib/types";
@@ -32,6 +33,7 @@ const memberNav = [
   { href: "/announcements", label: "Announcements", icon: Megaphone },
   { href: "/lectures", label: "Lectures", icon: BookOpen },
   { href: "/directory", label: "Directory", icon: Users },
+  { href: "/serving", label: "Serving", icon: HandHelping },
   { href: "/profile", label: "My Profile", icon: UserCircle },
 ];
 

--- a/components/serving/AdminServingSetup.tsx
+++ b/components/serving/AdminServingSetup.tsx
@@ -24,9 +24,12 @@ export function AdminServingSetup({ groups }: AdminServingSetupProps) {
 
   async function enable(groupId: string, name: string) {
     setBusy(groupId);
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
     const { error } = await supabase
       .from("serving_team_settings")
-      .upsert({ group_id: groupId, enabled: true });
+      .upsert({ group_id: groupId, enabled: true, updated_by: user?.id });
     setBusy(null);
 
     if (error) {

--- a/components/serving/AdminServingSetup.tsx
+++ b/components/serving/AdminServingSetup.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { toast } from "sonner";
+import type { MemberGroup } from "@/lib/types";
+
+interface AdminServingSetupProps {
+  groups: Pick<MemberGroup, "id" | "name" | "color">[];
+}
+
+/**
+ * Admin-only: turn on Sunday serving signups for a member group. This is
+ * where a group becomes a "serving team" — the group dialog intentionally
+ * doesn't expose it.
+ */
+export function AdminServingSetup({ groups }: AdminServingSetupProps) {
+  const [busy, setBusy] = useState<string | null>(null);
+  const router = useRouter();
+  const supabase = createClient();
+
+  async function enable(groupId: string, name: string) {
+    setBusy(groupId);
+    const { error } = await supabase
+      .from("serving_team_settings")
+      .upsert({ group_id: groupId, enabled: true });
+    setBusy(null);
+
+    if (error) {
+      toast.error(`Failed to enable serving for ${name}.`);
+      return;
+    }
+    toast.success(`Serving signups enabled for ${name}.`);
+    router.refresh();
+  }
+
+  return (
+    <Card className="mt-10">
+      <CardHeader>
+        <CardTitle className="text-lg">Set up a serving team</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground mb-4">
+          Turn on Sunday signups for a group. Members of the group will be able
+          to claim upcoming Sundays.
+        </p>
+        <div className="divide-y">
+          {groups.map((g) => (
+            <div key={g.id} className="flex items-center gap-3 py-2.5">
+              <span
+                className="inline-block w-3 h-3 rounded-full shrink-0"
+                style={{ backgroundColor: g.color ?? "#2F6BA8" }}
+              />
+              <span className="flex-1 min-w-0 font-medium truncate">{g.name}</span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={busy === g.id}
+                onClick={() => enable(g.id, g.name)}
+              >
+                Enable signups
+              </Button>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/serving/EmailTeamButton.tsx
+++ b/components/serving/EmailTeamButton.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "sonner";
+import { Mail } from "lucide-react";
+import { formatServiceDate } from "@/lib/serving/sundays";
+
+interface EmailTeamButtonProps {
+  groupId: string;
+  teamName: string;
+  openDates: string[];
+  memberCount: number;
+}
+
+/**
+ * Leader broadcast: previews the open Sundays the email will list, then sends
+ * every team member a message with one-tap signup links.
+ */
+export function EmailTeamButton({
+  groupId,
+  teamName,
+  openDates,
+  memberCount,
+}: EmailTeamButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const router = useRouter();
+
+  async function send() {
+    setSending(true);
+    const res = await fetch("/api/serving/broadcast", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ groupId, message: message.trim() || undefined }),
+    });
+    setSending(false);
+
+    if (res.ok) {
+      const data = await res.json();
+      toast.success(`Email sent to ${data.sent} team member${data.sent !== 1 ? "s" : ""}.`);
+      setOpen(false);
+      setMessage("");
+      router.refresh();
+    } else {
+      const body = await res.json().catch(() => null);
+      toast.error(body?.error || "Failed to send — please try again.");
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        onClick={() => setOpen(true)}
+        disabled={openDates.length === 0}
+      >
+        <Mail className="mr-2 h-4 w-4" />
+        Email the team
+      </Button>
+
+      <Dialog open={open} onOpenChange={(o) => !sending && setOpen(o)}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Email the {teamName}</DialogTitle>
+          </DialogHeader>
+
+          <p className="text-sm text-muted-foreground">
+            Everyone on the team ({memberCount} member{memberCount !== 1 ? "s" : ""})
+            will get an email listing the open Sundays below, each with a
+            one-tap signup button.
+          </p>
+
+          <ul className="text-sm list-disc pl-5 space-y-0.5 max-h-40 overflow-y-auto">
+            {openDates.map((d) => (
+              <li key={d}>{formatServiceDate(d)}</li>
+            ))}
+          </ul>
+
+          <div className="space-y-2">
+            <Label htmlFor="broadcast-message">
+              Add a personal note (optional)
+            </Label>
+            <Textarea
+              id="broadcast-message"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              maxLength={1000}
+              placeholder="e.g. We especially need help the last two Sundays of the month."
+            />
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              variant="ghost"
+              disabled={sending}
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={sending}
+              onClick={send}
+              className="bg-brand-primary hover:bg-brand-primary/90 text-white"
+            >
+              {sending ? "Sending..." : `Send to ${memberCount} member${memberCount !== 1 ? "s" : ""}`}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/serving/EmailTeamButton.tsx
+++ b/components/serving/EmailTeamButton.tsx
@@ -39,22 +39,27 @@ export function EmailTeamButton({
 
   async function send() {
     setSending(true);
-    const res = await fetch("/api/serving/broadcast", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ groupId, message: message.trim() || undefined }),
-    });
-    setSending(false);
+    try {
+      const res = await fetch("/api/serving/broadcast", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ groupId, message: message.trim() || undefined }),
+      });
 
-    if (res.ok) {
-      const data = await res.json();
-      toast.success(`Email sent to ${data.sent} team member${data.sent !== 1 ? "s" : ""}.`);
-      setOpen(false);
-      setMessage("");
-      router.refresh();
-    } else {
-      const body = await res.json().catch(() => null);
-      toast.error(body?.error || "Failed to send — please try again.");
+      if (res.ok) {
+        const data = await res.json();
+        toast.success(`Email sent to ${data.sent} team member${data.sent !== 1 ? "s" : ""}.`);
+        setOpen(false);
+        setMessage("");
+        router.refresh();
+      } else {
+        const body = await res.json().catch(() => null);
+        toast.error(body?.error || "Failed to send — please try again.");
+      }
+    } catch {
+      toast.error("Failed to send — please try again.");
+    } finally {
+      setSending(false);
     }
   }
 

--- a/components/serving/LinkActionConfirm.tsx
+++ b/components/serving/LinkActionConfirm.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { CheckCircle2 } from "lucide-react";
+
+interface LinkActionConfirmProps {
+  token: string;
+  action: "signup" | "cancel";
+  firstName: string;
+  teamName: string;
+  dateLabel: string;
+  spouseName: string | null;
+}
+
+/** The one explicit button press between a signed email link and the action. */
+export function LinkActionConfirm({
+  token,
+  action,
+  firstName,
+  teamName,
+  dateLabel,
+  spouseName,
+}: LinkActionConfirmProps) {
+  const [busy, setBusy] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(includeSpouse: boolean) {
+    setBusy(true);
+    setError(null);
+    const res = await fetch("/api/serving/link-action", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token, includeSpouse }),
+    });
+    setBusy(false);
+
+    if (res.ok) {
+      setDone(true);
+    } else {
+      const body = await res.json().catch(() => null);
+      setError(body?.error || "Something went wrong — please try again.");
+    }
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-20 max-w-lg text-center">
+      <Card className="p-8">
+        <CardContent className="pt-6">
+          {done ? (
+            <>
+              <CheckCircle2 className="h-12 w-12 text-green-600 mx-auto mb-4" />
+              <h1 className="font-serif text-3xl text-brand-primary mb-4">
+                {action === "signup" ? "You're all set!" : "Signup cancelled"}
+              </h1>
+              <p className="text-lg text-muted-foreground">
+                {action === "signup"
+                  ? `Thank you for serving with the ${teamName} on ${dateLabel}. A confirmation email with a calendar invitation is on its way.`
+                  : `Your ${dateLabel} signup is cancelled and the Sunday is open for someone else. Thank you for letting us know.`}
+              </p>
+            </>
+          ) : (
+            <>
+              <h1 className="font-serif text-3xl text-brand-primary mb-4">
+                {action === "signup" ? `Serve on ${dateLabel}?` : "Can't make it?"}
+              </h1>
+              <p className="text-lg text-muted-foreground mb-8">
+                {action === "signup"
+                  ? `Hi ${firstName}! Tap a button below and ${dateLabel} with the ${teamName} is yours.`
+                  : `Hi ${firstName}, tap the button to cancel your ${teamName} signup for ${dateLabel}. The Sunday will open back up for someone else.`}
+              </p>
+
+              <div className="flex flex-col gap-3">
+                {action === "signup" ? (
+                  <>
+                    <Button
+                      size="lg"
+                      disabled={busy}
+                      onClick={() => submit(false)}
+                      className="text-lg py-6 bg-brand-primary hover:bg-brand-primary/90 text-white"
+                    >
+                      {spouseName ? "Just me" : "Yes, I'll serve"}
+                    </Button>
+                    {spouseName && (
+                      <Button
+                        size="lg"
+                        disabled={busy}
+                        onClick={() => submit(true)}
+                        className="text-lg py-6 bg-brand-primary hover:bg-brand-primary/90 text-white"
+                      >
+                        Me &amp; {spouseName}
+                      </Button>
+                    )}
+                  </>
+                ) : (
+                  <Button
+                    size="lg"
+                    disabled={busy}
+                    onClick={() => submit(false)}
+                    variant="destructive"
+                    className="text-lg py-6"
+                  >
+                    Yes, cancel my signup
+                  </Button>
+                )}
+              </div>
+
+              {error && <p className="text-destructive mt-4">{error}</p>}
+            </>
+          )}
+
+          <Link
+            href="/serving"
+            className="inline-block mt-8 text-brand-primary hover:underline text-lg"
+          >
+            See the full serving schedule
+          </Link>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/serving/LinkActionConfirm.tsx
+++ b/components/serving/LinkActionConfirm.tsx
@@ -31,18 +31,23 @@ export function LinkActionConfirm({
   async function submit(includeSpouse: boolean) {
     setBusy(true);
     setError(null);
-    const res = await fetch("/api/serving/link-action", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ token, includeSpouse }),
-    });
-    setBusy(false);
+    try {
+      const res = await fetch("/api/serving/link-action", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, includeSpouse }),
+      });
 
-    if (res.ok) {
-      setDone(true);
-    } else {
-      const body = await res.json().catch(() => null);
-      setError(body?.error || "Something went wrong — please try again.");
+      if (res.ok) {
+        setDone(true);
+      } else {
+        const body = await res.json().catch(() => null);
+        setError(body?.error || "Something went wrong — please try again.");
+      }
+    } catch {
+      setError("Something went wrong — please try again.");
+    } finally {
+      setBusy(false);
     }
   }
 

--- a/components/serving/ServingSchedule.tsx
+++ b/components/serving/ServingSchedule.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import { CheckCircle2, X } from "lucide-react";
+import { daysUntilService, formatServiceDate } from "@/lib/serving/sundays";
+
+export interface ScheduleEntry {
+  id: string;
+  date: string;
+  createdBy: string;
+  attendeeIds: string[];
+  label: string;
+}
+
+interface ServingScheduleProps {
+  groupId: string;
+  teamName: string;
+  sundays: string[];
+  entries: Record<string, ScheduleEntry>;
+  userId: string;
+  spouse: { id: string; name: string } | null;
+  canSignUp: boolean;
+  canManage: boolean;
+}
+
+/**
+ * Vertical list of upcoming Sundays with one big "I'll do it" button per open
+ * week — deliberately not a month-grid calendar.
+ */
+export function ServingSchedule({
+  groupId,
+  teamName,
+  sundays,
+  entries,
+  userId,
+  spouse,
+  canSignUp,
+  canManage,
+}: ServingScheduleProps) {
+  const [pickerDate, setPickerDate] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const router = useRouter();
+
+  async function signUp(date: string, attendeeProfileIds: string[]) {
+    setBusy(true);
+    const res = await fetch("/api/serving/signups", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ groupId, serviceDate: date, attendeeProfileIds }),
+    });
+    setBusy(false);
+    setPickerDate(null);
+
+    if (res.ok) {
+      toast.success(
+        `You're signed up for ${formatServiceDate(date)}! A confirmation email is on its way.`
+      );
+    } else {
+      const body = await res.json().catch(() => null);
+      toast.error(body?.error || "Something went wrong — please try again.");
+    }
+    router.refresh();
+  }
+
+  async function cancel(entry: ScheduleEntry) {
+    const mine = entry.attendeeIds.includes(userId) || entry.createdBy === userId;
+    const message = mine
+      ? `Cancel your signup for ${formatServiceDate(entry.date)}? The Sunday will open back up for someone else.`
+      : `Remove ${entry.label} from ${formatServiceDate(entry.date)}?`;
+    if (!confirm(message)) return;
+
+    setBusy(true);
+    const res = await fetch("/api/serving/signups", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ signupId: entry.id }),
+    });
+    setBusy(false);
+
+    if (res.ok) {
+      toast.success("Signup cancelled.");
+    } else {
+      const body = await res.json().catch(() => null);
+      toast.error(body?.error || "Failed to cancel — please try again.");
+    }
+    router.refresh();
+  }
+
+  function handleTake(date: string) {
+    if (spouse) {
+      setPickerDate(date);
+    } else {
+      signUp(date, [userId]);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {sundays.map((date) => {
+        const entry = entries[date];
+        const mine =
+          entry &&
+          (entry.attendeeIds.includes(userId) || entry.createdBy === userId);
+        const days = daysUntilService(date);
+
+        return (
+          <Card
+            key={date}
+            className={entry ? "bg-muted/40" : "border-brand-primary/30"}
+          >
+            <CardContent className="py-4 flex items-center gap-4">
+              <div className="flex-1 min-w-0">
+                <p className="text-lg font-semibold">{formatServiceDate(date)}</p>
+                {entry ? (
+                  <p className="text-muted-foreground flex items-center gap-1.5">
+                    <CheckCircle2 className="h-4 w-4 text-green-600 shrink-0" />
+                    {mine ? (
+                      <span>
+                        <strong>You&apos;re serving</strong>
+                        {entry.attendeeIds.length > 1 ? ` — ${entry.label}` : ""}
+                      </span>
+                    ) : (
+                      <span>{entry.label}</span>
+                    )}
+                  </p>
+                ) : (
+                  <p className="text-muted-foreground">
+                    {days === 0 ? "Today — still open" : "Still needs someone"}
+                  </p>
+                )}
+              </div>
+
+              {!entry && canSignUp && (
+                <Button
+                  size="lg"
+                  disabled={busy}
+                  onClick={() => handleTake(date)}
+                  className="text-lg px-6 py-6 bg-brand-primary hover:bg-brand-primary/90 text-white shrink-0"
+                >
+                  I&apos;ll do it
+                </Button>
+              )}
+
+              {entry && mine && (
+                <Button
+                  variant="outline"
+                  disabled={busy}
+                  onClick={() => cancel(entry)}
+                  className="shrink-0"
+                >
+                  Can&apos;t make it?
+                </Button>
+              )}
+
+              {entry && !mine && canManage && (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  disabled={busy}
+                  onClick={() => cancel(entry)}
+                  aria-label={`Remove ${entry.label}`}
+                  className="text-muted-foreground hover:text-destructive shrink-0"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+        );
+      })}
+
+      <Dialog
+        open={!!pickerDate}
+        onOpenChange={(o) => !o && !busy && setPickerDate(null)}
+      >
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="text-xl">
+              {pickerDate ? formatServiceDate(pickerDate) : ""} — {teamName}
+            </DialogTitle>
+          </DialogHeader>
+          <p className="text-muted-foreground">Who&apos;s coming?</p>
+          <div className="flex flex-col gap-3 pt-2">
+            <Button
+              size="lg"
+              disabled={busy}
+              onClick={() => pickerDate && signUp(pickerDate, [userId])}
+              className="text-lg py-6 bg-brand-primary hover:bg-brand-primary/90 text-white"
+            >
+              Just me
+            </Button>
+            {spouse && (
+              <Button
+                size="lg"
+                disabled={busy}
+                onClick={() =>
+                  pickerDate && signUp(pickerDate, [userId, spouse.id])
+                }
+                className="text-lg py-6 bg-brand-primary hover:bg-brand-primary/90 text-white"
+              >
+                Me &amp; {spouse.name}
+              </Button>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/components/serving/ServingSchedule.tsx
+++ b/components/serving/ServingSchedule.tsx
@@ -53,21 +53,26 @@ export function ServingSchedule({
 
   async function signUp(date: string, attendeeProfileIds: string[]) {
     setBusy(true);
-    const res = await fetch("/api/serving/signups", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ groupId, serviceDate: date, attendeeProfileIds }),
-    });
-    setBusy(false);
-    setPickerDate(null);
+    try {
+      const res = await fetch("/api/serving/signups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ groupId, serviceDate: date, attendeeProfileIds }),
+      });
 
-    if (res.ok) {
-      toast.success(
-        `You're signed up for ${formatServiceDate(date)}! A confirmation email is on its way.`
-      );
-    } else {
-      const body = await res.json().catch(() => null);
-      toast.error(body?.error || "Something went wrong — please try again.");
+      if (res.ok) {
+        toast.success(
+          `You're signed up for ${formatServiceDate(date)}! A confirmation email is on its way.`
+        );
+      } else {
+        const body = await res.json().catch(() => null);
+        toast.error(body?.error || "Something went wrong — please try again.");
+      }
+    } catch {
+      toast.error("Something went wrong — please try again.");
+    } finally {
+      setBusy(false);
+      setPickerDate(null);
     }
     router.refresh();
   }
@@ -80,18 +85,23 @@ export function ServingSchedule({
     if (!confirm(message)) return;
 
     setBusy(true);
-    const res = await fetch("/api/serving/signups", {
-      method: "DELETE",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ signupId: entry.id }),
-    });
-    setBusy(false);
+    try {
+      const res = await fetch("/api/serving/signups", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ signupId: entry.id }),
+      });
 
-    if (res.ok) {
-      toast.success("Signup cancelled.");
-    } else {
-      const body = await res.json().catch(() => null);
-      toast.error(body?.error || "Failed to cancel — please try again.");
+      if (res.ok) {
+        toast.success("Signup cancelled.");
+      } else {
+        const body = await res.json().catch(() => null);
+        toast.error(body?.error || "Failed to cancel — please try again.");
+      }
+    } catch {
+      toast.error("Failed to cancel — please try again.");
+    } finally {
+      setBusy(false);
     }
     router.refresh();
   }

--- a/components/serving/ServingSettingsDialog.tsx
+++ b/components/serving/ServingSettingsDialog.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Settings } from "lucide-react";
+import { toast } from "sonner";
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+interface ServingSettingsDialogProps {
+  groupId: string;
+  settings: {
+    enabled: boolean;
+    reminder_days: number[];
+    window_weeks: number;
+  } | null;
+}
+
+export function ServingSettingsDialog({ groupId, settings }: ServingSettingsDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [enabled, setEnabled] = useState(settings?.enabled ?? false);
+  const [reminderDays, setReminderDays] = useState<number[]>(settings?.reminder_days ?? [4, 5]);
+  const [windowWeeks, setWindowWeeks] = useState(settings?.window_weeks ?? 8);
+  const [saving, setSaving] = useState(false);
+  const router = useRouter();
+  const supabase = createClient();
+
+  function toggleDay(dow: number) {
+    setReminderDays((prev) =>
+      prev.includes(dow) ? prev.filter((d) => d !== dow) : [...prev, dow].sort()
+    );
+  }
+
+  async function save() {
+    setSaving(true);
+    const { error } = await supabase.from("serving_team_settings").upsert({
+      group_id: groupId,
+      enabled,
+      reminder_days: reminderDays,
+      window_weeks: Math.max(1, Math.min(26, windowWeeks)),
+    });
+    setSaving(false);
+
+    if (error) {
+      toast.error("Failed to save settings.");
+      return;
+    }
+    toast.success("Settings saved.");
+    setOpen(false);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <Button variant="outline" size="sm" className="gap-1.5" onClick={() => setOpen(true)}>
+        <Settings className="h-4 w-4" />
+        Team settings
+      </Button>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Serving team settings</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-6 py-2">
+          {/* Enabled */}
+          <div className="flex items-center justify-between">
+            <Label htmlFor="st-enabled" className="text-base">
+              Signups enabled
+            </Label>
+            <Switch
+              id="st-enabled"
+              checked={enabled}
+              onCheckedChange={setEnabled}
+            />
+          </div>
+
+          {/* Reminder days */}
+          <div className="space-y-2">
+            <Label className="text-base">Reminder days</Label>
+            <p className="text-xs text-muted-foreground">
+              Send reminder emails on these days of the week.
+            </p>
+            <div className="flex flex-wrap gap-2 pt-1">
+              {DAY_LABELS.map((label, dow) => (
+                <button
+                  key={dow}
+                  type="button"
+                  onClick={() => toggleDay(dow)}
+                  className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
+                    reminderDays.includes(dow)
+                      ? "bg-brand-primary text-white border-brand-primary"
+                      : "border-border text-muted-foreground hover:border-brand-primary/50"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Window weeks */}
+          <div className="space-y-2">
+            <Label htmlFor="st-weeks" className="text-base">
+              Schedule window (weeks)
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              How many upcoming Sundays to show (1–26).
+            </p>
+            <input
+              id="st-weeks"
+              type="number"
+              min={1}
+              max={26}
+              value={windowWeeks}
+              onChange={(e) => setWindowWeeks(Number(e.target.value))}
+              className="w-24 rounded-md border border-border bg-background px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-brand-primary"
+            />
+          </div>
+
+          <Button
+            onClick={save}
+            disabled={saving}
+            className="w-full bg-brand-primary hover:bg-brand-primary/90 text-white"
+          >
+            {saving ? "Saving…" : "Save settings"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/serving/ServingSettingsDialog.tsx
+++ b/components/serving/ServingSettingsDialog.tsx
@@ -43,11 +43,15 @@ export function ServingSettingsDialog({ groupId, settings }: ServingSettingsDial
 
   async function save() {
     setSaving(true);
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
     const { error } = await supabase.from("serving_team_settings").upsert({
       group_id: groupId,
       enabled,
       reminder_days: reminderDays,
       window_weeks: Math.max(1, Math.min(26, windowWeeks)),
+      updated_by: user?.id,
     });
     setSaving(false);
 
@@ -95,6 +99,7 @@ export function ServingSettingsDialog({ groupId, settings }: ServingSettingsDial
                 <button
                   key={dow}
                   type="button"
+                  aria-pressed={reminderDays.includes(dow)}
                   onClick={() => toggleDay(dow)}
                   className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
                     reminderDays.includes(dow)

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -44,7 +44,7 @@ export async function sendInviteEmail(
   }
 }
 
-function escapeHtml(str: string): string {
+export function escapeHtml(str: string): string {
   return str
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")

--- a/lib/email/serving.ts
+++ b/lib/email/serving.ts
@@ -1,0 +1,162 @@
+/**
+ * Serving signup emails. Email is the front door for this feature — every
+ * message deep-links straight to the action it asks for.
+ */
+import { Resend } from "resend";
+import { siteConfig } from "@/lib/config";
+import { escapeHtml } from "@/lib/email/resend";
+import { formatServiceDateWithYear } from "@/lib/serving/sundays";
+
+function getResend() {
+  return new Resend(process.env.RESEND_API_KEY);
+}
+
+const bodyText = `font-size: 18px; line-height: 1.6; color: #44403c;`;
+const bigButton = `display: inline-block; background-color: ${siteConfig.colors.primary}; color: white; padding: 16px 32px; text-decoration: none; border-radius: 8px; font-size: 18px; margin-top: 20px;`;
+const footer = `font-size: 14px; color: #78716c; margin-top: 40px;`;
+
+function wrap(inner: string): string {
+  return `
+    <div style="font-family: Georgia, serif; max-width: 600px; margin: 0 auto; padding: 40px 20px;">
+      ${inner}
+      <p style="${footer}">&mdash; The ${siteConfig.name} Team</p>
+    </div>
+  `;
+}
+
+export async function sendServingConfirmationEmail(opts: {
+  to: string;
+  name: string;
+  teamName: string;
+  serviceDate: string;
+  attendeesLabel: string;
+  cancelUrl: string;
+  icsContent: string;
+}) {
+  const dateLabel = formatServiceDateWithYear(opts.serviceDate);
+  const { error } = await getResend().emails.send({
+    from: siteConfig.email.from,
+    to: opts.to,
+    subject: `You're signed up: ${opts.teamName}, ${dateLabel}`,
+    html: wrap(`
+      <h1 style="color: ${siteConfig.colors.primary}; font-size: 28px;">You're all set!</h1>
+      <p style="${bodyText}">
+        Hi ${escapeHtml(opts.name)}, thank you for serving with the
+        <strong>${escapeHtml(opts.teamName)}</strong>.
+      </p>
+      <div style="background: #fef3c7; padding: 20px; border-radius: 8px; margin: 20px 0;">
+        <p style="font-size: 18px; margin: 0; color: #44403c;">
+          <strong>When:</strong> ${dateLabel}
+        </p>
+        <p style="font-size: 18px; margin: 8px 0 0; color: #44403c;">
+          <strong>Who:</strong> ${escapeHtml(opts.attendeesLabel)}
+        </p>
+      </div>
+      <p style="${bodyText}">
+        A calendar invitation is attached so you can add it to your calendar.
+      </p>
+      <p style="${footer}">
+        Can&rsquo;t make it after all? No problem &mdash;
+        <a href="${opts.cancelUrl}" style="color: ${siteConfig.colors.primaryLight};">click here to cancel</a>
+        and the Sunday will open back up for someone else.
+      </p>
+    `),
+    attachments: [
+      {
+        filename: `serving-${opts.serviceDate}.ics`,
+        content: Buffer.from(opts.icsContent).toString("base64"),
+      },
+    ],
+  });
+
+  if (error) {
+    console.error("Failed to send serving confirmation email:", error);
+    throw error;
+  }
+}
+
+/** Quiet heads-up to a team leader when a signup is cancelled. */
+export async function sendServingCancelNoticeEmail(opts: {
+  to: string;
+  leaderName: string;
+  memberLabel: string;
+  teamName: string;
+  serviceDate: string;
+  servingUrl: string;
+}) {
+  const dateLabel = formatServiceDateWithYear(opts.serviceDate);
+  const { error } = await getResend().emails.send({
+    from: siteConfig.email.from,
+    to: opts.to,
+    subject: `${opts.teamName}: ${dateLabel} is open again`,
+    html: wrap(`
+      <h1 style="color: ${siteConfig.colors.primary}; font-size: 28px;">A Sunday opened up</h1>
+      <p style="${bodyText}">
+        Hi ${escapeHtml(opts.leaderName)},
+        <strong>${escapeHtml(opts.memberLabel)}</strong> can no longer serve with the
+        <strong>${escapeHtml(opts.teamName)}</strong> on <strong>${dateLabel}</strong>,
+        so that Sunday is open again.
+      </p>
+      <a href="${opts.servingUrl}" style="${bigButton}">View the Schedule</a>
+    `),
+  });
+
+  if (error) {
+    console.error("Failed to send serving cancel notice:", error);
+    throw error;
+  }
+}
+
+/** Leader broadcast listing the open Sundays, each with its own action link. */
+export async function sendServingBroadcastEmail(opts: {
+  to: string;
+  name: string;
+  teamName: string;
+  fromName: string;
+  message?: string;
+  openDates: { date: string; url: string }[];
+}) {
+  const rows = opts.openDates
+    .map(
+      ({ date, url }) => `
+        <table role="presentation" width="100%" style="border-bottom: 1px solid #e7e5e4;">
+          <tr>
+            <td style="padding: 14px 0; font-size: 18px; color: #44403c;">
+              ${formatServiceDateWithYear(date)}
+            </td>
+            <td align="right" style="padding: 14px 0;">
+              <a href="${url}"
+                 style="display: inline-block; background-color: ${siteConfig.colors.primary}; color: white; padding: 10px 20px; text-decoration: none; border-radius: 8px; font-size: 16px; white-space: nowrap;">
+                I&rsquo;ll do it
+              </a>
+            </td>
+          </tr>
+        </table>`
+    )
+    .join("");
+
+  const { error } = await getResend().emails.send({
+    from: siteConfig.email.from,
+    to: opts.to,
+    subject: `${opts.teamName}: Sundays that still need someone`,
+    html: wrap(`
+      <h1 style="color: ${siteConfig.colors.primary}; font-size: 28px;">Can you take a Sunday?</h1>
+      <p style="${bodyText}">
+        Hi ${escapeHtml(opts.name)}, ${escapeHtml(opts.fromName)} is looking for
+        volunteers from the <strong>${escapeHtml(opts.teamName)}</strong> for the
+        Sundays below. Tap a button and you&rsquo;re signed up &mdash; that&rsquo;s it.
+      </p>
+      ${opts.message ? `<p style="${bodyText}">${escapeHtml(opts.message)}</p>` : ""}
+      ${rows}
+      <p style="${footer}">
+        Already spoken for? You can always see who&rsquo;s covering each week at
+        <a href="${siteConfig.url}/serving" style="color: ${siteConfig.colors.primaryLight};">${siteConfig.url}/serving</a>.
+      </p>
+    `),
+  });
+
+  if (error) {
+    console.error("Failed to send serving broadcast email:", error);
+    throw error;
+  }
+}

--- a/lib/ics-utils.ts
+++ b/lib/ics-utils.ts
@@ -81,3 +81,22 @@ export function generateServingICS(input: ServingICSInput): string {
   }
   return value;
 }
+
+/** Combined feed: group events + serving signups in a single VCALENDAR. */
+export function generateCombinedICS(
+  events: Event[],
+  servingSignups: ServingICSInput[]
+): string {
+  const all: EventAttributes[] = [
+    ...events.map(eventToICSAttributes),
+    ...servingSignups.map(servingToICSAttributes),
+  ];
+  if (all.length === 0) {
+    return "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Small Group Hub//EN\r\nEND:VCALENDAR\r\n";
+  }
+  const { error, value } = createEvents(all);
+  if (error || !value) {
+    throw new Error(`Failed to generate ICS: ${error?.message ?? "unknown error"}`);
+  }
+  return value;
+}

--- a/lib/ics-utils.ts
+++ b/lib/ics-utils.ts
@@ -51,3 +51,33 @@ export function generateMultiEventICS(events: Event[]): string {
   }
   return value;
 }
+
+export interface ServingICSInput {
+  signupId: string;
+  /** YYYY-MM-DD */
+  serviceDate: string;
+  teamName: string;
+  description?: string;
+}
+
+/** All-day calendar entry for a serving Sunday (3-element dates → VALUE=DATE). */
+export function servingToICSAttributes(input: ServingICSInput): EventAttributes {
+  const [y, m, d] = input.serviceDate.split("-").map(Number);
+  const next = new Date(y, m - 1, d + 1);
+  return {
+    uid: `serving-${input.signupId}`,
+    title: `Serving: ${input.teamName}`,
+    start: [y, m, d],
+    end: [next.getFullYear(), next.getMonth() + 1, next.getDate()],
+    status: "CONFIRMED",
+    ...(input.description ? { description: input.description } : {}),
+  };
+}
+
+export function generateServingICS(input: ServingICSInput): string {
+  const { error, value } = createEvents([servingToICSAttributes(input)]);
+  if (error || !value) {
+    throw new Error(`Failed to generate ICS: ${error?.message ?? "unknown error"}`);
+  }
+  return value;
+}

--- a/lib/serving/config.ts
+++ b/lib/serving/config.ts
@@ -1,0 +1,21 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * 'signed' — serving email links act without logging in (HMAC-verified).
+ * 'login' — links send members through the normal login first.
+ * The site_settings row wins; SERVING_LINK_MODE is the self-hoster default.
+ */
+export type ServingLinkMode = "signed" | "login";
+
+export async function getServingLinkMode(
+  supabase: SupabaseClient
+): Promise<ServingLinkMode> {
+  const { data } = await supabase
+    .from("site_settings")
+    .select("value")
+    .eq("key", "serving_link_mode")
+    .maybeSingle();
+
+  const value = data?.value || process.env.SERVING_LINK_MODE || "signed";
+  return value === "login" ? "login" : "signed";
+}

--- a/lib/serving/config.ts
+++ b/lib/serving/config.ts
@@ -10,11 +10,14 @@ export type ServingLinkMode = "signed" | "login";
 export async function getServingLinkMode(
   supabase: SupabaseClient
 ): Promise<ServingLinkMode> {
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("site_settings")
     .select("value")
     .eq("key", "serving_link_mode")
     .maybeSingle();
+  if (error) {
+    console.debug("Failed to load serving link mode from site_settings:", error);
+  }
 
   const value = data?.value || process.env.SERVING_LINK_MODE || "signed";
   return value === "login" ? "login" : "signed";

--- a/lib/serving/display.ts
+++ b/lib/serving/display.ts
@@ -1,0 +1,23 @@
+import { displayName } from "@/lib/names";
+
+interface AttendeeNameParts {
+  first_name: string | null;
+  last_name: string | null;
+  preferred_name?: string | null;
+}
+
+/**
+ * Display name for a serving signup. A couple serving together shows as
+ * their household ("The Smiths"); a single attendee shows individually
+ * ("Danny Smith"). Falls back to joined names when a couple has no
+ * household name on file.
+ */
+export function signupDisplayName(
+  attendees: AttendeeNameParts[],
+  familyName: string | null
+): string {
+  if (attendees.length === 0) return "(unnamed)";
+  if (attendees.length === 1) return displayName(attendees[0]);
+  if (familyName) return familyName;
+  return attendees.map((a) => displayName(a)).join(" & ");
+}

--- a/lib/serving/links.ts
+++ b/lib/serving/links.ts
@@ -1,0 +1,81 @@
+/**
+ * Signed action links for serving emails. Lets members act straight from an
+ * email without logging in (configurable — see lib/serving/config.ts).
+ *
+ * Token format: base64url(JSON payload) + "." + base64url(HMAC-SHA256).
+ * The Deno edge function (send-serving-reminders) mints tokens in the same
+ * format — keep the payload shape in sync.
+ */
+import crypto from "crypto";
+
+export interface ServingLinkPayload {
+  v: 1;
+  /** What the link does when confirmed */
+  a: "signup" | "cancel";
+  /** Group (team) id */
+  g: string;
+  /** Service date YYYY-MM-DD */
+  d: string;
+  /** Profile id the link acts on behalf of */
+  p: string;
+  /** Expiry, unix seconds */
+  exp: number;
+}
+
+function getSecret(): string {
+  const secret = process.env.SERVING_LINK_SECRET;
+  if (!secret) {
+    throw new Error("SERVING_LINK_SECRET is not set");
+  }
+  return secret;
+}
+
+function sign(payloadB64: string): string {
+  return crypto
+    .createHmac("sha256", getSecret())
+    .update(payloadB64)
+    .digest("base64url");
+}
+
+export function createServingToken(
+  payload: Omit<ServingLinkPayload, "v" | "exp">,
+  ttlDays = 60
+): string {
+  const full: ServingLinkPayload = {
+    v: 1,
+    ...payload,
+    exp: Math.floor(Date.now() / 1000) + ttlDays * 86400,
+  };
+  const payloadB64 = Buffer.from(JSON.stringify(full)).toString("base64url");
+  return `${payloadB64}.${sign(payloadB64)}`;
+}
+
+/** Returns the payload when the token is authentic and unexpired, else null. */
+export function verifyServingToken(token: string): ServingLinkPayload | null {
+  const dot = token.lastIndexOf(".");
+  if (dot <= 0) return null;
+  const payloadB64 = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+
+  const expected = sign(payloadB64);
+  const sigBuf = Buffer.from(sig);
+  const expectedBuf = Buffer.from(expected);
+  if (
+    sigBuf.length !== expectedBuf.length ||
+    !crypto.timingSafeEqual(sigBuf, expectedBuf)
+  ) {
+    return null;
+  }
+
+  let payload: ServingLinkPayload;
+  try {
+    payload = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+
+  if (payload.v !== 1) return null;
+  if (payload.exp < Math.floor(Date.now() / 1000)) return null;
+  if (payload.a !== "signup" && payload.a !== "cancel") return null;
+  return payload;
+}

--- a/lib/serving/server.ts
+++ b/lib/serving/server.ts
@@ -105,13 +105,17 @@ export async function notifyLeadersOfCancel(
       | (NamedProfile & { email: string | null })
       | null;
     if (!leader?.email || leader.id === opts.excludeProfileId) continue;
-    await sendServingCancelNoticeEmail({
-      to: leader.email,
-      leaderName: displayName(leader),
-      memberLabel: opts.memberLabel,
-      teamName: opts.groupName,
-      serviceDate: opts.serviceDate,
-      servingUrl: `${siteConfig.url}/serving/${opts.groupId}`,
-    });
+    try {
+      await sendServingCancelNoticeEmail({
+        to: leader.email,
+        leaderName: displayName(leader),
+        memberLabel: opts.memberLabel,
+        teamName: opts.groupName,
+        serviceDate: opts.serviceDate,
+        servingUrl: `${siteConfig.url}/serving/${opts.groupId}`,
+      });
+    } catch (err) {
+      console.error("Failed to send serving cancel notice to leader:", leader.id, err);
+    }
   }
 }

--- a/lib/serving/server.ts
+++ b/lib/serving/server.ts
@@ -1,0 +1,117 @@
+/**
+ * Server-side serving helpers shared by the in-app signup API and the
+ * signed email-link API. Callers wrap these in try/catch — email failures
+ * must never undo a successful signup or cancel.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { siteConfig } from "@/lib/config";
+import { displayName } from "@/lib/names";
+import { generateServingICS } from "@/lib/ics-utils";
+import { getServingLinkMode } from "@/lib/serving/config";
+import { signupDisplayName } from "@/lib/serving/display";
+import { createServingToken } from "@/lib/serving/links";
+import {
+  sendServingCancelNoticeEmail,
+  sendServingConfirmationEmail,
+} from "@/lib/email/serving";
+
+export interface NamedProfile {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  preferred_name: string | null;
+}
+
+export async function resolveSignupLabel(
+  supabase: SupabaseClient,
+  attendees: NamedProfile[],
+  familyId: string | null
+): Promise<string> {
+  let familyName: string | null = null;
+  if (attendees.length > 1 && familyId) {
+    const { data: family } = await supabase
+      .from("family_units")
+      .select("family_name")
+      .eq("id", familyId)
+      .single();
+    familyName = family?.family_name ?? null;
+  }
+  return signupDisplayName(attendees, familyName);
+}
+
+export async function sendSignupConfirmation(
+  supabase: SupabaseClient,
+  opts: {
+    signupId: string;
+    groupId: string;
+    groupName: string;
+    serviceDate: string;
+    attendees: NamedProfile[];
+    familyId: string | null;
+    recipient: { id: string; email: string; name: string };
+  }
+) {
+  const attendeesLabel = await resolveSignupLabel(
+    supabase,
+    opts.attendees,
+    opts.familyId
+  );
+
+  const linkMode = await getServingLinkMode(supabase);
+  const cancelUrl =
+    linkMode === "signed"
+      ? `${siteConfig.url}/serving/go?token=${createServingToken({
+          a: "cancel",
+          g: opts.groupId,
+          d: opts.serviceDate,
+          p: opts.recipient.id,
+        })}`
+      : `${siteConfig.url}/serving/${opts.groupId}`;
+
+  await sendServingConfirmationEmail({
+    to: opts.recipient.email,
+    name: opts.recipient.name,
+    teamName: opts.groupName,
+    serviceDate: opts.serviceDate,
+    attendeesLabel,
+    cancelUrl,
+    icsContent: generateServingICS({
+      signupId: opts.signupId,
+      serviceDate: opts.serviceDate,
+      teamName: opts.groupName,
+    }),
+  });
+}
+
+/** Quietly tell the team's leaders a Sunday opened back up. */
+export async function notifyLeadersOfCancel(
+  service: SupabaseClient,
+  opts: {
+    groupId: string;
+    groupName: string;
+    serviceDate: string;
+    memberLabel: string;
+    excludeProfileId?: string;
+  }
+) {
+  const { data: leaders } = await service
+    .from("profile_groups")
+    .select("profiles(id, first_name, last_name, preferred_name, email)")
+    .eq("group_id", opts.groupId)
+    .eq("is_leader", true);
+
+  for (const row of leaders ?? []) {
+    const leader = row.profiles as unknown as
+      | (NamedProfile & { email: string | null })
+      | null;
+    if (!leader?.email || leader.id === opts.excludeProfileId) continue;
+    await sendServingCancelNoticeEmail({
+      to: leader.email,
+      leaderName: displayName(leader),
+      memberLabel: opts.memberLabel,
+      teamName: opts.groupName,
+      serviceDate: opts.serviceDate,
+      servingUrl: `${siteConfig.url}/serving/${opts.groupId}`,
+    });
+  }
+}

--- a/lib/serving/sundays.ts
+++ b/lib/serving/sundays.ts
@@ -1,0 +1,66 @@
+/**
+ * Sunday date helpers for serving signups. Slots are lazy — upcoming Sundays
+ * are computed here and signup rows only exist for covered dates.
+ */
+
+/** Format a Date as YYYY-MM-DD in local time (matches Postgres `date`). */
+export function toDateString(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * The next `weeks` Sunday dates as YYYY-MM-DD strings, starting with today
+ * when today is a Sunday.
+ */
+export function upcomingSundays(weeks: number, from: Date = new Date()): string[] {
+  const d = new Date(from);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() + ((7 - d.getDay()) % 7));
+
+  const sundays: string[] = [];
+  for (let i = 0; i < weeks; i++) {
+    sundays.push(toDateString(d));
+    d.setDate(d.getDate() + 7);
+  }
+  return sundays;
+}
+
+/** "Sunday, July 12" — for buttons, emails, and confirmations. */
+export function formatServiceDate(dateStr: string): string {
+  return new Date(dateStr + "T00:00:00").toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+/** "Sunday, July 12, 2026" — when the year matters (emails, ICS text). */
+export function formatServiceDateWithYear(dateStr: string): string {
+  return new Date(dateStr + "T00:00:00").toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+/** True when the string is a well-formed YYYY-MM-DD for a Sunday not in the past. */
+export function isValidServiceDate(dateStr: string, from: Date = new Date()): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return false;
+  const d = new Date(dateStr + "T00:00:00");
+  if (isNaN(d.getTime()) || d.getDay() !== 0) return false;
+  const today = new Date(from);
+  today.setHours(0, 0, 0, 0);
+  return dateStr >= toDateString(today);
+}
+
+/** Days from today (local midnight) until the given service date. */
+export function daysUntilService(dateStr: string, from: Date = new Date()): number {
+  const today = new Date(from);
+  today.setHours(0, 0, 0, 0);
+  const target = new Date(dateStr + "T00:00:00");
+  return Math.round((target.getTime() - today.getTime()) / 86400000);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -234,6 +234,48 @@ export interface ProfileGroup {
   group_id: string;
   assigned_by: string | null;
   assigned_at: string;
+  /** Leader of this group only — no global leader role */
+  is_leader: boolean;
+}
+
+/** Per-group serving signup configuration */
+export interface ServingTeamSettings {
+  group_id: string;
+  enabled: boolean;
+  /** Days of week to send reminders (0=Sunday .. 6=Saturday) */
+  reminder_days: number[];
+  reminder_method: "email";
+  /** How many upcoming Sundays to show / email about */
+  window_weeks: number;
+  updated_by: string | null;
+  updated_at: string;
+}
+
+/** One covered Sunday for one serving team */
+export interface ServingSignup {
+  id: string;
+  group_id: string;
+  /** YYYY-MM-DD */
+  service_date: string;
+  family_id: string | null;
+  created_by: string;
+  created_at: string;
+}
+
+export interface ServingSignupAttendee {
+  signup_id: string;
+  profile_id: string;
+}
+
+/** Log entry for a leader "Email the team" send */
+export interface ServingBroadcast {
+  id: string;
+  group_id: string;
+  sent_by: string | null;
+  subject: string;
+  open_dates: string[];
+  recipient_count: number;
+  created_at: string;
 }
 
 /** Minimal group info embedded in directory views */

--- a/supabase/functions/send-serving-reminders/index.ts
+++ b/supabase/functions/send-serving-reminders/index.ts
@@ -1,0 +1,272 @@
+// Supabase Edge Function: send-serving-reminders
+// Runs daily via pg_cron. For each enabled serving team where today is a
+// reminder day, emails attendees if the next Sunday is covered, or nudges
+// all team members if it's still open.
+//
+// pg_cron setup (run once in Supabase SQL editor — never by CI):
+//
+//   select cron.schedule(
+//     'send-serving-reminders',
+//     '0 8 * * *',
+//     $$
+//       select net.http_post(
+//         url := '<SUPABASE_PROJECT_URL>/functions/v1/send-serving-reminders',
+//         headers := '{"Authorization":"Bearer <SERVICE_ROLE_KEY>","Content-Type":"application/json"}'::jsonb,
+//         body := '{}'::jsonb
+//       );
+//     $$
+//   );
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY")!;
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SECRET_KEY = Deno.env.get("SUPABASE_SECRET_KEY")!;
+const SITE_URL = Deno.env.get("SITE_URL") || "https://incouragers.org";
+const EMAIL_FROM = Deno.env.get("EMAIL_FROM") || "Incouragers <noreply@incouragers.org>";
+const APP_NAME = Deno.env.get("APP_NAME") || "Incouragers";
+const BRAND_COLOR = Deno.env.get("BRAND_COLOR") || "#2F6BA8";
+const SERVING_LINK_SECRET = Deno.env.get("SERVING_LINK_SECRET");
+const SERVING_LINK_MODE = Deno.env.get("SERVING_LINK_MODE") || "signed";
+
+// ── HMAC token (same format as lib/serving/links.ts) ─────────────────────────
+
+interface ServingLinkPayload {
+  v: 1;
+  a: "signup" | "cancel";
+  g: string;
+  d: string;
+  p: string;
+  exp: number;
+}
+
+function b64url(buf: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(buf)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+}
+
+function b64urlStr(str: string): string {
+  const bytes = new TextEncoder().encode(str);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+async function hmacSign(message: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  return b64url(await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(message)));
+}
+
+async function createToken(
+  payload: Omit<ServingLinkPayload, "v" | "exp">,
+  secret: string,
+  ttlDays = 60
+): Promise<string> {
+  const full: ServingLinkPayload = {
+    v: 1,
+    ...payload,
+    exp: Math.floor(Date.now() / 1000) + ttlDays * 86400,
+  };
+  const payloadB64 = b64urlStr(JSON.stringify(full));
+  return `${payloadB64}.${await hmacSign(payloadB64, secret)}`;
+}
+
+// ── Sunday helpers ────────────────────────────────────────────────────────────
+
+function toDateStr(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+/** The next calendar Sunday from `from`, or today if today is a Sunday. */
+function nextSunday(from: Date = new Date()): string {
+  const d = new Date(from);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() + ((7 - d.getDay()) % 7));
+  return toDateStr(d);
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr + "T00:00:00").toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+// ── Email ─────────────────────────────────────────────────────────────────────
+
+async function sendEmail(opts: { to: string; subject: string; html: string }) {
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ from: EMAIL_FROM, to: opts.to, subject: opts.subject, html: opts.html }),
+  });
+  if (!res.ok) {
+    console.error("Resend error for", opts.to, await res.text());
+  }
+}
+
+function wrap(inner: string): string {
+  return `<div style="font-family:Georgia,serif;max-width:600px;margin:0 auto;padding:40px 20px;">
+    ${inner}
+    <p style="font-size:14px;color:#78716c;margin-top:40px;">&mdash; The ${APP_NAME} Team</p>
+  </div>`;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+Deno.serve(async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SECRET_KEY);
+  const todayDow = new Date().getDay(); // 0=Sun … 6=Sat
+
+  // Teams where today is a configured reminder day
+  const { data: teamSettings } = await supabase
+    .from("serving_team_settings")
+    .select("group_id, window_weeks, reminder_days")
+    .eq("enabled", true)
+    .contains("reminder_days", [todayDow]);
+
+  if (!teamSettings?.length) {
+    return new Response(
+      JSON.stringify({ message: "No reminders to send today" }),
+      { headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  // Whether signed links are in use for this installation
+  const { data: lmSetting } = await supabase
+    .from("site_settings")
+    .select("value")
+    .eq("key", "serving_link_mode")
+    .maybeSingle();
+  const linkMode = (lmSetting?.value ?? SERVING_LINK_MODE) === "login" ? "login" : "signed";
+  const canSign = linkMode === "signed" && !!SERVING_LINK_SECRET;
+
+  let emailsSent = 0;
+
+  for (const { group_id } of teamSettings) {
+    // Group name
+    const { data: group } = await supabase
+      .from("member_groups")
+      .select("name")
+      .eq("id", group_id)
+      .single();
+    if (!group) continue;
+    const teamName = group.name as string;
+
+    const sunday = nextSunday();
+    const dateLabel = formatDate(sunday);
+
+    // Is this Sunday covered?
+    const { data: signup } = await supabase
+      .from("serving_signups")
+      .select("id, serving_signup_attendees(profiles(id, first_name, preferred_name, email))")
+      .eq("group_id", group_id)
+      .eq("service_date", sunday)
+      .maybeSingle();
+
+    if (signup) {
+      // ── Covered: remind each attendee ─────────────────────────────────
+      const attendees = (signup.serving_signup_attendees ?? []) as Array<{
+        profiles: { id: string; first_name: string | null; preferred_name: string | null; email: string | null } | null;
+      }>;
+
+      for (const { profiles: p } of attendees) {
+        if (!p?.email) continue;
+        const name = p.preferred_name || p.first_name || "Friend";
+
+        let cancelUrl = `${SITE_URL}/serving/${group_id}`;
+        if (canSign) {
+          cancelUrl = `${SITE_URL}/serving/go?token=${await createToken(
+            { a: "cancel", g: group_id, d: sunday, p: p.id },
+            SERVING_LINK_SECRET!
+          )}`;
+        }
+
+        await sendEmail({
+          to: p.email,
+          subject: `Reminder: you're serving this Sunday with the ${teamName}`,
+          html: wrap(`
+            <h1 style="color:${BRAND_COLOR};font-size:28px;">See you Sunday!</h1>
+            <p style="font-size:18px;line-height:1.6;color:#44403c;">
+              Hi ${name}, just a reminder that you&rsquo;re signed up to serve with the
+              <strong>${teamName}</strong> this Sunday.
+            </p>
+            <div style="background:#fef3c7;padding:20px;border-radius:8px;margin:20px 0;">
+              <p style="font-size:18px;margin:0;color:#44403c;">
+                <strong>When:</strong> ${dateLabel}
+              </p>
+            </div>
+            <p style="font-size:14px;color:#78716c;">
+              Can&rsquo;t make it?
+              <a href="${cancelUrl}" style="color:${BRAND_COLOR};">Click here to cancel</a>
+              so someone else can cover.
+            </p>
+          `),
+        });
+        emailsSent++;
+      }
+    } else {
+      // ── Open: nudge all team members ──────────────────────────────────
+      const { data: members } = await supabase
+        .from("profile_groups")
+        .select("profiles(id, first_name, preferred_name, email)")
+        .eq("group_id", group_id);
+
+      for (const row of members ?? []) {
+        const m = row.profiles as { id: string; first_name: string | null; preferred_name: string | null; email: string | null } | null;
+        if (!m?.email) continue;
+
+        const name = m.preferred_name || m.first_name || "Friend";
+        let signupUrl = `${SITE_URL}/serving/${group_id}`;
+        if (canSign) {
+          signupUrl = `${SITE_URL}/serving/go?token=${await createToken(
+            { a: "signup", g: group_id, d: sunday, p: m.id },
+            SERVING_LINK_SECRET!
+          )}`;
+        }
+
+        await sendEmail({
+          to: m.email,
+          subject: `${teamName}: this Sunday still needs someone`,
+          html: wrap(`
+            <h1 style="color:${BRAND_COLOR};font-size:28px;">Can you take this Sunday?</h1>
+            <p style="font-size:18px;line-height:1.6;color:#44403c;">
+              Hi ${name}, the <strong>${teamName}</strong> still needs a volunteer
+              for this Sunday.
+            </p>
+            <table role="presentation" width="100%" style="border-bottom:1px solid #e7e5e4;">
+              <tr>
+                <td style="padding:14px 0;font-size:18px;color:#44403c;">${dateLabel}</td>
+                <td align="right" style="padding:14px 0;">
+                  <a href="${signupUrl}"
+                     style="display:inline-block;background-color:${BRAND_COLOR};color:white;padding:10px 20px;text-decoration:none;border-radius:8px;font-size:16px;white-space:nowrap;">
+                    I&rsquo;ll do it
+                  </a>
+                </td>
+              </tr>
+            </table>
+          `),
+        });
+        emailsSent++;
+      }
+    }
+  }
+
+  return new Response(
+    JSON.stringify({ message: `Sent ${emailsSent} reminder emails` }),
+    { headers: { "Content-Type": "application/json" } }
+  );
+});

--- a/supabase/functions/send-serving-reminders/index.ts
+++ b/supabase/functions/send-serving-reminders/index.ts
@@ -102,26 +102,42 @@ function formatDate(dateStr: string): string {
   });
 }
 
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 // ── Email ─────────────────────────────────────────────────────────────────────
 
-async function sendEmail(opts: { to: string; subject: string; html: string }) {
-  const res = await fetch("https://api.resend.com/emails", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${RESEND_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ from: EMAIL_FROM, to: opts.to, subject: opts.subject, html: opts.html }),
-  });
-  if (!res.ok) {
-    console.error("Resend error for", opts.to, await res.text());
+async function sendEmail(opts: { to: string; subject: string; html: string }): Promise<boolean> {
+  try {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${RESEND_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ from: EMAIL_FROM, to: opts.to, subject: opts.subject, html: opts.html }),
+    });
+    if (!res.ok) {
+      console.error("Resend error for", opts.to, await res.text());
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.error("Resend request failed for", opts.to, err);
+    return false;
   }
 }
 
 function wrap(inner: string): string {
   return `<div style="font-family:Georgia,serif;max-width:600px;margin:0 auto;padding:40px 20px;">
     ${inner}
-    <p style="font-size:14px;color:#78716c;margin-top:40px;">&mdash; The ${APP_NAME} Team</p>
+    <p style="font-size:14px;color:#78716c;margin-top:40px;">&mdash; The ${escapeHtml(APP_NAME)} Team</p>
   </div>`;
 }
 
@@ -186,6 +202,9 @@ Deno.serve(async () => {
       for (const { profiles: p } of attendees) {
         if (!p?.email) continue;
         const name = p.preferred_name || p.first_name || "Friend";
+        const safeName = escapeHtml(name);
+        const safeTeamName = escapeHtml(teamName);
+        const safeDateLabel = escapeHtml(dateLabel);
 
         let cancelUrl = `${SITE_URL}/serving/${group_id}`;
         if (canSign) {
@@ -195,18 +214,18 @@ Deno.serve(async () => {
           )}`;
         }
 
-        await sendEmail({
+        if (await sendEmail({
           to: p.email,
           subject: `Reminder: you're serving this Sunday with the ${teamName}`,
           html: wrap(`
             <h1 style="color:${BRAND_COLOR};font-size:28px;">See you Sunday!</h1>
             <p style="font-size:18px;line-height:1.6;color:#44403c;">
-              Hi ${name}, just a reminder that you&rsquo;re signed up to serve with the
-              <strong>${teamName}</strong> this Sunday.
+              Hi ${safeName}, just a reminder that you&rsquo;re signed up to serve with the
+              <strong>${safeTeamName}</strong> this Sunday.
             </p>
             <div style="background:#fef3c7;padding:20px;border-radius:8px;margin:20px 0;">
               <p style="font-size:18px;margin:0;color:#44403c;">
-                <strong>When:</strong> ${dateLabel}
+                <strong>When:</strong> ${safeDateLabel}
               </p>
             </div>
             <p style="font-size:14px;color:#78716c;">
@@ -215,8 +234,9 @@ Deno.serve(async () => {
               so someone else can cover.
             </p>
           `),
-        });
-        emailsSent++;
+        })) {
+          emailsSent++;
+        }
       }
     } else {
       // ── Open: nudge all team members ──────────────────────────────────
@@ -230,6 +250,9 @@ Deno.serve(async () => {
         if (!m?.email) continue;
 
         const name = m.preferred_name || m.first_name || "Friend";
+        const safeName = escapeHtml(name);
+        const safeTeamName = escapeHtml(teamName);
+        const safeDateLabel = escapeHtml(dateLabel);
         let signupUrl = `${SITE_URL}/serving/${group_id}`;
         if (canSign) {
           signupUrl = `${SITE_URL}/serving/go?token=${await createToken(
@@ -238,18 +261,18 @@ Deno.serve(async () => {
           )}`;
         }
 
-        await sendEmail({
+        if (await sendEmail({
           to: m.email,
           subject: `${teamName}: this Sunday still needs someone`,
           html: wrap(`
             <h1 style="color:${BRAND_COLOR};font-size:28px;">Can you take this Sunday?</h1>
             <p style="font-size:18px;line-height:1.6;color:#44403c;">
-              Hi ${name}, the <strong>${teamName}</strong> still needs a volunteer
+              Hi ${safeName}, the <strong>${safeTeamName}</strong> still needs a volunteer
               for this Sunday.
             </p>
             <table role="presentation" width="100%" style="border-bottom:1px solid #e7e5e4;">
               <tr>
-                <td style="padding:14px 0;font-size:18px;color:#44403c;">${dateLabel}</td>
+                <td style="padding:14px 0;font-size:18px;color:#44403c;">${safeDateLabel}</td>
                 <td align="right" style="padding:14px 0;">
                   <a href="${signupUrl}"
                      style="display:inline-block;background-color:${BRAND_COLOR};color:white;padding:10px 20px;text-decoration:none;border-radius:8px;font-size:16px;white-space:nowrap;">
@@ -259,8 +282,9 @@ Deno.serve(async () => {
               </tr>
             </table>
           `),
-        });
-        emailsSent++;
+        })) {
+          emailsSent++;
+        }
       }
     }
   }

--- a/supabase/migrations/20260705000000_serving_schedule.sql
+++ b/supabase/migrations/20260705000000_serving_schedule.sql
@@ -1,0 +1,193 @@
+-- Sunday serving signups for functional teams (prayer team, greeter team).
+-- Replaces the reply-all email workflow: one signup covers a whole Sunday,
+-- made by an individual or a couple. Slots are lazy — upcoming Sundays are
+-- computed in app code and rows only exist for actual signups.
+
+-- ==================
+-- PROFILE_GROUPS: per-group leaders
+-- ==================
+-- A leader leads exactly the group on this membership row — no global role.
+alter table public.profile_groups
+  add column is_leader boolean not null default false;
+
+-- Helper: is the current user a leader of the given group?
+create or replace function public.is_group_leader(_group_id uuid)
+returns boolean as $$
+  select exists (
+    select 1 from public.profile_groups
+    where profile_id = auth.uid()
+      and group_id = _group_id
+      and is_leader = true
+  );
+$$ language sql security definer;
+
+-- Admins manage leader flags (profile_groups previously had no update policy)
+create policy "Admins can update profile groups"
+  on public.profile_groups for update
+  using (public.is_admin());
+
+-- ==================
+-- SERVING_TEAM_SETTINGS: per-group feature config
+-- ==================
+create table public.serving_team_settings (
+  group_id uuid primary key references public.member_groups(id) on delete cascade,
+  enabled boolean not null default false,
+  -- Days of week to send reminders (0=Sunday .. 6=Saturday); default Thursday + Friday
+  reminder_days int[] not null default '{4,5}'
+    check (reminder_days <@ array[0, 1, 2, 3, 4, 5, 6]),
+  -- 'email' via Resend today; column reserved for 'sms' later
+  reminder_method text not null default 'email'
+    check (reminder_method in ('email')),
+  -- How many upcoming Sundays to show / email about
+  window_weeks int not null default 8 check (window_weeks between 1 and 26),
+  updated_by uuid references auth.users(id) on delete set null,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.serving_team_settings enable row level security;
+
+create policy "Members can view serving settings"
+  on public.serving_team_settings for select
+  using (public.is_member());
+
+create policy "Leaders and admins can insert serving settings"
+  on public.serving_team_settings for insert
+  with check (public.is_admin() or public.is_group_leader(group_id));
+
+create policy "Leaders and admins can update serving settings"
+  on public.serving_team_settings for update
+  using (public.is_admin() or public.is_group_leader(group_id));
+
+create policy "Admins can delete serving settings"
+  on public.serving_team_settings for delete
+  using (public.is_admin());
+
+-- ==================
+-- SERVING_SIGNUPS: one row = one covered Sunday for one group
+-- ==================
+create table public.serving_signups (
+  id uuid primary key default gen_random_uuid(),
+  group_id uuid not null references public.member_groups(id) on delete cascade,
+  service_date date not null,
+  -- Household covering the Sunday (for "The Hendersons" display); null for
+  -- signups by members without a household
+  family_id uuid references public.family_units(id) on delete set null,
+  created_by uuid not null references public.profiles(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique (group_id, service_date)
+);
+
+alter table public.serving_signups enable row level security;
+
+create index serving_signups_service_date_idx on public.serving_signups(service_date);
+
+create policy "Members can view serving signups"
+  on public.serving_signups for select
+  using (public.is_member());
+
+-- Members sign up themselves, for teams they belong to; leaders/admins can
+-- create signups for any Sunday on their team
+create policy "Members can create serving signups"
+  on public.serving_signups for insert
+  with check (
+    created_by = auth.uid()
+    and (
+      public.is_admin()
+      or public.is_group_leader(group_id)
+      or exists (
+        select 1 from public.profile_groups pg
+        where pg.profile_id = auth.uid() and pg.group_id = serving_signups.group_id
+      )
+    )
+  );
+
+create policy "Members can delete own serving signups"
+  on public.serving_signups for delete
+  using (
+    created_by = auth.uid()
+    or public.is_admin()
+    or public.is_group_leader(group_id)
+  );
+
+-- ==================
+-- SERVING_SIGNUP_ATTENDEES: who is actually coming (just me / me & spouse)
+-- ==================
+create table public.serving_signup_attendees (
+  signup_id uuid not null references public.serving_signups(id) on delete cascade,
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  primary key (signup_id, profile_id)
+);
+
+alter table public.serving_signup_attendees enable row level security;
+
+create index serving_signup_attendees_profile_idx
+  on public.serving_signup_attendees(profile_id);
+
+create policy "Members can view serving attendees"
+  on public.serving_signup_attendees for select
+  using (public.is_member());
+
+create policy "Signup owners can add attendees"
+  on public.serving_signup_attendees for insert
+  with check (
+    exists (
+      select 1 from public.serving_signups s
+      where s.id = signup_id
+        and (
+          s.created_by = auth.uid()
+          or public.is_admin()
+          or public.is_group_leader(s.group_id)
+        )
+    )
+  );
+
+create policy "Signup owners can remove attendees"
+  on public.serving_signup_attendees for delete
+  using (
+    exists (
+      select 1 from public.serving_signups s
+      where s.id = signup_id
+        and (
+          s.created_by = auth.uid()
+          or public.is_admin()
+          or public.is_group_leader(s.group_id)
+        )
+    )
+  );
+
+-- ==================
+-- SERVING_BROADCASTS: log of "Email the team" sends
+-- ==================
+create table public.serving_broadcasts (
+  id uuid primary key default gen_random_uuid(),
+  group_id uuid not null references public.member_groups(id) on delete cascade,
+  sent_by uuid references public.profiles(id) on delete set null,
+  subject text not null,
+  -- The open Sundays listed in the email at send time
+  open_dates date[] not null default '{}',
+  recipient_count int not null default 0,
+  created_at timestamptz not null default now()
+);
+
+alter table public.serving_broadcasts enable row level security;
+
+create policy "Leaders and admins can view serving broadcasts"
+  on public.serving_broadcasts for select
+  using (public.is_admin() or public.is_group_leader(group_id));
+
+create policy "Leaders and admins can log serving broadcasts"
+  on public.serving_broadcasts for insert
+  with check (
+    sent_by = auth.uid()
+    and (public.is_admin() or public.is_group_leader(group_id))
+  );
+
+-- ==================
+-- SITE SETTINGS: email link mode (signed HMAC links vs. login required)
+-- ==================
+-- 'signed' = email deep links act without login (default); 'login' = links
+-- require signing in first. Env SERVING_LINK_MODE is the fallback default
+-- for self-hosters; this row wins when present.
+insert into public.site_settings (key, value)
+values ('serving_link_mode', 'signed')
+on conflict (key) do nothing;


### PR DESCRIPTION
## Summary
- Add Sunday serving signup pages, signed link flows, and leader/admin serving tools.
- Add serving API routes for signups, broadcasts, and link actions, plus dashboard/sidebar entry points.
- Add serving email templates, ICS helpers/feed support, Supabase schema migration, and reminder function.

## Testing
- Not run; requested to create PR as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Serving area for members and admins, including team schedules, signup/cancel actions, and a dashboard panel for upcoming commitments.
  * Added team leader tools for managing roster leaders, enabling serving signups, and emailing teams about open Sundays.
  * Added signed serving links and reminder emails for easier one-tap signup and cancellation.

* **Bug Fixes**
  * Calendar feeds now include serving commitments alongside events.
  * Updated serving access and display behavior based on account status and team settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->