### PR TITLE
fix(serving): membership-gated visibility, spouse picker, and broadcast fixes

### DIFF
--- a/app/admin/serving/page.tsx
+++ b/app/admin/serving/page.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { displayName } from "@/lib/names";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface Team {
+  group_id: string;
+  name: string;
+}
+
+interface MemberRow {
+  profileId: string;
+  name: string;
+  counts: Record<string, number>; // group_id → count
+  total: number;
+}
+
+// ── Date range helpers ────────────────────────────────────────────────────────
+
+const RANGES = [
+  { label: "This year", value: "thisYear" },
+  { label: "Last year", value: "lastYear" },
+  { label: "Last 6 months", value: "6mo" },
+  { label: "All time", value: "all" },
+] as const;
+
+type RangeKey = (typeof RANGES)[number]["value"];
+
+function dateRange(key: RangeKey): { start: string | null; end: string | null } {
+  const now = new Date();
+  const y = now.getFullYear();
+
+  if (key === "thisYear") {
+    return { start: `${y}-01-01`, end: `${y}-12-31` };
+  }
+  if (key === "lastYear") {
+    return { start: `${y - 1}-01-01`, end: `${y - 1}-12-31` };
+  }
+  if (key === "6mo") {
+    const d = new Date(now);
+    d.setMonth(d.getMonth() - 6);
+    return {
+      start: d.toISOString().slice(0, 10),
+      end: now.toISOString().slice(0, 10),
+    };
+  }
+  return { start: null, end: null };
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export default function ServingStatsPage() {
+  const [range, setRange] = useState<RangeKey>("thisYear");
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [rows, setRows] = useState<MemberRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const supabase = createClient();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+
+      // Enabled teams
+      const { data: teamSettings } = await supabase
+        .from("serving_team_settings")
+        .select("group_id, member_groups(name)")
+        .eq("enabled", true);
+
+      const resolvedTeams: Team[] = (teamSettings ?? []).map((ts) => {
+        const mg = ts.member_groups as unknown as { name: string } | null;
+        return { group_id: ts.group_id as string, name: mg?.name ?? "Unknown team" };
+      });
+
+      if (cancelled) return;
+      setTeams(resolvedTeams);
+
+      if (!resolvedTeams.length) {
+        setRows([]);
+        setLoading(false);
+        return;
+      }
+
+      // Signups with attendees, filtered by date range
+      const { start, end } = dateRange(range);
+      const groupIds = resolvedTeams.map((t) => t.group_id);
+
+      let query = supabase
+        .from("serving_signups")
+        .select(
+          "id, service_date, group_id, serving_signup_attendees(profile_id, profiles(id, first_name, last_name, preferred_name))"
+        )
+        .in("group_id", groupIds)
+        .order("service_date", { ascending: false });
+
+      if (start) query = query.gte("service_date", start);
+      if (end) query = query.lte("service_date", end);
+
+      const { data: signups } = await query;
+      if (cancelled) return;
+
+      // Aggregate: profileId → groupId → count
+      const countMap = new Map<string, Map<string, number>>();
+      const nameMap = new Map<string, string>();
+
+      for (const signup of signups ?? []) {
+        const groupId = signup.group_id as string;
+        const attendees = (signup.serving_signup_attendees ?? []) as unknown as Array<{
+          profile_id: string;
+          profiles: { id: string; first_name: string | null; last_name: string | null; preferred_name: string | null } | null;
+        }>;
+
+        for (const a of attendees) {
+          if (!a.profiles) continue;
+          const pid = a.profile_id;
+          if (!nameMap.has(pid)) {
+            nameMap.set(pid, displayName(a.profiles));
+          }
+          if (!countMap.has(pid)) countMap.set(pid, new Map());
+          const gc = countMap.get(pid)!;
+          gc.set(groupId, (gc.get(groupId) ?? 0) + 1);
+        }
+      }
+
+      const memberRows: MemberRow[] = Array.from(countMap.entries())
+        .map(([profileId, gc]) => {
+          const counts: Record<string, number> = {};
+          let total = 0;
+          for (const [gid, n] of gc) {
+            counts[gid] = n;
+            total += n;
+          }
+          return { profileId, name: nameMap.get(profileId) ?? "Unknown", counts, total };
+        })
+        .sort((a, b) => b.total - a.total || a.name.localeCompare(b.name));
+
+      if (!cancelled) {
+        setRows(memberRows);
+        setLoading(false);
+      }
+    }
+
+    load();
+    return () => { cancelled = true; };
+  }, [range]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const totalServings = useMemo(
+    () => rows.reduce((s, r) => s + r.total, 0),
+    [rows]
+  );
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-4xl">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
+        <div>
+          <h1 className="text-3xl font-bold text-brand-primary">Serving Stats</h1>
+          <p className="text-muted-foreground mt-1">
+            Who has served, and how often, across all active teams.
+          </p>
+        </div>
+
+        {/* Range filter */}
+        <div className="flex gap-2 flex-wrap">
+          {RANGES.map((r) => (
+            <button
+              key={r.value}
+              type="button"
+              onClick={() => setRange(r.value)}
+              className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
+                range === r.value
+                  ? "bg-brand-primary text-white border-brand-primary"
+                  : "border-border text-muted-foreground hover:border-brand-primary/50"
+              }`}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading ? (
+        <p className="text-muted-foreground">Loading…</p>
+      ) : teams.length === 0 ? (
+        <Card>
+          <CardContent className="py-10 text-center text-muted-foreground">
+            No serving teams are enabled yet. Enable a team from the Serving page.
+          </CardContent>
+        </Card>
+      ) : rows.length === 0 ? (
+        <Card>
+          <CardContent className="py-10 text-center text-muted-foreground">
+            No serving data for this period.
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-lg">
+              {totalServings} serving slot{totalServings !== 1 ? "s" : ""} logged
+              {" · "}
+              {rows.length} member{rows.length !== 1 ? "s" : ""}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-muted/40">
+                    <th className="text-left px-6 py-3 font-semibold text-muted-foreground">
+                      Member
+                    </th>
+                    {teams.map((t) => (
+                      <th
+                        key={t.group_id}
+                        className="text-right px-4 py-3 font-semibold text-muted-foreground whitespace-nowrap"
+                      >
+                        {t.name}
+                      </th>
+                    ))}
+                    <th className="text-right px-6 py-3 font-semibold text-brand-primary">
+                      Total
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((row, i) => (
+                    <tr
+                      key={row.profileId}
+                      className={`border-b border-border last:border-0 ${
+                        i % 2 === 0 ? "" : "bg-muted/20"
+                      }`}
+                    >
+                      <td className="px-6 py-3 font-medium text-foreground">
+                        {row.name}
+                      </td>
+                      {teams.map((t) => (
+                        <td
+                          key={t.group_id}
+                          className="px-4 py-3 text-right tabular-nums text-muted-foreground"
+                        >
+                          {row.counts[t.group_id] ?? "—"}
+                        </td>
+                      ))}
+                      <td className="px-6 py-3 text-right tabular-nums font-bold text-brand-primary">
+                        {row.total}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+                {/* Footer totals row */}
+                <tfoot>
+                  <tr className="border-t-2 border-border bg-muted/40">
+                    <td className="px-6 py-3 font-semibold text-muted-foreground">
+                      Total
+                    </td>
+                    {teams.map((t) => {
+                      const teamTotal = rows.reduce(
+                        (s, r) => s + (r.counts[t.group_id] ?? 0),
+                        0
+                      );
+                      return (
+                        <td
+                          key={t.group_id}
+                          className="px-4 py-3 text-right tabular-nums font-semibold text-muted-foreground"
+                        >
+                          {teamTotal || "—"}
+                        </td>
+                      );
+                    })}
+                    <td className="px-6 py-3 text-right tabular-nums font-bold text-brand-primary">
+                      {totalServings}
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -50,16 +50,27 @@ export default async function RootLayout({
   const hasAuthCookie = cookieStore.getAll().some((c) => c.name.includes("auth-token"));
 
   let profile = null;
+  let hasServingAccess = false;
   if (hasAuthCookie) {
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();
     if (user) {
-      const { data } = await supabase
-        .from("profiles")
-        .select("*")
-        .eq("id", user.id)
-        .single();
+      const [{ data }, { data: groupData }] = await Promise.all([
+        supabase.from("profiles").select("*").eq("id", user.id).single(),
+        supabase.from("profile_groups").select("group_id").eq("profile_id", user.id),
+      ]);
       profile = data;
+
+      if (profile?.role === "admin") {
+        hasServingAccess = true;
+      } else if (groupData?.length) {
+        const { count } = await supabase
+          .from("serving_team_settings")
+          .select("group_id", { count: "exact", head: true })
+          .eq("enabled", true)
+          .in("group_id", groupData.map((g) => g.group_id as string));
+        hasServingAccess = (count ?? 0) > 0;
+      }
     }
   }
 
@@ -83,7 +94,7 @@ export default async function RootLayout({
       </head>
       <body className={`${cormorant.variable} ${interTight.variable} ${jetbrainsMono.variable} antialiased min-h-screen flex flex-col`}>
         <Header profile={profile} />
-        <AppShell profile={profile}>{children}</AppShell>
+        <AppShell profile={profile} hasServingAccess={hasServingAccess}>{children}</AppShell>
         <Footer />
         <Toaster />
         <Analytics />

--- a/app/serving/[groupId]/page.tsx
+++ b/app/serving/[groupId]/page.tsx
@@ -4,11 +4,12 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { siteConfig } from "@/lib/config";
 import { signupDisplayName } from "@/lib/serving/display";
-import { upcomingSundays } from "@/lib/serving/sundays";
+import { upcomingSundays, pastSundaysUntil } from "@/lib/serving/sundays";
 import {
   ServingSchedule,
   type ScheduleEntry,
 } from "@/components/serving/ServingSchedule";
+import { ServingHistory, type HistoryEntry } from "@/components/serving/ServingHistory";
 import { EmailTeamButton } from "@/components/serving/EmailTeamButton";
 import { ServingSettingsDialog } from "@/components/serving/ServingSettingsDialog";
 
@@ -126,6 +127,59 @@ export default async function ServingSchedulePage({
     };
   }
 
+  // Past signups for history section
+  const { data: pastSignupRows } = await supabase
+    .from("serving_signups")
+    .select(
+      "id, service_date, created_by, family_id, serving_signup_attendees(profiles(id, first_name, last_name, preferred_name))"
+    )
+    .eq("group_id", groupId)
+    .lt("service_date", sundays[0])
+    .order("service_date", { ascending: false });
+
+  const pastSignupMap = new Map<string, ScheduleEntry>();
+  const pastFamilyIds = [
+    ...new Set(
+      (pastSignupRows ?? [])
+        .filter((s) => (s.serving_signup_attendees?.length ?? 0) > 1 && s.family_id)
+        .map((s) => s.family_id as string)
+    ),
+  ];
+  if (pastFamilyIds.length > 0) {
+    const { data: pastFamilies } = await supabase
+      .from("family_units")
+      .select("id, family_name")
+      .in("id", pastFamilyIds);
+    for (const f of pastFamilies ?? []) familyNames.set(f.id, f.family_name);
+  }
+  for (const s of pastSignupRows ?? []) {
+    const attendees = (s.serving_signup_attendees ?? [])
+      .map((a) => a.profiles as unknown as AttendeeProfile)
+      .filter(Boolean);
+    pastSignupMap.set(s.service_date, {
+      id: s.id,
+      date: s.service_date,
+      createdBy: s.created_by ?? "",
+      attendeeIds: attendees.map((a) => a.id),
+      label: signupDisplayName(
+        attendees,
+        s.family_id ? (familyNames.get(s.family_id) ?? null) : null
+      ),
+    });
+  }
+
+  // All past Sundays from earliest signup to last week
+  const earliestPast =
+    pastSignupRows && pastSignupRows.length > 0
+      ? pastSignupRows[pastSignupRows.length - 1].service_date
+      : null;
+  const historyEntries: HistoryEntry[] = earliestPast
+    ? pastSundaysUntil(earliestPast).map((date) => ({
+        date,
+        entry: pastSignupMap.get(date) ?? null,
+      }))
+    : [];
+
   // Spouse option for the attendee picker ("just me" / "me & spouse")
   let spouse: { id: string; name: string } | null = null;
   if (profile.family_id) {
@@ -213,6 +267,10 @@ export default async function ServingSchedulePage({
         canSignUp={isMember || isLeader || isAdmin}
         canManage={isLeader || isAdmin}
       />
+
+      {historyEntries.length > 0 && (
+        <ServingHistory entries={historyEntries} />
+      )}
     </div>
   );
 }

--- a/app/serving/[groupId]/page.tsx
+++ b/app/serving/[groupId]/page.tsx
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabase/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
@@ -69,6 +69,8 @@ export default async function ServingSchedulePage({
 
   const isMember = !!membership;
   const isLeader = membership?.is_leader === true;
+
+  if (!isMember && !isLeader && !isAdmin) redirect("/serving");
 
   const { data: memberRows } = await supabase
     .from("profile_groups")
@@ -180,10 +182,12 @@ export default async function ServingSchedulePage({
       }))
     : [];
 
-  // Spouse option for the attendee picker ("just me" / "me & spouse")
+  // Spouse option for the attendee picker ("just me" / "me & spouse").
+  // Uses the service client so pending profiles (spouse never logged in) are visible.
   let spouse: { id: string; name: string } | null = null;
   if (profile.family_id) {
-    const { data: spouseRow } = await supabase
+    const service = await createServiceClient();
+    const { data: spouseRow } = await service
       .from("profiles")
       .select("id, first_name, last_name, preferred_name")
       .eq("family_id", profile.family_id)

--- a/app/serving/page.tsx
+++ b/app/serving/page.tsx
@@ -42,11 +42,11 @@ export default async function ServingPage() {
       .eq("profile_id", user.id),
   ]);
 
-  const teams = ((settingsRows ?? []) as SettingsWithGroup[]).filter(
-    (s) => s.member_groups
-  );
   const membershipMap = new Map(
     (memberships ?? []).map((m) => [m.group_id, m.is_leader as boolean])
+  );
+  const teams = ((settingsRows ?? []) as SettingsWithGroup[]).filter(
+    (s) => s.member_groups && (isAdmin || membershipMap.has(s.group_id))
   );
 
   // Coverage counts for each team's upcoming window

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -6,6 +6,7 @@ import type { Profile } from "@/lib/types";
 
 interface AppShellProps {
   profile: Profile | null;
+  hasServingAccess: boolean;
   children: React.ReactNode;
 }
 
@@ -21,7 +22,7 @@ const SIDEBAR_ROUTES = [
   "/profile",
 ];
 
-export function AppShell({ profile, children }: AppShellProps) {
+export function AppShell({ profile, hasServingAccess, children }: AppShellProps) {
   const pathname = usePathname();
   const isMember =
     profile && ["member", "content_editor", "admin"].includes(profile.role);
@@ -34,7 +35,7 @@ export function AppShell({ profile, children }: AppShellProps) {
 
   return (
     <div className="flex flex-1">
-      <Sidebar profile={profile!} />
+      <Sidebar profile={profile!} hasServingAccess={hasServingAccess} />
       <main className="flex-1 overflow-y-auto">{children}</main>
     </div>
   );

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   ChevronRight,
   MailPlus,
   HandHelping,
+  BarChart2,
 } from "lucide-react";
 import { useState, useEffect } from "react";
 import type { Profile } from "@/lib/types";
@@ -44,6 +45,7 @@ const adminNav = [
   { href: "/admin/groups", label: "Groups", icon: Users },
   { href: "/admin/invite", label: "Bulk Invite", icon: MailPlus },
   { href: "/admin/calendars", label: "Calendars", icon: CalendarDays },
+  { href: "/admin/serving", label: "Serving Stats", icon: BarChart2 },
   { href: "/admin/pages", label: "Manage Pages", icon: FileText },
 ];
 

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -26,6 +26,7 @@ import { createClient } from "@/lib/supabase/client";
 
 interface SidebarProps {
   profile: Profile;
+  hasServingAccess: boolean;
 }
 
 const memberNav = [
@@ -49,7 +50,7 @@ const adminNav = [
   { href: "/admin/pages", label: "Manage Pages", icon: FileText },
 ];
 
-export function Sidebar({ profile }: SidebarProps) {
+export function Sidebar({ profile, hasServingAccess }: SidebarProps) {
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
   const [pages, setPages] = useState<PageContent[]>([]);
@@ -84,12 +85,14 @@ export function Sidebar({ profile }: SidebarProps) {
       }`}
     >
       <nav className="flex-1 overflow-y-auto py-4 px-2 space-y-1">
-        {memberNav.map((item) => (
-          <Link key={item.href} href={item.href} className={linkClass(item.href)}>
-            <item.icon className="h-5 w-5 shrink-0" />
-            {!collapsed && <span>{item.label}</span>}
-          </Link>
-        ))}
+        {memberNav
+          .filter((item) => item.href !== "/serving" || hasServingAccess)
+          .map((item) => (
+            <Link key={item.href} href={item.href} className={linkClass(item.href)}>
+              <item.icon className="h-5 w-5 shrink-0" />
+              {!collapsed && <span>{item.label}</span>}
+            </Link>
+          ))}
 
         {pages.length > 0 && (
           <>

--- a/components/serving/AdminServingSetup.tsx
+++ b/components/serving/AdminServingSetup.tsx
@@ -33,7 +33,7 @@ export function AdminServingSetup({ groups }: AdminServingSetupProps) {
     setBusy(null);
 
     if (error) {
-      toast.error(`Failed to enable serving for ${name}.`);
+      toast.error(`Failed to enable serving for ${name}: ${error.message}`);
       return;
     }
     toast.success(`Serving signups enabled for ${name}.`);

--- a/components/serving/EmailTeamButton.tsx
+++ b/components/serving/EmailTeamButton.tsx
@@ -80,11 +80,18 @@ export function EmailTeamButton({
             <DialogTitle>Email the {teamName}</DialogTitle>
           </DialogHeader>
 
-          <p className="text-sm text-muted-foreground">
-            Everyone on the team ({memberCount} member{memberCount !== 1 ? "s" : ""})
-            will get an email listing the open Sundays below, each with a
-            one-tap signup button.
-          </p>
+          {memberCount === 0 ? (
+            <p className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
+              No team members found. Add members to this group in{" "}
+              <strong>Admin → Groups</strong> first.
+            </p>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Everyone on the team ({memberCount} member{memberCount !== 1 ? "s" : ""})
+              will get an email listing the open Sundays below, each with a
+              one-tap signup button.
+            </p>
+          )}
 
           <ul className="text-sm list-disc pl-5 space-y-0.5 max-h-40 overflow-y-auto">
             {openDates.map((d) => (
@@ -114,7 +121,7 @@ export function EmailTeamButton({
               Cancel
             </Button>
             <Button
-              disabled={sending}
+              disabled={sending || memberCount === 0}
               onClick={send}
               className="bg-brand-primary hover:bg-brand-primary/90 text-white"
             >

--- a/components/serving/ServingHistory.tsx
+++ b/components/serving/ServingHistory.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { formatServiceDate } from "@/lib/serving/sundays";
+import type { ScheduleEntry } from "./ServingSchedule";
+
+export interface HistoryEntry {
+  date: string;
+  entry: ScheduleEntry | null;
+}
+
+interface ServingHistoryProps {
+  entries: HistoryEntry[];
+}
+
+export function ServingHistory({ entries }: ServingHistoryProps) {
+  const [open, setOpen] = useState(false);
+
+  if (!entries.length) return null;
+
+  return (
+    <div className="mt-10 border-t border-border pt-8">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-2 text-sm font-semibold text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {open ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+        Previous weeks ({entries.length})
+      </button>
+
+      {open && (
+        <div className="mt-4 space-y-0 divide-y divide-border">
+          {entries.map(({ date, entry }) => (
+            <div
+              key={date}
+              className="flex items-center justify-between py-3 gap-4"
+            >
+              <span className="font-sans text-sm text-muted-foreground shrink-0">
+                {formatServiceDate(date)}
+              </span>
+              {entry ? (
+                <span className="font-sans text-sm font-medium text-foreground text-right">
+                  {entry.label}
+                </span>
+              ) : (
+                <span className="font-sans text-sm text-muted-foreground/60 italic text-right">
+                  No one signed up
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/serving/sundays.ts
+++ b/lib/serving/sundays.ts
@@ -64,3 +64,26 @@ export function daysUntilService(dateStr: string, from: Date = new Date()): numb
   const target = new Date(dateStr + "T00:00:00");
   return Math.round((target.getTime() - today.getTime()) / 86400000);
 }
+
+/**
+ * All past Sundays from `from` (inclusive) up to but not including today,
+ * returned newest-first. Returns empty array if `from` is today or in the future.
+ */
+export function pastSundaysUntil(from: string, until: Date = new Date()): string[] {
+  const end = new Date(until);
+  end.setHours(0, 0, 0, 0);
+  // Roll back to last Sunday (exclusive of today if today is Sunday)
+  const dow = end.getDay();
+  end.setDate(end.getDate() - (dow === 0 ? 7 : dow));
+
+  const start = new Date(from + "T00:00:00");
+  if (end < start) return [];
+
+  const result: string[] = [];
+  const d = new Date(end);
+  while (d >= start) {
+    result.push(toDateString(d));
+    d.setDate(d.getDate() - 7);
+  }
+  return result;
+}

--- a/supabase/functions/send-serving-reminders/index.ts
+++ b/supabase/functions/send-serving-reminders/index.ts
@@ -352,11 +352,13 @@ async function runMonthly(
       })) sent++;
     }
 
-    // Log broadcast
+    // Log broadcast (service key bypasses RLS; sent_by = null marks automated)
     await supabase.from("serving_broadcasts").insert({
       group_id,
-      sent_by: null, // automated — no user
-      message: `Monthly auto-broadcast: ${openDates.length} open Sunday(s)`,
+      sent_by: null,
+      subject: `${teamName}: monthly open-Sunday broadcast`,
+      open_dates: openDates,
+      recipient_count: sent,
     });
   }
 

--- a/supabase/functions/send-serving-reminders/index.ts
+++ b/supabase/functions/send-serving-reminders/index.ts
@@ -275,6 +275,7 @@ async function runMonthly(
   let sent = 0;
 
   for (const { group_id, window_weeks } of teamSettings) {
+    let teamSent = 0;
     const { data: group } = await supabase
       .from("member_groups")
       .select("name")
@@ -349,7 +350,7 @@ async function runMonthly(
             <a href="${SITE_URL}/serving/${group_id}" style="color:${BRAND_COLOR};">View the team page</a>
           </p>
         `),
-      })) sent++;
+      })) { sent++; teamSent++; }
     }
 
     // Log broadcast (service key bypasses RLS; sent_by = null marks automated)
@@ -358,7 +359,7 @@ async function runMonthly(
       sent_by: null,
       subject: `${teamName}: monthly open-Sunday broadcast`,
       open_dates: openDates,
-      recipient_count: sent,
+      recipient_count: teamSent,
     });
   }
 

--- a/supabase/functions/send-serving-reminders/index.ts
+++ b/supabase/functions/send-serving-reminders/index.ts
@@ -1,18 +1,29 @@
 // Supabase Edge Function: send-serving-reminders
-// Runs daily via pg_cron. For each enabled serving team where today is a
-// reminder day, emails attendees if the next Sunday is covered, or nudges
-// all team members if it's still open.
 //
-// pg_cron setup (run once in Supabase SQL editor — never by CI):
+// Two modes, two pg_cron entries (run once in Supabase SQL editor — never CI):
 //
+//   -- Daily: remind attendees of covered Sundays (Sat by default)
 //   select cron.schedule(
-//     'send-serving-reminders',
+//     'send-serving-reminders-daily',
 //     '0 8 * * *',
 //     $$
 //       select net.http_post(
 //         url := '<SUPABASE_PROJECT_URL>/functions/v1/send-serving-reminders',
 //         headers := '{"Authorization":"Bearer <SERVICE_ROLE_KEY>","Content-Type":"application/json"}'::jsonb,
-//         body := '{}'::jsonb
+//         body := '{"mode":"daily"}'::jsonb
+//       );
+//     $$
+//   );
+//
+//   -- Monthly: broadcast open Sundays to the whole team on the 1st
+//   select cron.schedule(
+//     'send-serving-monthly-broadcast',
+//     '0 8 1 * *',
+//     $$
+//       select net.http_post(
+//         url := '<SUPABASE_PROJECT_URL>/functions/v1/send-serving-reminders',
+//         headers := '{"Authorization":"Bearer <SERVICE_ROLE_KEY>","Content-Type":"application/json"}'::jsonb,
+//         body := '{"mode":"monthly"}'::jsonb
 //       );
 //     $$
 //   );
@@ -85,12 +96,23 @@ function toDateStr(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
-/** The next calendar Sunday from `from`, or today if today is a Sunday. */
 function nextSunday(from: Date = new Date()): string {
   const d = new Date(from);
   d.setHours(0, 0, 0, 0);
   d.setDate(d.getDate() + ((7 - d.getDay()) % 7));
   return toDateStr(d);
+}
+
+function upcomingSundays(weeks: number, from: Date = new Date()): string[] {
+  const d = new Date(from);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() + ((7 - d.getDay()) % 7));
+  const result: string[] = [];
+  for (let i = 0; i < weeks; i++) {
+    result.push(toDateStr(d));
+    d.setDate(d.getDate() + 7);
+  }
+  return result;
 }
 
 function formatDate(dateStr: string): string {
@@ -141,39 +163,38 @@ function wrap(inner: string): string {
   </div>`;
 }
 
-// ── Main ──────────────────────────────────────────────────────────────────────
+// ── Shared: resolve link mode ─────────────────────────────────────────────────
 
-Deno.serve(async () => {
-  const supabase = createClient(SUPABASE_URL, SUPABASE_SECRET_KEY);
-  const todayDow = new Date().getDay(); // 0=Sun … 6=Sat
-
-  // Teams where today is a configured reminder day
-  const { data: teamSettings } = await supabase
-    .from("serving_team_settings")
-    .select("group_id, window_weeks, reminder_days")
-    .eq("enabled", true)
-    .contains("reminder_days", [todayDow]);
-
-  if (!teamSettings?.length) {
-    return new Response(
-      JSON.stringify({ message: "No reminders to send today" }),
-      { headers: { "Content-Type": "application/json" } }
-    );
-  }
-
-  // Whether signed links are in use for this installation
-  const { data: lmSetting } = await supabase
+async function resolveCanSign(supabase: ReturnType<typeof createClient>): Promise<boolean> {
+  const { data } = await supabase
     .from("site_settings")
     .select("value")
     .eq("key", "serving_link_mode")
     .maybeSingle();
-  const linkMode = (lmSetting?.value ?? SERVING_LINK_MODE) === "login" ? "login" : "signed";
-  const canSign = linkMode === "signed" && !!SERVING_LINK_SECRET;
+  const mode = (data?.value ?? SERVING_LINK_MODE) === "login" ? "login" : "signed";
+  return mode === "signed" && !!SERVING_LINK_SECRET;
+}
 
-  let emailsSent = 0;
+// ── Daily mode: remind attendees of the next covered Sunday ──────────────────
+
+async function runDaily(
+  supabase: ReturnType<typeof createClient>,
+  canSign: boolean
+): Promise<number> {
+  const todayDow = new Date().getDay();
+
+  // Only process teams whose reminder_days include today
+  const { data: teamSettings } = await supabase
+    .from("serving_team_settings")
+    .select("group_id")
+    .eq("enabled", true)
+    .contains("reminder_days", [todayDow]);
+
+  if (!teamSettings?.length) return 0;
+
+  let sent = 0;
 
   for (const { group_id } of teamSettings) {
-    // Group name
     const { data: group } = await supabase
       .from("member_groups")
       .select("name")
@@ -183,9 +204,7 @@ Deno.serve(async () => {
     const teamName = group.name as string;
 
     const sunday = nextSunday();
-    const dateLabel = formatDate(sunday);
 
-    // Is this Sunday covered?
     const { data: signup } = await supabase
       .from("serving_signups")
       .select("id, serving_signup_attendees(profiles(id, first_name, preferred_name, email))")
@@ -193,86 +212,117 @@ Deno.serve(async () => {
       .eq("service_date", sunday)
       .maybeSingle();
 
-    if (signup) {
-      // ── Covered: remind each attendee ─────────────────────────────────
-      const attendees = (signup.serving_signup_attendees ?? []) as Array<{
-        profiles: { id: string; first_name: string | null; preferred_name: string | null; email: string | null } | null;
-      }>;
+    if (!signup) continue; // open Sunday — no reminder to send
 
-      for (const { profiles: p } of attendees) {
-        if (!p?.email) continue;
-        const name = p.preferred_name || p.first_name || "Friend";
-        const safeName = escapeHtml(name);
-        const safeTeamName = escapeHtml(teamName);
-        const safeDateLabel = escapeHtml(dateLabel);
+    const attendees = (signup.serving_signup_attendees ?? []) as Array<{
+      profiles: { id: string; first_name: string | null; preferred_name: string | null; email: string | null } | null;
+    }>;
 
-        let cancelUrl = `${SITE_URL}/serving/${group_id}`;
-        if (canSign) {
-          cancelUrl = `${SITE_URL}/serving/go?token=${await createToken(
-            { a: "cancel", g: group_id, d: sunday, p: p.id },
-            SERVING_LINK_SECRET!
-          )}`;
-        }
+    for (const { profiles: p } of attendees) {
+      if (!p?.email) continue;
+      const name = escapeHtml(p.preferred_name || p.first_name || "Friend");
+      const safeTeam = escapeHtml(teamName);
+      const dateLabel = escapeHtml(formatDate(sunday));
 
-        if (await sendEmail({
-          to: p.email,
-          subject: `Reminder: you're serving this Sunday with the ${teamName}`,
-          html: wrap(`
-            <h1 style="color:${BRAND_COLOR};font-size:28px;">See you Sunday!</h1>
-            <p style="font-size:18px;line-height:1.6;color:#44403c;">
-              Hi ${safeName}, just a reminder that you&rsquo;re signed up to serve with the
-              <strong>${safeTeamName}</strong> this Sunday.
-            </p>
-            <div style="background:#fef3c7;padding:20px;border-radius:8px;margin:20px 0;">
-              <p style="font-size:18px;margin:0;color:#44403c;">
-                <strong>When:</strong> ${safeDateLabel}
-              </p>
-            </div>
-            <p style="font-size:14px;color:#78716c;">
-              Can&rsquo;t make it?
-              <a href="${cancelUrl}" style="color:${BRAND_COLOR};">Click here to cancel</a>
-              so someone else can cover.
-            </p>
-          `),
-        })) {
-          emailsSent++;
-        }
+      let cancelUrl = `${SITE_URL}/serving/${group_id}`;
+      if (canSign) {
+        cancelUrl = `${SITE_URL}/serving/go?token=${await createToken(
+          { a: "cancel", g: group_id, d: sunday, p: p.id },
+          SERVING_LINK_SECRET!
+        )}`;
       }
-    } else {
-      // ── Open: nudge all team members ──────────────────────────────────
-      const { data: members } = await supabase
-        .from("profile_groups")
-        .select("profiles(id, first_name, preferred_name, email)")
-        .eq("group_id", group_id);
 
-      for (const row of members ?? []) {
-        const m = row.profiles as { id: string; first_name: string | null; preferred_name: string | null; email: string | null } | null;
-        if (!m?.email) continue;
-
-        const name = m.preferred_name || m.first_name || "Friend";
-        const safeName = escapeHtml(name);
-        const safeTeamName = escapeHtml(teamName);
-        const safeDateLabel = escapeHtml(dateLabel);
-        let signupUrl = `${SITE_URL}/serving/${group_id}`;
-        if (canSign) {
-          signupUrl = `${SITE_URL}/serving/go?token=${await createToken(
-            { a: "signup", g: group_id, d: sunday, p: m.id },
-            SERVING_LINK_SECRET!
-          )}`;
-        }
-
-        if (await sendEmail({
-          to: m.email,
-          subject: `${teamName}: this Sunday still needs someone`,
-          html: wrap(`
-            <h1 style="color:${BRAND_COLOR};font-size:28px;">Can you take this Sunday?</h1>
-            <p style="font-size:18px;line-height:1.6;color:#44403c;">
-              Hi ${safeName}, the <strong>${safeTeamName}</strong> still needs a volunteer
-              for this Sunday.
+      if (await sendEmail({
+        to: p.email,
+        subject: `Reminder: you're serving this Sunday with the ${teamName}`,
+        html: wrap(`
+          <h1 style="color:${BRAND_COLOR};font-size:28px;">See you Sunday!</h1>
+          <p style="font-size:18px;line-height:1.6;color:#44403c;">
+            Hi ${name}, just a reminder that you&rsquo;re signed up to serve with the
+            <strong>${safeTeam}</strong> this Sunday.
+          </p>
+          <div style="background:#fef3c7;padding:20px;border-radius:8px;margin:20px 0;">
+            <p style="font-size:18px;margin:0;color:#44403c;">
+              <strong>When:</strong> ${dateLabel}
             </p>
+          </div>
+          <p style="font-size:14px;color:#78716c;">
+            Can&rsquo;t make it?
+            <a href="${cancelUrl}" style="color:${BRAND_COLOR};">Click here to cancel</a>
+            so someone else can cover.
+          </p>
+        `),
+      })) sent++;
+    }
+  }
+
+  return sent;
+}
+
+// ── Monthly mode: broadcast open Sundays to the whole team ───────────────────
+
+async function runMonthly(
+  supabase: ReturnType<typeof createClient>,
+  canSign: boolean
+): Promise<number> {
+  const { data: teamSettings } = await supabase
+    .from("serving_team_settings")
+    .select("group_id, window_weeks")
+    .eq("enabled", true);
+
+  if (!teamSettings?.length) return 0;
+
+  let sent = 0;
+
+  for (const { group_id, window_weeks } of teamSettings) {
+    const { data: group } = await supabase
+      .from("member_groups")
+      .select("name")
+      .eq("id", group_id)
+      .single();
+    if (!group) continue;
+    const teamName = group.name as string;
+
+    const sundays = upcomingSundays(window_weeks ?? 8);
+
+    // Find which Sundays are already covered
+    const { data: signups } = await supabase
+      .from("serving_signups")
+      .select("service_date")
+      .eq("group_id", group_id)
+      .in("service_date", sundays);
+
+    const covered = new Set((signups ?? []).map((s) => s.service_date as string));
+    const openDates = sundays.filter((d) => !covered.has(d));
+
+    if (!openDates.length) continue; // all covered — nothing to broadcast
+
+    // Get all team members
+    const { data: members } = await supabase
+      .from("profile_groups")
+      .select("profiles(id, first_name, preferred_name, email)")
+      .eq("group_id", group_id);
+
+    for (const row of members ?? []) {
+      const m = row.profiles as { id: string; first_name: string | null; preferred_name: string | null; email: string | null } | null;
+      if (!m?.email) continue;
+
+      const name = escapeHtml(m.preferred_name || m.first_name || "Friend");
+      const safeTeam = escapeHtml(teamName);
+
+      const rows = await Promise.all(
+        openDates.map(async (date) => {
+          let signupUrl = `${SITE_URL}/serving/${group_id}`;
+          if (canSign) {
+            signupUrl = `${SITE_URL}/serving/go?token=${await createToken(
+              { a: "signup", g: group_id, d: date, p: m.id },
+              SERVING_LINK_SECRET!
+            )}`;
+          }
+          return `
             <table role="presentation" width="100%" style="border-bottom:1px solid #e7e5e4;">
               <tr>
-                <td style="padding:14px 0;font-size:18px;color:#44403c;">${safeDateLabel}</td>
+                <td style="padding:14px 0;font-size:18px;color:#44403c;">${escapeHtml(formatDate(date))}</td>
                 <td align="right" style="padding:14px 0;">
                   <a href="${signupUrl}"
                      style="display:inline-block;background-color:${BRAND_COLOR};color:white;padding:10px 20px;text-decoration:none;border-radius:8px;font-size:16px;white-space:nowrap;">
@@ -280,17 +330,60 @@ Deno.serve(async () => {
                   </a>
                 </td>
               </tr>
-            </table>
-          `),
-        })) {
-          emailsSent++;
-        }
-      }
+            </table>`;
+        })
+      );
+
+      if (await sendEmail({
+        to: m.email,
+        subject: `${teamName}: open Sundays for the coming weeks`,
+        html: wrap(`
+          <h1 style="color:${BRAND_COLOR};font-size:28px;">Can you take a Sunday?</h1>
+          <p style="font-size:18px;line-height:1.6;color:#44403c;">
+            Hi ${name}, here are the upcoming Sundays for the <strong>${safeTeam}</strong>
+            that still need a volunteer. Tap a button and you&rsquo;re signed up.
+          </p>
+          ${rows.join("")}
+          <p style="font-size:14px;color:#78716c;margin-top:24px;">
+            Want to see the full schedule?
+            <a href="${SITE_URL}/serving/${group_id}" style="color:${BRAND_COLOR};">View the team page</a>
+          </p>
+        `),
+      })) sent++;
     }
+
+    // Log broadcast
+    await supabase.from("serving_broadcasts").insert({
+      group_id,
+      sent_by: null, // automated — no user
+      message: `Monthly auto-broadcast: ${openDates.length} open Sunday(s)`,
+    });
   }
 
+  return sent;
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+Deno.serve(async (req) => {
+  let mode = "daily";
+  try {
+    const body = await req.json();
+    if (body?.mode === "monthly") mode = "monthly";
+  } catch {
+    // no body or bad JSON — default to daily
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SECRET_KEY);
+  const canSign = await resolveCanSign(supabase);
+
+  const sent =
+    mode === "monthly"
+      ? await runMonthly(supabase, canSign)
+      : await runDaily(supabase, canSign);
+
   return new Response(
-    JSON.stringify({ message: `Sent ${emailsSent} reminder emails` }),
+    JSON.stringify({ mode, message: `Sent ${sent} emails` }),
     { headers: { "Content-Type": "application/json" } }
   );
 });


### PR DESCRIPTION
## Summary

- **Serving nav hidden** for members not on any enabled serving team — computed server-side in the root layout so there's no flash; admins always see it
- **Overview page** only lists teams the user is a member of; admins see all enabled teams
- **Schedule page** redirects non-members back to `/serving` instead of showing a read-only view they can't interact with
- **Spouse picker** now uses the service client so spouses with `role = 'pending'` (never logged in) are found — previously the directory RLS filtered them out
- **EmailTeamButton** shows an actionable warning ("Add members in Admin → Groups") and disables Send when `memberCount = 0`, instead of silently showing "Send to 0 members"
- **AdminServingSetup** toast now includes the actual Supabase error message for easier debugging
- **Edge function monthly broadcast** fixed: was inserting into a non-existent `message` column instead of `subject` (NOT NULL); also now correctly populates `open_dates` and `recipient_count`

## Test plan

- [ ] Member not on any serving team: Serving tab absent from sidebar; direct `/serving` URL redirects to dashboard or shows empty state
- [ ] Member on a serving team: Serving tab visible, overview shows only their team(s)
- [ ] Admin: sees all enabled teams, Serving tab always visible
- [ ] Spouse with `role = 'pending'`: "Who's coming?" dialog shows "Me & [spouse]" option
- [ ] Leader clicking "Email the team" on a group with no members sees the warning and a disabled Send button
- [ ] Enable serving for a new team via the setup card — toast now shows the actual DB error if it fails

https://claude.ai/code/session_01MAK4wMMCwtiGAx3dYV7AwH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin “Serving Stats” page with date-range filtering, team breakdowns, totals, and empty states.
  * Added a “Previous weeks” serving history view on team pages.
  * Expanded serving reminders to handle both daily reminders and monthly broadcasts for open dates.

* **Bug Fixes**
  * Improved serving access and navigation so users only see serving areas they can use.
  * Prevented team emails from sending when no members are found.
  * Showed clearer error details when enabling serving signups fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->