### PR TITLE
chore: add Vercel Speed Insights

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Cormorant_Garamond, Inter_Tight, JetBrains_Mono } from "next/font/google";
 import { Toaster } from "@/components/ui/sonner";
 import { Header } from "@/components/layout/Header";
@@ -86,6 +87,7 @@ export default async function RootLayout({
         <Footer />
         <Toaster />
         <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@supabase/supabase-js": "^2.103.3",
         "@types/dompurify": "^3.2.0",
         "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "add-to-calendar-button-react": "^2.13.9",
         "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
@@ -4417,6 +4418,44 @@
         "@remix-run/react": {
           "optional": true
         },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
         "@sveltejs/kit": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@supabase/supabase-js": "^2.103.3",
     "@types/dompurify": "^3.2.0",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "add-to-calendar-button-react": "^2.13.9",
     "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary
- add @vercel/speed-insights dependency
- render the SpeedInsights component in the root layout

## Verification
- npm ls @vercel/speed-insights --depth=0
- npx tsc --noEmit

Note: npm run lint currently fails due an existing eslint@10.6.0 / eslint-plugin-react compatibility error in eslint-config-next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vercel Speed Insights to the app, alongside existing analytics, to help monitor site performance and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->