### PR TITLE
feat(household): spouse/primary self-service household management

### DIFF
--- a/app/api/household/link-member/route.ts
+++ b/app/api/household/link-member/route.ts
@@ -47,9 +47,14 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const { profile_id } = body;
+  const { profile_id, relationship } = body;
   if (!profile_id || typeof profile_id !== "string") {
     return NextResponse.json({ error: "profile_id is required" }, { status: 400 });
+  }
+
+  const validRelationships = ["primary", "spouse", "child", "parent", "sibling", "other"];
+  if (relationship && !validRelationships.includes(relationship as string)) {
+    return NextResponse.json({ error: "Invalid relationship value." }, { status: 400 });
   }
 
   // Can't link yourself
@@ -83,7 +88,10 @@ export async function POST(request: Request) {
   const service = await createServiceClient();
   const { error } = await service
     .from("profiles")
-    .update({ family_id: currentProfile.family_id })
+    .update({
+      family_id: currentProfile.family_id,
+      ...(relationship ? { relationship } : {}),
+    })
     .eq("id", profile_id);
 
   if (error) {
@@ -92,6 +100,6 @@ export async function POST(request: Request) {
   }
 
   return NextResponse.json({
-    data: { profile_id, family_id: currentProfile.family_id },
+    data: { profile_id, family_id: currentProfile.family_id, relationship: relationship ?? null },
   });
 }

--- a/app/api/household/link-member/route.ts
+++ b/app/api/household/link-member/route.ts
@@ -84,19 +84,32 @@ export async function POST(request: Request) {
     );
   }
 
-  // Use service client to bypass RLS for the cross-profile family_id update
+  // Use service client to bypass RLS for the cross-profile family_id update.
+  // The .is("family_id", null) predicate closes the TOCTOU window: if another
+  // request assigned this person to a household between the check above and this
+  // write, the update will match 0 rows and we return 409 rather than silently
+  // overwriting.
   const service = await createServiceClient();
-  const { error } = await service
+  const { data: updated, error } = await service
     .from("profiles")
     .update({
       family_id: currentProfile.family_id,
       ...(relationship ? { relationship } : {}),
     })
-    .eq("id", profile_id);
+    .eq("id", profile_id)
+    .is("family_id", null)
+    .select("id");
 
   if (error) {
     console.error("link-member error:", error);
     return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  if (!updated || updated.length === 0) {
+    return NextResponse.json(
+      { error: "This member was assigned to a household by someone else just now. Refresh and try again." },
+      { status: 409 },
+    );
   }
 
   return NextResponse.json({

--- a/app/api/household/link-member/route.ts
+++ b/app/api/household/link-member/route.ts
@@ -1,0 +1,97 @@
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+/**
+ * POST /api/household/link-member
+ *
+ * Allows a primary/spouse to add an existing enrolled member (who has no
+ * household assigned) to their own household. Uses the service client to
+ * bypass RLS since regular members can't update another profile's family_id.
+ *
+ * Body: { profile_id: string }
+ */
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data: currentProfile } = await supabase
+    .from("profiles")
+    .select("role, family_id, setup_completed, relationship")
+    .eq("id", user.id)
+    .single();
+
+  if (
+    !currentProfile ||
+    !["member", "content_editor", "admin"].includes(currentProfile.role) ||
+    !currentProfile.setup_completed ||
+    !currentProfile.family_id
+  ) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!["primary", "spouse"].includes(currentProfile.relationship ?? "")) {
+    return NextResponse.json(
+      { error: "Only the household primary or spouse can add members." },
+      { status: 403 },
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { profile_id } = body;
+  if (!profile_id || typeof profile_id !== "string") {
+    return NextResponse.json({ error: "profile_id is required" }, { status: 400 });
+  }
+
+  // Can't link yourself
+  if (profile_id === user.id) {
+    return NextResponse.json({ error: "Cannot link your own profile." }, { status: 400 });
+  }
+
+  // Verify the target profile exists, has no household, and is a member
+  const { data: target } = await supabase
+    .from("profiles")
+    .select("id, first_name, last_name, family_id, role, setup_completed")
+    .eq("id", profile_id)
+    .single();
+
+  if (!target) {
+    return NextResponse.json({ error: "Member not found." }, { status: 404 });
+  }
+
+  if (!["member", "content_editor", "admin"].includes(target.role)) {
+    return NextResponse.json({ error: "This person is not an enrolled member." }, { status: 400 });
+  }
+
+  if (target.family_id) {
+    return NextResponse.json(
+      { error: "This member is already in a household. Contact an admin to move them." },
+      { status: 409 },
+    );
+  }
+
+  // Use service client to bypass RLS for the cross-profile family_id update
+  const service = await createServiceClient();
+  const { error } = await service
+    .from("profiles")
+    .update({ family_id: currentProfile.family_id })
+    .eq("id", profile_id);
+
+  if (error) {
+    console.error("link-member error:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    data: { profile_id, family_id: currentProfile.family_id },
+  });
+}

--- a/app/api/household/members/[id]/route.ts
+++ b/app/api/household/members/[id]/route.ts
@@ -37,6 +37,13 @@ export async function PATCH(request: Request, { params }: RouteParams) {
   const ctx = await getMemberContext(supabase);
   if (!ctx) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
+  if (!["primary", "spouse"].includes(ctx.profile.relationship ?? "")) {
+    return NextResponse.json(
+      { error: "Only the household primary or spouse can edit family members." },
+      { status: 403 },
+    );
+  }
+
   // Verify the family member belongs to the current user's household
   const { data: existing } = await supabase
     .from("family_members")

--- a/app/api/household/members/[id]/route.ts
+++ b/app/api/household/members/[id]/route.ts
@@ -1,0 +1,117 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import { titleCaseName } from "@/lib/sanitize";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+async function getMemberContext(supabase: Awaited<ReturnType<typeof createClient>>) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role, family_id, setup_completed")
+    .eq("id", user.id)
+    .single();
+
+  if (
+    !profile ||
+    !["member", "content_editor", "admin"].includes(profile.role) ||
+    !profile.setup_completed ||
+    !profile.family_id
+  ) {
+    return null;
+  }
+
+  return { user, profile };
+}
+
+/** PATCH /api/household/members/[id] — update a family member in current household */
+export async function PATCH(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const ctx = await getMemberContext(supabase);
+  if (!ctx) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  // Verify the family member belongs to the current user's household
+  const { data: existing } = await supabase
+    .from("family_members")
+    .select("family_id")
+    .eq("id", id)
+    .single();
+
+  if (!existing || existing.family_id !== ctx.profile.family_id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { first_name, last_name, relationship, birth_month, birth_day, birth_year } = body;
+
+  const updates: Record<string, unknown> = {};
+  if (first_name !== undefined) {
+    const name = titleCaseName(String(first_name));
+    if (!name) return NextResponse.json({ error: "first_name cannot be empty" }, { status: 400 });
+    updates.first_name = name;
+  }
+  if (last_name !== undefined) updates.last_name = titleCaseName(String(last_name ?? "")) || null;
+  if (relationship !== undefined) updates.relationship = relationship;
+  if (birth_month !== undefined) updates.birth_month = birth_month ? Number(birth_month) : null;
+  if (birth_day !== undefined) updates.birth_day = birth_day ? Number(birth_day) : null;
+  if (birth_year !== undefined) updates.birth_year = birth_year ? Number(birth_year) : null;
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: "No fields to update" }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from("family_members")
+    .update(updates)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("household/members PATCH error:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ data });
+}
+
+/** DELETE /api/household/members/[id] — remove a family member from current household */
+export async function DELETE(_request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const ctx = await getMemberContext(supabase);
+  if (!ctx) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  // Verify the family member belongs to the current user's household
+  const { data: existing } = await supabase
+    .from("family_members")
+    .select("family_id")
+    .eq("id", id)
+    .single();
+
+  if (!existing || existing.family_id !== ctx.profile.family_id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const { error } = await supabase.from("family_members").delete().eq("id", id);
+
+  if (error) {
+    console.error("household/members DELETE error:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/household/members/[id]/route.ts
+++ b/app/api/household/members/[id]/route.ts
@@ -55,7 +55,17 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const { first_name, last_name, relationship, birth_month, birth_day, birth_year } = body;
+  const {
+    first_name,
+    last_name,
+    preferred_name,
+    relationship,
+    birth_month,
+    birth_day,
+    birth_year,
+    is_class_member,
+    avatar_url,
+  } = body;
 
   const updates: Record<string, unknown> = {};
   if (first_name !== undefined) {
@@ -64,10 +74,13 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     updates.first_name = name;
   }
   if (last_name !== undefined) updates.last_name = titleCaseName(String(last_name ?? "")) || null;
+  if (preferred_name !== undefined) updates.preferred_name = titleCaseName(String(preferred_name ?? "")) || null;
   if (relationship !== undefined) updates.relationship = relationship;
   if (birth_month !== undefined) updates.birth_month = birth_month ? Number(birth_month) : null;
   if (birth_day !== undefined) updates.birth_day = birth_day ? Number(birth_day) : null;
   if (birth_year !== undefined) updates.birth_year = birth_year ? Number(birth_year) : null;
+  if (is_class_member !== undefined) updates.is_class_member = Boolean(is_class_member);
+  if (avatar_url !== undefined) updates.avatar_url = avatar_url || null;
 
   if (Object.keys(updates).length === 0) {
     return NextResponse.json({ error: "No fields to update" }, { status: 400 });

--- a/app/api/household/members/[id]/route.ts
+++ b/app/api/household/members/[id]/route.ts
@@ -14,7 +14,7 @@ async function getMemberContext(supabase: Awaited<ReturnType<typeof createClient
 
   const { data: profile } = await supabase
     .from("profiles")
-    .select("role, family_id, setup_completed")
+    .select("role, family_id, setup_completed, relationship")
     .eq("id", user.id)
     .single();
 
@@ -107,6 +107,13 @@ export async function DELETE(_request: Request, { params }: RouteParams) {
   const supabase = await createClient();
   const ctx = await getMemberContext(supabase);
   if (!ctx) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  if (!["primary", "spouse"].includes(ctx.profile.relationship ?? "")) {
+    return NextResponse.json(
+      { error: "Only the household primary or spouse can remove family members." },
+      { status: 403 },
+    );
+  }
 
   // Verify the family member belongs to the current user's household
   const { data: existing } = await supabase

--- a/app/api/household/members/route.ts
+++ b/app/api/household/members/route.ts
@@ -1,0 +1,84 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import { titleCaseName } from "@/lib/sanitize";
+
+async function getMemberContext(supabase: Awaited<ReturnType<typeof createClient>>) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role, family_id, setup_completed")
+    .eq("id", user.id)
+    .single();
+
+  if (
+    !profile ||
+    !["member", "content_editor", "admin"].includes(profile.role) ||
+    !profile.setup_completed ||
+    !profile.family_id
+  ) {
+    return null;
+  }
+
+  return { user, profile };
+}
+
+/** GET /api/household/members — list non-auth family members for current household */
+export async function GET() {
+  const supabase = await createClient();
+  const ctx = await getMemberContext(supabase);
+  if (!ctx) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { data, error } = await supabase
+    .from("family_members")
+    .select("*")
+    .eq("family_id", ctx.profile.family_id)
+    .order("relationship");
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ data: data ?? [] });
+}
+
+/** POST /api/household/members — add a non-auth family member to current household */
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const ctx = await getMemberContext(supabase);
+  if (!ctx) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { first_name, last_name, relationship, birth_month, birth_day, birth_year } = body;
+
+  const firstName = titleCaseName(String(first_name ?? ""));
+  if (!firstName) return NextResponse.json({ error: "first_name is required" }, { status: 400 });
+  if (!relationship) return NextResponse.json({ error: "relationship is required" }, { status: 400 });
+
+  const { data, error } = await supabase
+    .from("family_members")
+    .insert({
+      family_id: ctx.profile.family_id,
+      first_name: firstName,
+      last_name: titleCaseName(String(last_name ?? "")) || null,
+      relationship,
+      birth_month: birth_month ? Number(birth_month) : null,
+      birth_day: birth_day ? Number(birth_day) : null,
+      birth_year: birth_year ? Number(birth_year) : null,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error("household/members POST error:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ data }, { status: 201 });
+}

--- a/app/api/household/members/route.ts
+++ b/app/api/household/members/route.ts
@@ -10,7 +10,7 @@ async function getMemberContext(supabase: Awaited<ReturnType<typeof createClient
 
   const { data: profile } = await supabase
     .from("profiles")
-    .select("role, family_id, setup_completed")
+    .select("role, family_id, setup_completed, relationship")
     .eq("id", user.id)
     .single();
 
@@ -47,6 +47,13 @@ export async function POST(request: Request) {
   const supabase = await createClient();
   const ctx = await getMemberContext(supabase);
   if (!ctx) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  if (!["primary", "spouse"].includes(ctx.profile.relationship ?? "")) {
+    return NextResponse.json(
+      { error: "Only the household primary or spouse can add family members." },
+      { status: 403 },
+    );
+  }
 
   let body: Record<string, unknown>;
   try {

--- a/app/api/household/members/route.ts
+++ b/app/api/household/members/route.ts
@@ -55,7 +55,16 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const { first_name, last_name, relationship, birth_month, birth_day, birth_year } = body;
+  const {
+    first_name,
+    last_name,
+    preferred_name,
+    relationship,
+    birth_month,
+    birth_day,
+    birth_year,
+    is_class_member,
+  } = body;
 
   const firstName = titleCaseName(String(first_name ?? ""));
   if (!firstName) return NextResponse.json({ error: "first_name is required" }, { status: 400 });
@@ -67,10 +76,12 @@ export async function POST(request: Request) {
       family_id: ctx.profile.family_id,
       first_name: firstName,
       last_name: titleCaseName(String(last_name ?? "")) || null,
+      preferred_name: titleCaseName(String(preferred_name ?? "")) || null,
       relationship,
       birth_month: birth_month ? Number(birth_month) : null,
       birth_day: birth_day ? Number(birth_day) : null,
       birth_year: birth_year ? Number(birth_year) : null,
+      is_class_member: is_class_member ? Boolean(is_class_member) : false,
     })
     .select()
     .single();

--- a/app/api/household/route.ts
+++ b/app/api/household/route.ts
@@ -17,7 +17,7 @@ async function getHouseholdContext(supabase: Awaited<ReturnType<typeof createCli
 
   const { data: profile } = await supabase
     .from("profiles")
-    .select("role, family_id, setup_completed")
+    .select("role, family_id, setup_completed, relationship")
     .eq("id", user.id)
     .single();
 
@@ -54,6 +54,13 @@ export async function PATCH(request: Request) {
   const supabase = await createClient();
   const ctx = await getHouseholdContext(supabase);
   if (!ctx) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  if (!["primary", "spouse"].includes(ctx.profile.relationship ?? "")) {
+    return NextResponse.json(
+      { error: "Only the household primary or spouse can update household info." },
+      { status: 403 },
+    );
+  }
 
   let body: Record<string, unknown>;
   try {

--- a/app/api/household/route.ts
+++ b/app/api/household/route.ts
@@ -1,0 +1,124 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import {
+  titleCaseName,
+  titleCaseStreet,
+  titleCaseCity,
+  normalizePhone,
+  normalizeState,
+  normalizePostalCode,
+} from "@/lib/sanitize";
+
+async function getHouseholdContext(supabase: Awaited<ReturnType<typeof createClient>>) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role, family_id, setup_completed")
+    .eq("id", user.id)
+    .single();
+
+  if (
+    !profile ||
+    !["member", "content_editor", "admin"].includes(profile.role) ||
+    !profile.setup_completed ||
+    !profile.family_id
+  ) {
+    return null;
+  }
+
+  return { user, profile };
+}
+
+/** GET /api/household — fetch current user's family unit */
+export async function GET() {
+  const supabase = await createClient();
+  const ctx = await getHouseholdContext(supabase);
+  if (!ctx) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { data: family, error } = await supabase
+    .from("family_units")
+    .select("*")
+    .eq("id", ctx.profile.family_id)
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ data: family });
+}
+
+/** PATCH /api/household — update current user's family unit info */
+export async function PATCH(request: Request) {
+  const supabase = await createClient();
+  const ctx = await getHouseholdContext(supabase);
+  if (!ctx) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const {
+    family_name,
+    address_line1,
+    address_line2,
+    city,
+    state,
+    postal_code,
+    phone_home,
+    anniversary,
+    hide_address,
+    hide_phone_home,
+  } = body;
+
+  const updates: Record<string, unknown> = {};
+
+  if (family_name !== undefined) {
+    const name = titleCaseName(String(family_name));
+    if (!name) return NextResponse.json({ error: "Family name is required" }, { status: 400 });
+    updates.family_name = name;
+  }
+  if (address_line1 !== undefined) updates.address_line1 = titleCaseStreet(String(address_line1 ?? "")) || null;
+  if (address_line2 !== undefined) updates.address_line2 = titleCaseStreet(String(address_line2 ?? "")) || null;
+  if (city !== undefined) updates.city = titleCaseCity(String(city ?? "")) || null;
+  if (state !== undefined) {
+    const stateCode = state ? normalizeState(String(state)) : null;
+    if (state && !stateCode) return NextResponse.json({ error: "Invalid state" }, { status: 400 });
+    updates.state = stateCode;
+  }
+  if (postal_code !== undefined) {
+    const postal = postal_code ? normalizePostalCode(String(postal_code)) : null;
+    if (postal_code && !postal) return NextResponse.json({ error: "Invalid ZIP code" }, { status: 400 });
+    updates.postal_code = postal;
+  }
+  if (phone_home !== undefined) {
+    const phone = phone_home ? normalizePhone(String(phone_home)) : null;
+    if (phone_home && !phone) return NextResponse.json({ error: "Invalid home phone" }, { status: 400 });
+    updates.phone_home = phone;
+  }
+  if (anniversary !== undefined) updates.anniversary = anniversary || null;
+  if (hide_address !== undefined) updates.hide_address = Boolean(hide_address);
+  if (hide_phone_home !== undefined) updates.hide_phone_home = Boolean(hide_phone_home);
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: "No fields to update" }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from("family_units")
+    .update(updates)
+    .eq("id", ctx.profile.family_id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("household PATCH error:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ data });
+}

--- a/app/api/household/search-members/route.ts
+++ b/app/api/household/search-members/route.ts
@@ -1,0 +1,57 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/household/search-members?q=name
+ *
+ * Search enrolled profiles who have no household assigned, to allow a
+ * primary/spouse to link them to their own household.
+ */
+export async function GET(request: Request) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data: currentProfile } = await supabase
+    .from("profiles")
+    .select("role, family_id, setup_completed, relationship")
+    .eq("id", user.id)
+    .single();
+
+  if (
+    !currentProfile ||
+    !["member", "content_editor", "admin"].includes(currentProfile.role) ||
+    !currentProfile.setup_completed ||
+    !currentProfile.family_id
+  ) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!["primary", "spouse"].includes(currentProfile.relationship ?? "")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const q = (searchParams.get("q") ?? "").trim();
+  if (q.length < 2) {
+    return NextResponse.json({ data: [] });
+  }
+
+  // Search profiles without a household, matching first or last name
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id, first_name, last_name, preferred_name, avatar_url, email")
+    .is("family_id", null)
+    .neq("id", user.id)
+    .in("role", ["member", "content_editor", "admin"])
+    .eq("setup_completed", true)
+    .or(`first_name.ilike.%${q}%,last_name.ilike.%${q}%,preferred_name.ilike.%${q}%`)
+    .order("first_name")
+    .limit(10);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ data: data ?? [] });
+}

--- a/app/api/household/search-members/route.ts
+++ b/app/api/household/search-members/route.ts
@@ -40,18 +40,30 @@ export async function GET(request: Request) {
     return NextResponse.json({ data: [] });
   }
 
-  // Search profiles without a household, matching first or last name
+  // Escape PostgREST filter special characters to prevent malformed queries
+  const safe = q.replace(/[,()]/g, "");
+
+  // Search profiles without a household, matching first or last name.
+  // We select hide_email so we can respect the member's privacy setting
+  // before displaying their email in the UI.
   const { data, error } = await supabase
     .from("profiles")
-    .select("id, first_name, last_name, preferred_name, avatar_url, email")
+    .select("id, first_name, last_name, preferred_name, avatar_url, email, hide_email")
     .is("family_id", null)
     .neq("id", user.id)
     .in("role", ["member", "content_editor", "admin"])
     .eq("setup_completed", true)
-    .or(`first_name.ilike.%${q}%,last_name.ilike.%${q}%,preferred_name.ilike.%${q}%`)
+    .or(`first_name.ilike.%${safe}%,last_name.ilike.%${safe}%,preferred_name.ilike.%${safe}%`)
     .order("first_name")
     .limit(10);
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ data: data ?? [] });
+
+  // Mask email for members who have opted out of showing it
+  const results = (data ?? []).map(({ hide_email, email, ...rest }) => ({
+    ...rest,
+    email: hide_email ? null : email,
+  }));
+
+  return NextResponse.json({ data: results });
 }

--- a/app/household/HouseholdClient.tsx
+++ b/app/household/HouseholdClient.tsx
@@ -1,0 +1,671 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Separator } from "@/components/ui/separator";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "sonner";
+import { Pencil, Plus, Trash2, User, X } from "lucide-react";
+import {
+  formatPhone,
+  formatPhoneAsYouType,
+  titleCaseName,
+  titleCaseStreet,
+  titleCaseCity,
+} from "@/lib/sanitize";
+import { displayName, initials } from "@/lib/names";
+import type { Profile, FamilyUnit, FamilyMember, FamilyMemberRelationship } from "@/lib/types";
+
+const MONTHS = [
+  { value: "1", label: "January" },
+  { value: "2", label: "February" },
+  { value: "3", label: "March" },
+  { value: "4", label: "April" },
+  { value: "5", label: "May" },
+  { value: "6", label: "June" },
+  { value: "7", label: "July" },
+  { value: "8", label: "August" },
+  { value: "9", label: "September" },
+  { value: "10", label: "October" },
+  { value: "11", label: "November" },
+  { value: "12", label: "December" },
+];
+
+const RELATIONSHIPS: { value: FamilyMemberRelationship; label: string }[] = [
+  { value: "child", label: "Child" },
+  { value: "spouse", label: "Spouse" },
+  { value: "parent", label: "Parent" },
+  { value: "sibling", label: "Sibling" },
+  { value: "other", label: "Other" },
+];
+
+interface HouseholdInfo {
+  family_name: string;
+  address_line1: string;
+  address_line2: string;
+  city: string;
+  state: string;
+  postal_code: string;
+  phone_home: string;
+  anniversary: string;
+  hide_address: boolean;
+  hide_phone_home: boolean;
+}
+
+interface MemberFormState {
+  first_name: string;
+  last_name: string;
+  relationship: FamilyMemberRelationship;
+  birth_month: string;
+  birth_day: string;
+  birth_year: string;
+}
+
+const EMPTY_MEMBER_FORM: MemberFormState = {
+  first_name: "",
+  last_name: "",
+  relationship: "child",
+  birth_month: "",
+  birth_day: "",
+  birth_year: "",
+};
+
+interface HouseholdClientProps {
+  currentProfile: Profile;
+  family: FamilyUnit;
+  initialFamilyMembers: FamilyMember[];
+  householdProfiles: Pick<Profile, "id" | "first_name" | "last_name" | "preferred_name" | "relationship" | "role" | "avatar_url" | "email">[];
+}
+
+function fromFamily(f: FamilyUnit): HouseholdInfo {
+  return {
+    family_name: f.family_name,
+    address_line1: f.address_line1 ?? "",
+    address_line2: f.address_line2 ?? "",
+    city: f.city ?? "",
+    state: f.state ?? "",
+    postal_code: f.postal_code ?? "",
+    phone_home: formatPhone(f.phone_home) ?? "",
+    anniversary: f.anniversary ?? "",
+    hide_address: f.hide_address,
+    hide_phone_home: f.hide_phone_home,
+  };
+}
+
+export function HouseholdClient({
+  currentProfile,
+  family,
+  initialFamilyMembers,
+  householdProfiles,
+}: HouseholdClientProps) {
+  const [info, setInfo] = useState<HouseholdInfo>(fromFamily(family));
+  const [savingInfo, setSavingInfo] = useState(false);
+
+  const [familyMembers, setFamilyMembers] = useState<FamilyMember[]>(initialFamilyMembers);
+  const [showMemberForm, setShowMemberForm] = useState(false);
+  const [editingMember, setEditingMember] = useState<FamilyMember | null>(null);
+  const [memberForm, setMemberForm] = useState<MemberFormState>(EMPTY_MEMBER_FORM);
+  const [savingMember, setSavingMember] = useState(false);
+
+  // ---- Household info ----
+  async function handleSaveInfo(e: React.FormEvent) {
+    e.preventDefault();
+    setSavingInfo(true);
+
+    const res = await fetch("/api/household", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        family_name: info.family_name,
+        address_line1: info.address_line1,
+        address_line2: info.address_line2,
+        city: info.city,
+        state: info.state,
+        postal_code: info.postal_code,
+        phone_home: info.phone_home,
+        anniversary: info.anniversary || null,
+        hide_address: info.hide_address,
+        hide_phone_home: info.hide_phone_home,
+      }),
+    });
+
+    setSavingInfo(false);
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      toast.error(body.error ?? "Failed to save household info.");
+      return;
+    }
+
+    toast.success("Household info updated.");
+  }
+
+  // ---- Family members ----
+  const loadMembers = useCallback(async () => {
+    const res = await fetch("/api/household/members");
+    if (!res.ok) return;
+    const body = await res.json();
+    setFamilyMembers(body.data ?? []);
+  }, []);
+
+  function startAddMember() {
+    setEditingMember(null);
+    setMemberForm(EMPTY_MEMBER_FORM);
+    setShowMemberForm(true);
+  }
+
+  function startEditMember(fm: FamilyMember) {
+    setEditingMember(fm);
+    setMemberForm({
+      first_name: fm.first_name,
+      last_name: fm.last_name ?? "",
+      relationship: fm.relationship,
+      birth_month: fm.birth_month?.toString() ?? "",
+      birth_day: fm.birth_day?.toString() ?? "",
+      birth_year: fm.birth_year?.toString() ?? "",
+    });
+    setShowMemberForm(true);
+  }
+
+  function cancelMemberForm() {
+    setShowMemberForm(false);
+    setEditingMember(null);
+    setMemberForm(EMPTY_MEMBER_FORM);
+  }
+
+  async function handleSaveMember() {
+    const firstName = titleCaseName(memberForm.first_name);
+    if (!firstName) {
+      toast.error("First name is required.");
+      return;
+    }
+
+    setSavingMember(true);
+
+    const payload = {
+      first_name: firstName,
+      last_name: titleCaseName(memberForm.last_name) || null,
+      relationship: memberForm.relationship,
+      birth_month: memberForm.birth_month ? Number(memberForm.birth_month) : null,
+      birth_day: memberForm.birth_day ? Number(memberForm.birth_day) : null,
+      birth_year: memberForm.birth_year ? Number(memberForm.birth_year) : null,
+    };
+
+    const url = editingMember
+      ? `/api/household/members/${editingMember.id}`
+      : "/api/household/members";
+    const method = editingMember ? "PATCH" : "POST";
+
+    const res = await fetch(url, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    setSavingMember(false);
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      toast.error(body.error ?? "Failed to save family member.");
+      return;
+    }
+
+    toast.success(editingMember ? "Family member updated." : "Family member added.");
+    cancelMemberForm();
+    loadMembers();
+  }
+
+  async function handleDeleteMember(fm: FamilyMember) {
+    if (!confirm(`Remove ${fm.first_name} from this household?`)) return;
+
+    const res = await fetch(`/api/household/members/${fm.id}`, { method: "DELETE" });
+    if (!res.ok) {
+      toast.error("Failed to remove family member.");
+      return;
+    }
+    toast.success("Family member removed.");
+    loadMembers();
+  }
+
+  const canEditSpouseProfiles =
+    currentProfile.relationship === "primary" ||
+    currentProfile.relationship === "spouse";
+
+  return (
+    <div className="space-y-8">
+      {/* ---- Household Info ---- */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Household Info</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSaveInfo} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="family_name" className="text-base">
+                Family name <span className="text-destructive" aria-hidden>*</span>
+              </Label>
+              <Input
+                id="family_name"
+                value={info.family_name}
+                onChange={(e) => setInfo({ ...info, family_name: e.target.value })}
+                onBlur={(e) =>
+                  setInfo({ ...info, family_name: titleCaseName(e.target.value) || "" })
+                }
+                required
+                className="text-base py-5"
+              />
+            </div>
+
+            <Separator />
+
+            <div className="space-y-2">
+              <Label htmlFor="address_line1" className="text-base">Street address</Label>
+              <Input
+                id="address_line1"
+                value={info.address_line1}
+                onChange={(e) => setInfo({ ...info, address_line1: e.target.value })}
+                onBlur={(e) =>
+                  setInfo({ ...info, address_line1: titleCaseStreet(e.target.value) || "" })
+                }
+                placeholder="123 Main St"
+                className="text-base py-5"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="address_line2" className="text-base">
+                Apt / unit{" "}
+                <span className="text-muted-foreground font-normal">(optional)</span>
+              </Label>
+              <Input
+                id="address_line2"
+                value={info.address_line2}
+                onChange={(e) => setInfo({ ...info, address_line2: e.target.value })}
+                onBlur={(e) =>
+                  setInfo({ ...info, address_line2: titleCaseStreet(e.target.value) || "" })
+                }
+                placeholder="Apt 4B"
+                className="text-base py-5"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-6 gap-3">
+              <div className="sm:col-span-3 space-y-2">
+                <Label htmlFor="city" className="text-base">City</Label>
+                <Input
+                  id="city"
+                  value={info.city}
+                  onChange={(e) => setInfo({ ...info, city: e.target.value })}
+                  onBlur={(e) =>
+                    setInfo({ ...info, city: titleCaseCity(e.target.value) || "" })
+                  }
+                  className="text-base py-5"
+                />
+              </div>
+              <div className="sm:col-span-1 space-y-2">
+                <Label htmlFor="state" className="text-base">State</Label>
+                <Input
+                  id="state"
+                  value={info.state}
+                  onChange={(e) => setInfo({ ...info, state: e.target.value.toUpperCase() })}
+                  maxLength={2}
+                  placeholder="TX"
+                  className="text-base py-5 uppercase"
+                />
+              </div>
+              <div className="sm:col-span-2 space-y-2">
+                <Label htmlFor="postal_code" className="text-base">ZIP</Label>
+                <Input
+                  id="postal_code"
+                  value={info.postal_code}
+                  onChange={(e) => setInfo({ ...info, postal_code: e.target.value })}
+                  placeholder="12345"
+                  className="text-base py-5"
+                />
+              </div>
+            </div>
+
+            <Separator />
+
+            <div className="space-y-2">
+              <Label htmlFor="phone_home" className="text-base">
+                Home phone{" "}
+                <span className="text-muted-foreground font-normal">(optional)</span>
+              </Label>
+              <Input
+                id="phone_home"
+                type="tel"
+                inputMode="tel"
+                value={info.phone_home}
+                onChange={(e) =>
+                  setInfo({ ...info, phone_home: formatPhoneAsYouType(e.target.value) })
+                }
+                placeholder="(555) 123-4567"
+                className="text-base py-5"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="anniversary" className="text-base">
+                Anniversary{" "}
+                <span className="text-muted-foreground font-normal">(optional)</span>
+              </Label>
+              <Input
+                id="anniversary"
+                type="date"
+                value={info.anniversary}
+                onChange={(e) => setInfo({ ...info, anniversary: e.target.value })}
+                className="text-base py-5"
+              />
+            </div>
+
+            <Separator />
+
+            <div className="space-y-3">
+              <p className="text-sm font-semibold">Privacy</p>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="hide_address" className="text-base cursor-pointer">
+                  Hide address from directory
+                </Label>
+                <Switch
+                  id="hide_address"
+                  checked={info.hide_address}
+                  onCheckedChange={(v) => setInfo({ ...info, hide_address: v })}
+                />
+              </div>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="hide_phone_home" className="text-base cursor-pointer">
+                  Hide home phone from directory
+                </Label>
+                <Switch
+                  id="hide_phone_home"
+                  checked={info.hide_phone_home}
+                  onCheckedChange={(v) => setInfo({ ...info, hide_phone_home: v })}
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end">
+              <Button
+                type="submit"
+                disabled={savingInfo}
+                className="bg-brand-primary hover:bg-brand-primary/90 text-white"
+              >
+                {savingInfo ? "Saving..." : "Save Household Info"}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {/* ---- Enrolled Members ---- */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Enrolled Members</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {/* Current user */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Avatar className="h-9 w-9">
+                {currentProfile.avatar_url && (
+                  <AvatarImage src={currentProfile.avatar_url} alt={displayName(currentProfile)} />
+                )}
+                <AvatarFallback className="bg-brand-primary text-white text-sm">
+                  {initials(currentProfile)}
+                </AvatarFallback>
+              </Avatar>
+              <div>
+                <span className="text-sm font-medium">{displayName(currentProfile)}</span>
+                <Badge variant="outline" className="ml-2 text-xs capitalize">
+                  {currentProfile.relationship}
+                </Badge>
+                <Badge variant="secondary" className="ml-1 text-xs">
+                  You
+                </Badge>
+              </div>
+            </div>
+            <Button variant="outline" size="sm" nativeButton={false} render={<Link href="/profile" />}>
+              <Pencil className="mr-1 h-4 w-4" />
+              Edit
+            </Button>
+          </div>
+
+          {householdProfiles.map((p) => (
+            <div key={p.id} className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <Avatar className="h-9 w-9">
+                  {p.avatar_url && (
+                    <AvatarImage src={p.avatar_url} alt={displayName(p)} />
+                  )}
+                  <AvatarFallback className="bg-brand-primary text-white text-sm">
+                    {initials(p)}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <span className="text-sm font-medium">{displayName(p)}</span>
+                  <Badge variant="outline" className="ml-2 text-xs capitalize">
+                    {p.relationship}
+                  </Badge>
+                </div>
+              </div>
+              {canEditSpouseProfiles ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  nativeButton={false}
+                  render={<Link href={`/household/member/${p.id}`} />}
+                >
+                  <Pencil className="mr-1 h-4 w-4" />
+                  Edit
+                </Button>
+              ) : (
+                <span className="text-xs text-muted-foreground">Contact admin to edit</span>
+              )}
+            </div>
+          ))}
+
+          {householdProfiles.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              No other enrolled members in this household.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ---- Non-auth Family Members ---- */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-xl">Family Members</CardTitle>
+            {!showMemberForm && (
+              <Button variant="outline" size="sm" onClick={startAddMember}>
+                <Plus className="mr-1 h-4 w-4" />
+                Add member
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Children, parents, and other household members who don&apos;t have their own account.
+          </p>
+
+          {familyMembers.map((fm) => (
+            <div
+              key={fm.id}
+              className="flex items-center justify-between bg-muted/40 rounded-md px-3 py-2"
+            >
+              <div className="flex items-center gap-3">
+                <div className="h-9 w-9 rounded-full bg-muted flex items-center justify-center">
+                  <User className="h-4 w-4 text-muted-foreground" />
+                </div>
+                <div>
+                  <span className="text-sm font-medium">
+                    {fm.first_name}
+                    {fm.last_name && ` ${fm.last_name}`}
+                  </span>
+                  <Badge variant="outline" className="ml-2 text-xs capitalize">
+                    {fm.relationship}
+                  </Badge>
+                  {fm.birth_month && fm.birth_day && (
+                    <span className="text-xs text-muted-foreground ml-2">
+                      · {MONTHS[fm.birth_month - 1]?.label} {fm.birth_day}
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div className="flex gap-1">
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => startEditMember(fm)}
+                >
+                  <Pencil className="h-4 w-4" />
+                  <span className="sr-only">Edit</span>
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => handleDeleteMember(fm)}
+                >
+                  <Trash2 className="h-4 w-4 text-destructive" />
+                  <span className="sr-only">Remove</span>
+                </Button>
+              </div>
+            </div>
+          ))}
+
+          {familyMembers.length === 0 && !showMemberForm && (
+            <p className="text-sm text-muted-foreground">No additional family members yet.</p>
+          )}
+
+          {/* Add / Edit member inline form */}
+          {showMemberForm && (
+            <div className="border rounded-lg p-4 space-y-4 bg-muted/20">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-semibold">
+                  {editingMember ? "Edit family member" : "Add family member"}
+                </p>
+                <Button variant="ghost" size="icon-sm" onClick={cancelMemberForm}>
+                  <X className="h-4 w-4" />
+                  <span className="sr-only">Cancel</span>
+                </Button>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <Label htmlFor="fm_first" className="text-sm">First name</Label>
+                  <Input
+                    id="fm_first"
+                    value={memberForm.first_name}
+                    onChange={(e) => setMemberForm({ ...memberForm, first_name: e.target.value })}
+                    className="h-9"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="fm_last" className="text-sm">Last name</Label>
+                  <Input
+                    id="fm_last"
+                    value={memberForm.last_name}
+                    onChange={(e) => setMemberForm({ ...memberForm, last_name: e.target.value })}
+                    className="h-9"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-1">
+                <Label htmlFor="fm_rel" className="text-sm">Relationship</Label>
+                <Select
+                  value={memberForm.relationship}
+                  onValueChange={(v) =>
+                    setMemberForm({ ...memberForm, relationship: v as FamilyMemberRelationship })
+                  }
+                >
+                  <SelectTrigger id="fm_rel">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {RELATIONSHIPS.map((r) => (
+                      <SelectItem key={r.value} value={r.value}>
+                        {r.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div>
+                <Label className="text-sm">Birthday (optional)</Label>
+                <div className="grid grid-cols-3 gap-2 mt-1">
+                  <Select
+                    value={memberForm.birth_month}
+                    onValueChange={(v) =>
+                      setMemberForm({ ...memberForm, birth_month: v ?? "" })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Month" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {MONTHS.map((m) => (
+                        <SelectItem key={m.value} value={m.value}>
+                          {m.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Input
+                    type="number"
+                    min="1"
+                    max="31"
+                    placeholder="Day"
+                    value={memberForm.birth_day}
+                    onChange={(e) => setMemberForm({ ...memberForm, birth_day: e.target.value })}
+                  />
+                  <Input
+                    type="number"
+                    min="1900"
+                    max="2100"
+                    placeholder="Year"
+                    value={memberForm.birth_year}
+                    onChange={(e) =>
+                      setMemberForm({ ...memberForm, birth_year: e.target.value })
+                    }
+                  />
+                </div>
+              </div>
+
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" size="sm" onClick={cancelMemberForm}>
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  disabled={savingMember}
+                  onClick={handleSaveMember}
+                  className="bg-brand-primary hover:bg-brand-primary/90 text-white"
+                >
+                  {savingMember ? "Saving..." : editingMember ? "Update" : "Add"}
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/household/HouseholdClient.tsx
+++ b/app/household/HouseholdClient.tsx
@@ -19,6 +19,13 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { toast } from "sonner";
 import { Pencil, Plus, Trash2, User, UserPlus } from "lucide-react";
 import {
@@ -29,7 +36,16 @@ import {
   titleCaseCity,
 } from "@/lib/sanitize";
 import { displayName, initials } from "@/lib/names";
-import type { Profile, FamilyUnit, FamilyMember } from "@/lib/types";
+import type { Profile, FamilyUnit, FamilyMember, FamilyMemberRelationship } from "@/lib/types";
+
+const LINK_RELATIONSHIPS: { value: FamilyMemberRelationship; label: string }[] = [
+  { value: "spouse", label: "Spouse" },
+  { value: "primary", label: "Primary" },
+  { value: "child", label: "Child (adult)" },
+  { value: "parent", label: "Parent" },
+  { value: "sibling", label: "Sibling" },
+  { value: "other", label: "Other" },
+];
 
 interface HouseholdInfo {
   family_name: string;
@@ -97,6 +113,7 @@ export function HouseholdClient({
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
   const [linkingId, setLinkingId] = useState<string | null>(null);
+  const [linkRelationship, setLinkRelationship] = useState<FamilyMemberRelationship>("spouse");
   const searchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const canEditSpouseProfiles =
@@ -183,21 +200,22 @@ export function HouseholdClient({
     const res = await fetch("/api/household/link-member", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ profile_id: profileId }),
+      body: JSON.stringify({ profile_id: profileId, relationship: linkRelationship }),
     });
 
     setLinkingId(null);
 
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
-      toast.error(body.error ?? "Failed to link member.");
+      toast.error(body.error ?? "Failed to add member to household.");
       return;
     }
 
-    toast.success("Member added to your household. They can now edit their own profile.");
+    toast.success("Member added to your household.");
     setAddDialogOpen(false);
     setSearchQuery("");
     setSearchResults([]);
+    setLinkRelationship("spouse");
     router.refresh();
   }
 
@@ -456,20 +474,31 @@ export function HouseholdClient({
         <CardHeader>
           <div className="flex items-center justify-between">
             <CardTitle className="text-xl">Family Members Without Accounts</CardTitle>
-            <Button
-              variant="outline"
-              size="sm"
-              nativeButton={false}
-              render={<Link href="/household/member/fm/new" />}
-            >
-              <Plus className="mr-1 h-4 w-4" />
-              Add member
-            </Button>
+            {canEditSpouseProfiles && (
+              <Button
+                variant="outline"
+                size="sm"
+                nativeButton={false}
+                render={<Link href="/household/member/fm/new" />}
+              >
+                <Plus className="mr-1 h-4 w-4" />
+                Add member
+              </Button>
+            )}
           </div>
         </CardHeader>
         <CardContent className="space-y-3">
           <p className="text-sm text-muted-foreground">
-            Children, parents, and others who don&apos;t have their own account.
+            Children, parents, and others who don&apos;t have their own account. If someone
+            already has an account in the app, use{" "}
+            <button
+              type="button"
+              onClick={() => setAddDialogOpen(true)}
+              className="underline underline-offset-2 text-foreground hover:text-brand-primary"
+            >
+              Link member
+            </button>{" "}
+            instead.
           </p>
 
           {familyMembers.map((fm) => (
@@ -539,11 +568,31 @@ export function HouseholdClient({
           </DialogHeader>
 
           <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="link-relationship" className="text-sm font-medium">
+                Their relationship to your household
+              </Label>
+              <Select
+                value={linkRelationship}
+                onValueChange={(v) => setLinkRelationship(v as FamilyMemberRelationship)}
+              >
+                <SelectTrigger id="link-relationship">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {LINK_RELATIONSHIPS.map((r) => (
+                    <SelectItem key={r.value} value={r.value}>
+                      {r.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
             <Input
               placeholder="Search by name..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              autoFocus
             />
 
             {searchLoading && (

--- a/app/household/HouseholdClient.tsx
+++ b/app/household/HouseholdClient.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -11,14 +12,15 @@ import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { Pencil, Plus, Trash2, User, X } from "lucide-react";
+import { Pencil, Plus, Trash2, User, UserPlus } from "lucide-react";
 import {
   formatPhone,
   formatPhoneAsYouType,
@@ -27,30 +29,7 @@ import {
   titleCaseCity,
 } from "@/lib/sanitize";
 import { displayName, initials } from "@/lib/names";
-import type { Profile, FamilyUnit, FamilyMember, FamilyMemberRelationship } from "@/lib/types";
-
-const MONTHS = [
-  { value: "1", label: "January" },
-  { value: "2", label: "February" },
-  { value: "3", label: "March" },
-  { value: "4", label: "April" },
-  { value: "5", label: "May" },
-  { value: "6", label: "June" },
-  { value: "7", label: "July" },
-  { value: "8", label: "August" },
-  { value: "9", label: "September" },
-  { value: "10", label: "October" },
-  { value: "11", label: "November" },
-  { value: "12", label: "December" },
-];
-
-const RELATIONSHIPS: { value: FamilyMemberRelationship; label: string }[] = [
-  { value: "child", label: "Child" },
-  { value: "spouse", label: "Spouse" },
-  { value: "parent", label: "Parent" },
-  { value: "sibling", label: "Sibling" },
-  { value: "other", label: "Other" },
-];
+import type { Profile, FamilyUnit, FamilyMember } from "@/lib/types";
 
 interface HouseholdInfo {
   family_name: string;
@@ -65,29 +44,23 @@ interface HouseholdInfo {
   hide_phone_home: boolean;
 }
 
-interface MemberFormState {
+interface SearchResult {
+  id: string;
   first_name: string;
-  last_name: string;
-  relationship: FamilyMemberRelationship;
-  birth_month: string;
-  birth_day: string;
-  birth_year: string;
+  last_name: string | null;
+  preferred_name: string | null;
+  avatar_url: string | null;
+  email: string | null;
 }
-
-const EMPTY_MEMBER_FORM: MemberFormState = {
-  first_name: "",
-  last_name: "",
-  relationship: "child",
-  birth_month: "",
-  birth_day: "",
-  birth_year: "",
-};
 
 interface HouseholdClientProps {
   currentProfile: Profile;
   family: FamilyUnit;
   initialFamilyMembers: FamilyMember[];
-  householdProfiles: Pick<Profile, "id" | "first_name" | "last_name" | "preferred_name" | "relationship" | "role" | "avatar_url" | "email">[];
+  householdProfiles: Pick<
+    Profile,
+    "id" | "first_name" | "last_name" | "preferred_name" | "relationship" | "role" | "avatar_url" | "email"
+  >[];
 }
 
 function fromFamily(f: FamilyUnit): HouseholdInfo {
@@ -111,14 +84,24 @@ export function HouseholdClient({
   initialFamilyMembers,
   householdProfiles,
 }: HouseholdClientProps) {
+  const router = useRouter();
   const [info, setInfo] = useState<HouseholdInfo>(fromFamily(family));
   const [savingInfo, setSavingInfo] = useState(false);
-
   const [familyMembers, setFamilyMembers] = useState<FamilyMember[]>(initialFamilyMembers);
-  const [showMemberForm, setShowMemberForm] = useState(false);
-  const [editingMember, setEditingMember] = useState<FamilyMember | null>(null);
-  const [memberForm, setMemberForm] = useState<MemberFormState>(EMPTY_MEMBER_FORM);
-  const [savingMember, setSavingMember] = useState(false);
+
+  // "Add member" dialog
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+
+  // "Link existing account" search within the dialog
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [linkingId, setLinkingId] = useState<string | null>(null);
+  const searchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const canEditSpouseProfiles =
+    currentProfile.relationship === "primary" ||
+    currentProfile.relationship === "spouse";
 
   // ---- Household info ----
   async function handleSaveInfo(e: React.FormEvent) {
@@ -153,81 +136,7 @@ export function HouseholdClient({
     toast.success("Household info updated.");
   }
 
-  // ---- Family members ----
-  const loadMembers = useCallback(async () => {
-    const res = await fetch("/api/household/members");
-    if (!res.ok) return;
-    const body = await res.json();
-    setFamilyMembers(body.data ?? []);
-  }, []);
-
-  function startAddMember() {
-    setEditingMember(null);
-    setMemberForm(EMPTY_MEMBER_FORM);
-    setShowMemberForm(true);
-  }
-
-  function startEditMember(fm: FamilyMember) {
-    setEditingMember(fm);
-    setMemberForm({
-      first_name: fm.first_name,
-      last_name: fm.last_name ?? "",
-      relationship: fm.relationship,
-      birth_month: fm.birth_month?.toString() ?? "",
-      birth_day: fm.birth_day?.toString() ?? "",
-      birth_year: fm.birth_year?.toString() ?? "",
-    });
-    setShowMemberForm(true);
-  }
-
-  function cancelMemberForm() {
-    setShowMemberForm(false);
-    setEditingMember(null);
-    setMemberForm(EMPTY_MEMBER_FORM);
-  }
-
-  async function handleSaveMember() {
-    const firstName = titleCaseName(memberForm.first_name);
-    if (!firstName) {
-      toast.error("First name is required.");
-      return;
-    }
-
-    setSavingMember(true);
-
-    const payload = {
-      first_name: firstName,
-      last_name: titleCaseName(memberForm.last_name) || null,
-      relationship: memberForm.relationship,
-      birth_month: memberForm.birth_month ? Number(memberForm.birth_month) : null,
-      birth_day: memberForm.birth_day ? Number(memberForm.birth_day) : null,
-      birth_year: memberForm.birth_year ? Number(memberForm.birth_year) : null,
-    };
-
-    const url = editingMember
-      ? `/api/household/members/${editingMember.id}`
-      : "/api/household/members";
-    const method = editingMember ? "PATCH" : "POST";
-
-    const res = await fetch(url, {
-      method,
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
-
-    setSavingMember(false);
-
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({}));
-      toast.error(body.error ?? "Failed to save family member.");
-      return;
-    }
-
-    toast.success(editingMember ? "Family member updated." : "Family member added.");
-    cancelMemberForm();
-    loadMembers();
-  }
-
+  // ---- Non-auth family member delete ----
   async function handleDeleteMember(fm: FamilyMember) {
     if (!confirm(`Remove ${fm.first_name} from this household?`)) return;
 
@@ -237,12 +146,60 @@ export function HouseholdClient({
       return;
     }
     toast.success("Family member removed.");
-    loadMembers();
+    setFamilyMembers((prev) => prev.filter((m) => m.id !== fm.id));
   }
 
-  const canEditSpouseProfiles =
-    currentProfile.relationship === "primary" ||
-    currentProfile.relationship === "spouse";
+  // ---- Link existing account ----
+  useEffect(() => {
+    if (searchQuery.length < 2) {
+      setSearchResults([]);
+      return;
+    }
+
+    if (searchTimeout.current) clearTimeout(searchTimeout.current);
+    searchTimeout.current = setTimeout(async () => {
+      setSearchLoading(true);
+      try {
+        const res = await fetch(
+          `/api/household/search-members?q=${encodeURIComponent(searchQuery)}`,
+        );
+        if (res.ok) {
+          const body = await res.json();
+          setSearchResults(body.data ?? []);
+        }
+      } finally {
+        setSearchLoading(false);
+      }
+    }, 300);
+
+    return () => {
+      if (searchTimeout.current) clearTimeout(searchTimeout.current);
+    };
+  }, [searchQuery]);
+
+  async function handleLinkMember(profileId: string) {
+    setLinkingId(profileId);
+
+    const res = await fetch("/api/household/link-member", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile_id: profileId }),
+    });
+
+    setLinkingId(null);
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      toast.error(body.error ?? "Failed to link member.");
+      return;
+    }
+
+    toast.success("Member added to your household. They can now edit their own profile.");
+    setAddDialogOpen(false);
+    setSearchQuery("");
+    setSearchResults([]);
+    router.refresh();
+  }
 
   return (
     <div className="space-y-8">
@@ -414,7 +371,15 @@ export function HouseholdClient({
       {/* ---- Enrolled Members ---- */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-xl">Enrolled Members</CardTitle>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-xl">Members with Accounts</CardTitle>
+            {canEditSpouseProfiles && (
+              <Button variant="outline" size="sm" onClick={() => setAddDialogOpen(true)}>
+                <UserPlus className="mr-1 h-4 w-4" />
+                Link member
+              </Button>
+            )}
+          </div>
         </CardHeader>
         <CardContent className="space-y-3">
           {/* Current user */}
@@ -470,7 +435,7 @@ export function HouseholdClient({
                   render={<Link href={`/household/member/${p.id}`} />}
                 >
                   <Pencil className="mr-1 h-4 w-4" />
-                  Edit
+                  Edit profile
                 </Button>
               ) : (
                 <span className="text-xs text-muted-foreground">Contact admin to edit</span>
@@ -480,7 +445,7 @@ export function HouseholdClient({
 
           {householdProfiles.length === 0 && (
             <p className="text-sm text-muted-foreground">
-              No other enrolled members in this household.
+              No other enrolled members in this household yet.
             </p>
           )}
         </CardContent>
@@ -490,18 +455,21 @@ export function HouseholdClient({
       <Card>
         <CardHeader>
           <div className="flex items-center justify-between">
-            <CardTitle className="text-xl">Family Members</CardTitle>
-            {!showMemberForm && (
-              <Button variant="outline" size="sm" onClick={startAddMember}>
-                <Plus className="mr-1 h-4 w-4" />
-                Add member
-              </Button>
-            )}
+            <CardTitle className="text-xl">Family Members Without Accounts</CardTitle>
+            <Button
+              variant="outline"
+              size="sm"
+              nativeButton={false}
+              render={<Link href="/household/member/fm/new" />}
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              Add member
+            </Button>
           </div>
         </CardHeader>
         <CardContent className="space-y-3">
           <p className="text-sm text-muted-foreground">
-            Children, parents, and other household members who don&apos;t have their own account.
+            Children, parents, and others who don&apos;t have their own account.
           </p>
 
           {familyMembers.map((fm) => (
@@ -510,32 +478,36 @@ export function HouseholdClient({
               className="flex items-center justify-between bg-muted/40 rounded-md px-3 py-2"
             >
               <div className="flex items-center gap-3">
-                <div className="h-9 w-9 rounded-full bg-muted flex items-center justify-center">
-                  <User className="h-4 w-4 text-muted-foreground" />
-                </div>
+                <Avatar className="h-9 w-9">
+                  {fm.avatar_url && (
+                    <AvatarImage
+                      src={fm.avatar_url}
+                      alt={fm.preferred_name || fm.first_name}
+                    />
+                  )}
+                  <AvatarFallback className="bg-muted">
+                    <User className="h-4 w-4 text-muted-foreground" />
+                  </AvatarFallback>
+                </Avatar>
                 <div>
                   <span className="text-sm font-medium">
-                    {fm.first_name}
+                    {fm.preferred_name || fm.first_name}
                     {fm.last_name && ` ${fm.last_name}`}
                   </span>
                   <Badge variant="outline" className="ml-2 text-xs capitalize">
                     {fm.relationship}
                   </Badge>
-                  {fm.birth_month && fm.birth_day && (
-                    <span className="text-xs text-muted-foreground ml-2">
-                      · {MONTHS[fm.birth_month - 1]?.label} {fm.birth_day}
-                    </span>
-                  )}
                 </div>
               </div>
               <div className="flex gap-1">
                 <Button
                   variant="ghost"
-                  size="icon-sm"
-                  onClick={() => startEditMember(fm)}
+                  size="sm"
+                  nativeButton={false}
+                  render={<Link href={`/household/member/fm/${fm.id}`} />}
                 >
-                  <Pencil className="h-4 w-4" />
-                  <span className="sr-only">Edit</span>
+                  <Pencil className="mr-1 h-3.5 w-3.5" />
+                  Edit
                 </Button>
                 <Button
                   variant="ghost"
@@ -549,123 +521,81 @@ export function HouseholdClient({
             </div>
           ))}
 
-          {familyMembers.length === 0 && !showMemberForm && (
+          {familyMembers.length === 0 && (
             <p className="text-sm text-muted-foreground">No additional family members yet.</p>
-          )}
-
-          {/* Add / Edit member inline form */}
-          {showMemberForm && (
-            <div className="border rounded-lg p-4 space-y-4 bg-muted/20">
-              <div className="flex items-center justify-between">
-                <p className="text-sm font-semibold">
-                  {editingMember ? "Edit family member" : "Add family member"}
-                </p>
-                <Button variant="ghost" size="icon-sm" onClick={cancelMemberForm}>
-                  <X className="h-4 w-4" />
-                  <span className="sr-only">Cancel</span>
-                </Button>
-              </div>
-
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1">
-                  <Label htmlFor="fm_first" className="text-sm">First name</Label>
-                  <Input
-                    id="fm_first"
-                    value={memberForm.first_name}
-                    onChange={(e) => setMemberForm({ ...memberForm, first_name: e.target.value })}
-                    className="h-9"
-                  />
-                </div>
-                <div className="space-y-1">
-                  <Label htmlFor="fm_last" className="text-sm">Last name</Label>
-                  <Input
-                    id="fm_last"
-                    value={memberForm.last_name}
-                    onChange={(e) => setMemberForm({ ...memberForm, last_name: e.target.value })}
-                    className="h-9"
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-1">
-                <Label htmlFor="fm_rel" className="text-sm">Relationship</Label>
-                <Select
-                  value={memberForm.relationship}
-                  onValueChange={(v) =>
-                    setMemberForm({ ...memberForm, relationship: v as FamilyMemberRelationship })
-                  }
-                >
-                  <SelectTrigger id="fm_rel">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {RELATIONSHIPS.map((r) => (
-                      <SelectItem key={r.value} value={r.value}>
-                        {r.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div>
-                <Label className="text-sm">Birthday (optional)</Label>
-                <div className="grid grid-cols-3 gap-2 mt-1">
-                  <Select
-                    value={memberForm.birth_month}
-                    onValueChange={(v) =>
-                      setMemberForm({ ...memberForm, birth_month: v ?? "" })
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Month" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {MONTHS.map((m) => (
-                        <SelectItem key={m.value} value={m.value}>
-                          {m.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <Input
-                    type="number"
-                    min="1"
-                    max="31"
-                    placeholder="Day"
-                    value={memberForm.birth_day}
-                    onChange={(e) => setMemberForm({ ...memberForm, birth_day: e.target.value })}
-                  />
-                  <Input
-                    type="number"
-                    min="1900"
-                    max="2100"
-                    placeholder="Year"
-                    value={memberForm.birth_year}
-                    onChange={(e) =>
-                      setMemberForm({ ...memberForm, birth_year: e.target.value })
-                    }
-                  />
-                </div>
-              </div>
-
-              <div className="flex justify-end gap-2">
-                <Button variant="outline" size="sm" onClick={cancelMemberForm}>
-                  Cancel
-                </Button>
-                <Button
-                  size="sm"
-                  disabled={savingMember}
-                  onClick={handleSaveMember}
-                  className="bg-brand-primary hover:bg-brand-primary/90 text-white"
-                >
-                  {savingMember ? "Saving..." : editingMember ? "Update" : "Add"}
-                </Button>
-              </div>
-            </div>
           )}
         </CardContent>
       </Card>
+
+      {/* ---- Link existing account dialog ---- */}
+      <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Link an existing account</DialogTitle>
+            <DialogDescription>
+              Search for a member who already has an account but hasn&apos;t been assigned to a
+              household yet.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <Input
+              placeholder="Search by name..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              autoFocus
+            />
+
+            {searchLoading && (
+              <p className="text-sm text-muted-foreground text-center py-2">Searching...</p>
+            )}
+
+            {!searchLoading && searchResults.length === 0 && searchQuery.length >= 2 && (
+              <p className="text-sm text-muted-foreground text-center py-2">
+                No unassigned members found.
+              </p>
+            )}
+
+            {searchResults.map((r) => (
+              <div
+                key={r.id}
+                className="flex items-center justify-between rounded-md border px-3 py-2"
+              >
+                <div className="flex items-center gap-2">
+                  <Avatar className="h-8 w-8">
+                    {r.avatar_url && <AvatarImage src={r.avatar_url} alt={r.first_name} />}
+                    <AvatarFallback className="text-xs bg-brand-primary text-white">
+                      {`${r.first_name.charAt(0)}${(r.last_name ?? "").charAt(0)}`.toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <p className="text-sm font-medium">
+                      {r.preferred_name || r.first_name} {r.last_name}
+                    </p>
+                    {r.email && (
+                      <p className="text-xs text-muted-foreground">{r.email}</p>
+                    )}
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  disabled={linkingId === r.id}
+                  onClick={() => handleLinkMember(r.id)}
+                  className="bg-brand-primary hover:bg-brand-primary/90 text-white"
+                >
+                  {linkingId === r.id ? "Linking..." : "Add"}
+                </Button>
+              </div>
+            ))}
+          </div>
+
+          <DialogFooter showCloseButton>
+            <p className="text-xs text-muted-foreground mr-auto">
+              Only shows members with no household assigned.
+            </p>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/app/household/HouseholdClient.tsx
+++ b/app/household/HouseholdClient.tsx
@@ -75,7 +75,7 @@ interface HouseholdClientProps {
   initialFamilyMembers: FamilyMember[];
   householdProfiles: Pick<
     Profile,
-    "id" | "first_name" | "last_name" | "preferred_name" | "relationship" | "role" | "avatar_url" | "email"
+    "id" | "first_name" | "last_name" | "preferred_name" | "relationship" | "role" | "avatar_url"
   >[];
 }
 

--- a/app/household/member/HouseholdMemberEditClient.tsx
+++ b/app/household/member/HouseholdMemberEditClient.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { ProfileForm } from "@/components/profile/ProfileForm";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+import type { Profile, FamilyUnit, FamilyMemberRelationship } from "@/lib/types";
+
+const RELATIONSHIPS: { value: FamilyMemberRelationship; label: string }[] = [
+  { value: "primary", label: "Primary" },
+  { value: "spouse", label: "Spouse" },
+  { value: "child", label: "Child" },
+  { value: "parent", label: "Parent" },
+  { value: "sibling", label: "Sibling" },
+  { value: "other", label: "Other" },
+];
+
+interface Props {
+  profile: Profile;
+}
+
+export function HouseholdMemberEditClient({ profile }: Props) {
+  const router = useRouter();
+  const supabase = createClient();
+  const [relationship, setRelationship] = useState<FamilyMemberRelationship>(profile.relationship);
+  const [savingRelationship, setSavingRelationship] = useState(false);
+
+  async function handleRelationshipChange(value: FamilyMemberRelationship) {
+    setRelationship(value);
+    setSavingRelationship(true);
+
+    const { error } = await supabase
+      .from("profiles")
+      .update({ relationship: value })
+      .eq("id", profile.id);
+
+    setSavingRelationship(false);
+
+    if (error) {
+      toast.error("Failed to update relationship.");
+      setRelationship(profile.relationship); // revert
+    } else {
+      toast.success("Relationship updated.");
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Relationship — editable separately since ProfileForm doesn't expose it */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Household Role</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            <Label htmlFor="relationship" className="text-base">
+              Relationship to household
+            </Label>
+            <Select
+              value={relationship}
+              onValueChange={(v) => handleRelationshipChange(v as FamilyMemberRelationship)}
+              disabled={savingRelationship}
+            >
+              <SelectTrigger id="relationship" className="text-base py-5">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RELATIONSHIPS.map((r) => (
+                  <SelectItem key={r.value} value={r.value}>
+                    {r.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {savingRelationship && (
+              <p className="text-xs text-muted-foreground">Saving...</p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <ProfileForm
+        profile={profile}
+        families={[] as FamilyUnit[]}
+        isAdmin={false}
+        relaxValidation={true}
+        onSaved={() => router.push("/household")}
+      />
+    </div>
+  );
+}

--- a/app/household/member/[id]/page.tsx
+++ b/app/household/member/[id]/page.tsx
@@ -1,0 +1,88 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { ProfileForm } from "@/components/profile/ProfileForm";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { siteConfig } from "@/lib/config";
+import { displayName } from "@/lib/names";
+import type { Profile, FamilyUnit } from "@/lib/types";
+
+export const metadata = { title: `Edit Household Member | ${siteConfig.name}` };
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function HouseholdMemberEditPage({ params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const { data: currentProfile } = await supabase
+    .from("profiles")
+    .select("role, family_id, setup_completed, relationship")
+    .eq("id", user.id)
+    .single();
+
+  if (
+    !currentProfile ||
+    !["member", "content_editor", "admin"].includes(currentProfile.role) ||
+    !currentProfile.setup_completed ||
+    !currentProfile.family_id
+  ) {
+    redirect("/dashboard");
+  }
+
+  // Only primary and spouse can edit other enrolled household members
+  if (!["primary", "spouse"].includes(currentProfile.relationship ?? "")) {
+    redirect("/household");
+  }
+
+  const { data: targetProfile } = await supabase
+    .from("profiles")
+    .select("*")
+    .eq("id", id)
+    .single<Profile>();
+
+  if (!targetProfile) notFound();
+
+  // Ensure the target is in the same household
+  if (targetProfile.family_id !== currentProfile.family_id) {
+    redirect("/household");
+  }
+
+  // Don't let them edit themselves here — that's /profile
+  if (targetProfile.id === user.id) redirect("/profile");
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-3xl">
+      <Button
+        variant="ghost"
+        size="sm"
+        nativeButton={false}
+        render={<Link href="/household" />}
+        className="mb-4"
+      >
+        <ArrowLeft className="mr-2 h-4 w-4" />
+        Back to household
+      </Button>
+      <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-2">
+        Edit Member
+      </h1>
+      <p className="text-base text-muted-foreground mb-8">
+        Editing profile for <strong>{displayName(targetProfile)}</strong>.
+      </p>
+
+      <ProfileForm
+        profile={targetProfile}
+        families={[] as FamilyUnit[]}
+        isAdmin={false}
+      />
+    </div>
+  );
+}

--- a/app/household/member/[id]/page.tsx
+++ b/app/household/member/[id]/page.tsx
@@ -1,12 +1,12 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect, notFound } from "next/navigation";
 import Link from "next/link";
-import { ProfileForm } from "@/components/profile/ProfileForm";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import { siteConfig } from "@/lib/config";
 import { displayName } from "@/lib/names";
-import type { Profile, FamilyUnit } from "@/lib/types";
+import type { Profile } from "@/lib/types";
+import { HouseholdMemberEditClient } from "../HouseholdMemberEditClient";
 
 export const metadata = { title: `Edit Household Member | ${siteConfig.name}` };
 
@@ -78,11 +78,7 @@ export default async function HouseholdMemberEditPage({ params }: Props) {
         Editing profile for <strong>{displayName(targetProfile)}</strong>.
       </p>
 
-      <ProfileForm
-        profile={targetProfile}
-        families={[] as FamilyUnit[]}
-        isAdmin={false}
-      />
+      <HouseholdMemberEditClient profile={targetProfile} />
     </div>
   );
 }

--- a/app/household/member/fm/FamilyMemberForm.tsx
+++ b/app/household/member/fm/FamilyMemberForm.tsx
@@ -79,6 +79,7 @@ export function FamilyMemberForm({ member }: Props) {
     const file = e.target.files?.[0];
     if (!file || !member) return; // avatar upload only works after creation (member.id needed)
 
+    const previousAvatarUrl = avatarUrl;
     setUploadingAvatar(true);
     try {
       const url = await uploadImage(file, "avatar", `family-members/${member.id}/avatar`);
@@ -94,6 +95,7 @@ export function FamilyMemberForm({ member }: Props) {
       toast.success("Photo updated.");
     } catch (err) {
       console.error(err);
+      setAvatarUrl(previousAvatarUrl);
       toast.error("Failed to upload photo.");
     } finally {
       setUploadingAvatar(false);

--- a/app/household/member/fm/FamilyMemberForm.tsx
+++ b/app/household/member/fm/FamilyMemberForm.tsx
@@ -73,6 +73,7 @@ export function FamilyMemberForm({ member }: Props) {
   const displayFirst = preferredName || firstName || "Member";
   const displayLast = lastName;
   const initials = `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase() || "?";
+  const currentYear = new Date().getFullYear();
 
   async function handleAvatarUpload(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -109,6 +110,23 @@ export function FamilyMemberForm({ member }: Props) {
       return;
     }
 
+    // Basic date sanity checks
+    const dayNum = birthDay ? Number(birthDay) : null;
+    const monthNum = birthMonth ? Number(birthMonth) : null;
+    const yearNum = birthYear ? Number(birthYear) : null;
+    if (dayNum !== null && (dayNum < 1 || dayNum > 31)) {
+      toast.error("Birthday day must be between 1 and 31.");
+      return;
+    }
+    if (yearNum !== null && (yearNum < 1900 || yearNum > currentYear)) {
+      toast.error(`Birthday year must be between 1900 and ${currentYear}.`);
+      return;
+    }
+    if ((monthNum !== null) !== (dayNum !== null)) {
+      toast.error("Please provide both a month and a day for the birthday.");
+      return;
+    }
+
     setSaving(true);
 
     const payload = {
@@ -139,7 +157,11 @@ export function FamilyMemberForm({ member }: Props) {
       return;
     }
 
-    toast.success(isNew ? "Family member added." : "Family member updated.");
+    if (isNew) {
+      toast.success("Family member added. You can add a photo by editing them from the household page.");
+    } else {
+      toast.success("Family member updated.");
+    }
     router.push("/household");
   }
 
@@ -297,7 +319,7 @@ export function FamilyMemberForm({ member }: Props) {
                 id="birth_year"
                 type="number"
                 min="1900"
-                max="2100"
+                max={currentYear}
                 value={birthYear}
                 onChange={(e) => setBirthYear(e.target.value)}
                 placeholder="Year"

--- a/app/household/member/fm/FamilyMemberForm.tsx
+++ b/app/household/member/fm/FamilyMemberForm.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Card, CardContent } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "sonner";
+import { Camera } from "lucide-react";
+import { titleCaseName } from "@/lib/sanitize";
+import { uploadImage } from "@/lib/uploadImage";
+import type { FamilyMember, FamilyMemberRelationship } from "@/lib/types";
+
+const MONTHS = [
+  { value: "1", label: "January" },
+  { value: "2", label: "February" },
+  { value: "3", label: "March" },
+  { value: "4", label: "April" },
+  { value: "5", label: "May" },
+  { value: "6", label: "June" },
+  { value: "7", label: "July" },
+  { value: "8", label: "August" },
+  { value: "9", label: "September" },
+  { value: "10", label: "October" },
+  { value: "11", label: "November" },
+  { value: "12", label: "December" },
+];
+
+const RELATIONSHIPS: { value: FamilyMemberRelationship; label: string }[] = [
+  { value: "child", label: "Child" },
+  { value: "spouse", label: "Spouse" },
+  { value: "parent", label: "Parent" },
+  { value: "sibling", label: "Sibling" },
+  { value: "other", label: "Other" },
+];
+
+interface Props {
+  /** null = creating new member */
+  member: FamilyMember | null;
+}
+
+export function FamilyMemberForm({ member }: Props) {
+  const router = useRouter();
+
+  const [firstName, setFirstName] = useState(member?.first_name ?? "");
+  const [lastName, setLastName] = useState(member?.last_name ?? "");
+  const [preferredName, setPreferredName] = useState(member?.preferred_name ?? "");
+  const [relationship, setRelationship] = useState<FamilyMemberRelationship>(
+    member?.relationship ?? "child",
+  );
+  const [birthMonth, setBirthMonth] = useState(member?.birth_month?.toString() ?? "");
+  const [birthDay, setBirthDay] = useState(member?.birth_day?.toString() ?? "");
+  const [birthYear, setBirthYear] = useState(member?.birth_year?.toString() ?? "");
+  const [isClassMember, setIsClassMember] = useState(member?.is_class_member ?? false);
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(member?.avatar_url ?? null);
+
+  const [saving, setSaving] = useState(false);
+  const [uploadingAvatar, setUploadingAvatar] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const isNew = member === null;
+  const displayFirst = preferredName || firstName || "Member";
+  const displayLast = lastName;
+  const initials = `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase() || "?";
+
+  async function handleAvatarUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file || !member) return; // avatar upload only works after creation (member.id needed)
+
+    setUploadingAvatar(true);
+    try {
+      const url = await uploadImage(file, "avatar", `family-members/${member.id}/avatar`);
+      const bustedUrl = `${url}?t=${Date.now()}`;
+      setAvatarUrl(bustedUrl);
+
+      const res = await fetch(`/api/household/members/${member.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ avatar_url: url }),
+      });
+      if (!res.ok) throw new Error("Failed to save avatar");
+      toast.success("Photo updated.");
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to upload photo.");
+    } finally {
+      setUploadingAvatar(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    const first = titleCaseName(firstName);
+    if (!first) {
+      toast.error("First name is required.");
+      return;
+    }
+
+    setSaving(true);
+
+    const payload = {
+      first_name: first,
+      last_name: titleCaseName(lastName) || null,
+      preferred_name: titleCaseName(preferredName) || null,
+      relationship,
+      birth_month: birthMonth ? Number(birthMonth) : null,
+      birth_day: birthDay ? Number(birthDay) : null,
+      birth_year: birthYear ? Number(birthYear) : null,
+      is_class_member: isClassMember,
+    };
+
+    const url = isNew ? "/api/household/members" : `/api/household/members/${member.id}`;
+    const method = isNew ? "POST" : "PATCH";
+
+    const res = await fetch(url, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    setSaving(false);
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      toast.error(body.error ?? "Failed to save.");
+      return;
+    }
+
+    toast.success(isNew ? "Family member added." : "Family member updated.");
+    router.push("/household");
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {/* Avatar — only when editing an existing member */}
+      {!isNew && (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-6">
+              <div className="relative">
+                <Avatar className="h-24 w-24">
+                  {avatarUrl && <AvatarImage src={avatarUrl} alt="Photo" />}
+                  <AvatarFallback className="text-2xl bg-brand-primary text-white">
+                    {initials}
+                  </AvatarFallback>
+                </Avatar>
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={uploadingAvatar}
+                  className="absolute -bottom-1 -right-1 bg-brand-primary hover:bg-brand-primary/90 text-white rounded-full p-2 shadow-md transition-colors disabled:opacity-50"
+                  aria-label="Upload photo"
+                >
+                  <Camera className="h-4 w-4" />
+                </button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handleAvatarUpload}
+                  className="hidden"
+                />
+              </div>
+              <div>
+                <p className="text-lg font-semibold">
+                  {displayFirst} {displayLast}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {uploadingAvatar ? "Uploading..." : "Click the camera icon to update the photo."}
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Name */}
+      <Card>
+        <CardContent className="pt-6 space-y-5">
+          <div className="grid sm:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="first_name" className="text-base">
+                First name <span className="text-destructive" aria-hidden>*</span>
+              </Label>
+              <Input
+                id="first_name"
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                onBlur={(e) => setFirstName(titleCaseName(e.target.value) || "")}
+                required
+                className="text-base py-5"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="last_name" className="text-base">
+                Last name
+              </Label>
+              <Input
+                id="last_name"
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+                onBlur={(e) => setLastName(titleCaseName(e.target.value) || "")}
+                className="text-base py-5"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="preferred_name" className="text-base">
+              Preferred name / nickname{" "}
+              <span className="text-muted-foreground font-normal">(optional)</span>
+            </Label>
+            <Input
+              id="preferred_name"
+              value={preferredName}
+              onChange={(e) => setPreferredName(e.target.value)}
+              onBlur={(e) => setPreferredName(titleCaseName(e.target.value) || "")}
+              placeholder="Goes by..."
+              className="text-base py-5"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="relationship" className="text-base">
+              Relationship <span className="text-destructive" aria-hidden>*</span>
+            </Label>
+            <Select
+              value={relationship}
+              onValueChange={(v) => setRelationship(v as FamilyMemberRelationship)}
+            >
+              <SelectTrigger id="relationship" className="text-base py-5">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RELATIONSHIPS.map((r) => (
+                  <SelectItem key={r.value} value={r.value}>
+                    {r.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Birthday */}
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <p className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+            Birthday
+          </p>
+          <div className="grid grid-cols-3 gap-3">
+            <div className="space-y-2">
+              <Label className="text-base">Month</Label>
+              <Select value={birthMonth} onValueChange={(v) => setBirthMonth(v ?? "")}>
+                <SelectTrigger className="text-base py-5">
+                  <SelectValue placeholder="Month" />
+                </SelectTrigger>
+                <SelectContent>
+                  {MONTHS.map((m) => (
+                    <SelectItem key={m.value} value={m.value}>
+                      {m.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="birth_day" className="text-base">Day</Label>
+              <Input
+                id="birth_day"
+                type="number"
+                min="1"
+                max="31"
+                value={birthDay}
+                onChange={(e) => setBirthDay(e.target.value)}
+                placeholder="Day"
+                className="text-base py-5"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="birth_year" className="text-base">Year</Label>
+              <Input
+                id="birth_year"
+                type="number"
+                min="1900"
+                max="2100"
+                value={birthYear}
+                onChange={(e) => setBirthYear(e.target.value)}
+                placeholder="Year"
+                className="text-base py-5"
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Class membership */}
+      <Card>
+        <CardContent className="pt-6">
+          <Separator className="mb-4" />
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="is_class_member" className="text-base cursor-pointer">
+                Attends small group
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                Mark this if they attend the small group class themselves.
+              </p>
+            </div>
+            <Switch
+              id="is_class_member"
+              checked={isClassMember}
+              onCheckedChange={setIsClassMember}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex justify-end gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => router.push("/household")}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          disabled={saving}
+          className="bg-brand-primary hover:bg-brand-primary/90 text-white"
+        >
+          {saving ? "Saving..." : isNew ? "Add Family Member" : "Save Changes"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/app/household/member/fm/[id]/page.tsx
+++ b/app/household/member/fm/[id]/page.tsx
@@ -1,0 +1,73 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { siteConfig } from "@/lib/config";
+import type { FamilyMember } from "@/lib/types";
+import { FamilyMemberForm } from "../FamilyMemberForm";
+
+export const metadata = { title: `Edit Family Member | ${siteConfig.name}` };
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function EditFamilyMemberPage({ params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role, family_id, setup_completed")
+    .eq("id", user.id)
+    .single();
+
+  if (
+    !profile ||
+    !["member", "content_editor", "admin"].includes(profile.role) ||
+    !profile.setup_completed ||
+    !profile.family_id
+  ) {
+    redirect("/dashboard");
+  }
+
+  const { data: member } = await supabase
+    .from("family_members")
+    .select("*")
+    .eq("id", id)
+    .single<FamilyMember>();
+
+  if (!member) notFound();
+
+  // Ensure the member belongs to the current user's household
+  if (member.family_id !== profile.family_id) redirect("/household");
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-2xl">
+      <Button
+        variant="ghost"
+        size="sm"
+        nativeButton={false}
+        render={<Link href="/household" />}
+        className="mb-4"
+      >
+        <ArrowLeft className="mr-2 h-4 w-4" />
+        Back to household
+      </Button>
+      <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-2">
+        Edit Family Member
+      </h1>
+      <p className="text-base text-muted-foreground mb-8">
+        Update info for <strong>{member.preferred_name || member.first_name}</strong>.
+      </p>
+
+      <FamilyMemberForm member={member} />
+    </div>
+  );
+}

--- a/app/household/member/fm/new/page.tsx
+++ b/app/household/member/fm/new/page.tsx
@@ -1,0 +1,56 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { siteConfig } from "@/lib/config";
+import { FamilyMemberForm } from "../FamilyMemberForm";
+
+export const metadata = { title: `Add Family Member | ${siteConfig.name}` };
+
+export default async function NewFamilyMemberPage() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role, family_id, setup_completed")
+    .eq("id", user.id)
+    .single();
+
+  if (
+    !profile ||
+    !["member", "content_editor", "admin"].includes(profile.role) ||
+    !profile.setup_completed ||
+    !profile.family_id
+  ) {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-2xl">
+      <Button
+        variant="ghost"
+        size="sm"
+        nativeButton={false}
+        render={<Link href="/household" />}
+        className="mb-4"
+      >
+        <ArrowLeft className="mr-2 h-4 w-4" />
+        Back to household
+      </Button>
+      <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-2">
+        Add Family Member
+      </h1>
+      <p className="text-base text-muted-foreground mb-8">
+        Add a child, parent, or other family member who doesn&apos;t have their own account.
+      </p>
+
+      <FamilyMemberForm member={null} />
+    </div>
+  );
+}

--- a/app/household/page.tsx
+++ b/app/household/page.tsx
@@ -49,10 +49,10 @@ export default async function HouseholdPage() {
     // Fetch other enrolled members in the household using the new RLS policy
     supabase
       .from("profiles")
-      .select("id, first_name, last_name, preferred_name, relationship, role, avatar_url, email")
+      .select("id, first_name, last_name, preferred_name, relationship, role, avatar_url")
       .eq("family_id", profile.family_id)
       .neq("id", user.id)
-      .returns<Pick<Profile, "id" | "first_name" | "last_name" | "preferred_name" | "relationship" | "role" | "avatar_url" | "email">[]>(),
+      .returns<Pick<Profile, "id" | "first_name" | "last_name" | "preferred_name" | "relationship" | "role" | "avatar_url">[]>(),
   ]);
 
   if (!family) redirect("/profile");

--- a/app/household/page.tsx
+++ b/app/household/page.tsx
@@ -1,0 +1,87 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { siteConfig } from "@/lib/config";
+import type { Profile, FamilyUnit, FamilyMember } from "@/lib/types";
+import { HouseholdClient } from "./HouseholdClient";
+
+export const metadata = { title: `My Household | ${siteConfig.name}` };
+
+export default async function HouseholdPage() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("*")
+    .eq("id", user.id)
+    .single<Profile>();
+
+  if (!profile) redirect("/dashboard");
+  if (!["member", "content_editor", "admin"].includes(profile.role)) {
+    redirect("/dashboard");
+  }
+  if (!profile.setup_completed) redirect("/profile/setup");
+  if (!profile.family_id) redirect("/profile");
+
+  const [
+    { data: family },
+    { data: familyMembers },
+    { data: householdProfiles },
+  ] = await Promise.all([
+    supabase
+      .from("family_units")
+      .select("*")
+      .eq("id", profile.family_id)
+      .single<FamilyUnit>(),
+    supabase
+      .from("family_members")
+      .select("*")
+      .eq("family_id", profile.family_id)
+      .order("relationship")
+      .returns<FamilyMember[]>(),
+    // Fetch other enrolled members in the household using the new RLS policy
+    supabase
+      .from("profiles")
+      .select("id, first_name, last_name, preferred_name, relationship, role, avatar_url, email")
+      .eq("family_id", profile.family_id)
+      .neq("id", user.id)
+      .returns<Pick<Profile, "id" | "first_name" | "last_name" | "preferred_name" | "relationship" | "role" | "avatar_url" | "email">[]>(),
+  ]);
+
+  if (!family) redirect("/profile");
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-3xl">
+      <Button
+        variant="ghost"
+        size="sm"
+        nativeButton={false}
+        render={<Link href="/profile" />}
+        className="mb-4"
+      >
+        <ArrowLeft className="mr-2 h-4 w-4" />
+        Back to my profile
+      </Button>
+      <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-2">
+        My Household
+      </h1>
+      <p className="text-base text-muted-foreground mb-8">
+        Manage your household&apos;s contact info and family members.
+      </p>
+
+      <HouseholdClient
+        currentProfile={profile}
+        family={family}
+        initialFamilyMembers={familyMembers ?? []}
+        householdProfiles={householdProfiles ?? []}
+      />
+    </div>
+  );
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,8 +1,11 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import { ProfileForm } from "@/components/profile/ProfileForm";
 import { DirectoryPreview } from "@/components/profile/DirectoryPreview";
+import { Button } from "@/components/ui/button";
 import { siteConfig } from "@/lib/config";
+import { Home } from "lucide-react";
 import type { Profile, FamilyUnit } from "@/lib/types";
 
 export const metadata = { title: `My Profile | ${siteConfig.name}` };
@@ -50,6 +53,23 @@ export default async function ProfilePage() {
       </div>
 
       <ProfileForm profile={profile} families={families} isAdmin={false} />
+
+      {profile.family_id && (
+        <div className="mt-8 pt-6 border-t">
+          <Button
+            variant="outline"
+            nativeButton={false}
+            render={<Link href="/household" />}
+            className="w-full sm:w-auto"
+          >
+            <Home className="mr-2 h-4 w-4" />
+            Manage Household
+          </Button>
+          <p className="text-sm text-muted-foreground mt-2">
+            Update your household&apos;s address, home phone, and family members.
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/profile/ProfileForm.tsx
+++ b/components/profile/ProfileForm.tsx
@@ -40,6 +40,13 @@ interface ProfileFormProps {
   families: FamilyUnit[];
   /** Admin mode allows editing family assignment + ignores privacy enforcement on save */
   isAdmin?: boolean;
+  /**
+   * When true, skips the birthday and visible-contact requirements.
+   * Used when a household primary/spouse edits another member's profile —
+   * the person being edited may have an incomplete profile that they will
+   * fill in themselves.
+   */
+  relaxValidation?: boolean;
   /** Called after successful save so parent can refresh/redirect */
   onSaved?: () => void;
 }
@@ -132,6 +139,7 @@ export function ProfileForm({
   profile,
   families,
   isAdmin = false,
+  relaxValidation = false,
   onSaved,
 }: ProfileFormProps) {
   const [state, setState] = useState<FormState>(initialState(profile));
@@ -199,7 +207,7 @@ export function ProfileForm({
       setSaving(false);
       return;
     }
-    if (!state.birth_month || !state.birth_day) {
+    if (!relaxValidation && (!state.birth_month || !state.birth_day)) {
       toast.error("Birthday month and day are required.");
       setSaving(false);
       return;
@@ -211,7 +219,7 @@ export function ProfileForm({
       (state.phone_work && !state.hide_phone_work)
     );
     const hasVisibleEmail = !!state.email && !state.hide_email;
-    if (!hasPhone && !hasVisibleEmail) {
+    if (!relaxValidation && !hasPhone && !hasVisibleEmail) {
       toast.error(
         "Please provide at least one phone number, or keep your email visible so others can reach you.",
       );
@@ -355,7 +363,9 @@ export function ProfileForm({
               <p className="text-sm text-muted-foreground">
                 {uploadingAvatar
                   ? "Uploading photo..."
-                  : "Click the camera icon to update your photo."}
+                  : relaxValidation
+                    ? "Click the camera icon to update their photo."
+                    : "Click the camera icon to update your photo."}
               </p>
             </div>
           </div>
@@ -363,13 +373,12 @@ export function ProfileForm({
       </Card>
 
       <Tabs defaultValue="personal">
-        <TabsList className="grid w-full grid-cols-5">
+        <TabsList className={`grid w-full ${isAdmin ? "grid-cols-5" : "grid-cols-4"}`}>
           <TabsTrigger value="personal">Personal</TabsTrigger>
           <TabsTrigger value="contact">Contact</TabsTrigger>
           <TabsTrigger value="address">Address</TabsTrigger>
           {isAdmin && <TabsTrigger value="family">Family</TabsTrigger>}
           <TabsTrigger value="privacy">Privacy</TabsTrigger>
-          {!isAdmin && <div />}
         </TabsList>
 
         {/* =========================================================
@@ -753,7 +762,12 @@ export function ProfileForm({
                     }
                   >
                     <SelectTrigger className="text-base py-5">
-                      <SelectValue placeholder="No family assigned" />
+                      <SelectValue placeholder="No family assigned">
+                        {(v: string | null | undefined) => {
+                          if (!v || v === "none") return "No family assigned";
+                          return families.find((f) => f.id === v)?.family_name ?? "(Unknown family)";
+                        }}
+                      </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="none">— No family —</SelectItem>

--- a/supabase/migrations/20260706000000_household_self_service.sql
+++ b/supabase/migrations/20260706000000_household_self_service.sql
@@ -1,0 +1,88 @@
+-- Household self-service: allow household members to manage their own data.
+-- Also fixes is_member() to include content_editor role.
+
+-- ==================
+-- FIX: is_member() now includes content_editor
+-- content_editors are part of the community and should see the directory.
+-- ==================
+create or replace function public.is_member()
+returns boolean as $$
+  select exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role in ('member', 'content_editor', 'admin')
+  );
+$$ language sql security definer;
+
+-- ==================
+-- HELPER: security-definer function to get current user's family_id.
+-- Used in RLS policies to avoid circular self-references on the profiles table.
+-- ==================
+create or replace function public.current_family_id()
+returns uuid as $$
+  select family_id from public.profiles where id = auth.uid();
+$$ language sql security definer stable;
+
+-- ==================
+-- FAMILY_UNITS: household members can update their own family record
+-- (address, phone, anniversary, family name, privacy flags)
+-- ==================
+create policy "Members can update own family unit"
+  on public.family_units for update
+  using (
+    id = public.current_family_id()
+    and public.is_member()
+  );
+
+-- ==================
+-- FAMILY_MEMBERS: household members can add and remove non-auth members
+-- (children, non-attending spouses, etc.)
+-- An UPDATE policy already exists from the family_members migration.
+-- ==================
+create policy "Members can insert own household family members"
+  on public.family_members for insert
+  with check (
+    family_id = public.current_family_id()
+    and public.is_member()
+  );
+
+create policy "Members can delete own household family members"
+  on public.family_members for delete
+  using (
+    family_id = public.current_family_id()
+    and public.is_member()
+  );
+
+-- ==================
+-- PROFILES: household primaries/spouses can update each other's profiles.
+-- Covers editing a spouse's contact info, address, birthday, etc.
+-- Does NOT allow changing roles, family assignment, or email (app enforces these).
+-- ==================
+create policy "Household leaders can update household member profiles"
+  on public.profiles for update
+  using (
+    -- Not editing their own profile (own profile handled by existing policy)
+    auth.uid() != id
+    -- Both must be in the same non-null household
+    and family_id is not null
+    and family_id = public.current_family_id()
+    -- Viewer must be primary or spouse relationship
+    and exists (
+      select 1 from public.profiles self
+      where self.id = auth.uid()
+        and self.relationship in ('primary', 'spouse')
+        and self.role in ('member', 'content_editor', 'admin')
+    )
+  );
+
+-- ==================
+-- PROFILES SELECT: household members can view each other's full profiles
+-- (needed for the household management page to load household members' data)
+-- ==================
+create policy "Household members can view each other's full profiles"
+  on public.profiles for select
+  using (
+    family_id is not null
+    and family_id = public.current_family_id()
+    and auth.uid() != id
+    and public.is_member()
+  );

--- a/supabase/migrations/20260706000001_household_avatar_storage.sql
+++ b/supabase/migrations/20260706000001_household_avatar_storage.sql
@@ -1,0 +1,103 @@
+-- Allow members to upload avatars for non-auth family members stored under
+-- family-members/<id>/ in the avatars bucket.
+create policy "Members can upload household family member avatars"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'avatars'
+    and public.is_member()
+    and (storage.foldername(name))[1] = 'family-members'
+    and (storage.foldername(name))[2] in (
+      select fm.id::text
+      from public.family_members fm
+      where fm.family_id = public.current_family_id()
+    )
+  );
+
+create policy "Members can update household family member avatars"
+  on storage.objects for update
+  using (
+    bucket_id = 'avatars'
+    and public.is_member()
+    and (storage.foldername(name))[1] = 'family-members'
+    and (storage.foldername(name))[2] in (
+      select fm.id::text
+      from public.family_members fm
+      where fm.family_id = public.current_family_id()
+    )
+  );
+
+create policy "Members can delete household family member avatars"
+  on storage.objects for delete
+  using (
+    bucket_id = 'avatars'
+    and public.is_member()
+    and (storage.foldername(name))[1] = 'family-members'
+    and (storage.foldername(name))[2] in (
+      select fm.id::text
+      from public.family_members fm
+      where fm.family_id = public.current_family_id()
+    )
+  );
+
+-- Allow primary/spouse to manage avatars for other enrolled household members.
+-- The existing policy locks uploads to auth.uid()/<path>, which blocks editing
+-- a spouse's avatar from the household member edit page.
+
+create policy "Household leaders can upload household member avatars"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'avatars'
+    and public.is_member()
+    -- The folder target must be an enrolled member of the same household
+    and (storage.foldername(name))[1] in (
+      select p.id::text
+      from public.profiles p
+      where p.family_id = public.current_family_id()
+        and p.family_id is not null
+        and p.id != auth.uid()
+    )
+    -- Current user must be primary or spouse
+    and exists (
+      select 1 from public.profiles self
+      where self.id = auth.uid()
+        and self.relationship in ('primary', 'spouse')
+    )
+  );
+
+create policy "Household leaders can update household member avatars"
+  on storage.objects for update
+  using (
+    bucket_id = 'avatars'
+    and public.is_member()
+    and (storage.foldername(name))[1] in (
+      select p.id::text
+      from public.profiles p
+      where p.family_id = public.current_family_id()
+        and p.family_id is not null
+        and p.id != auth.uid()
+    )
+    and exists (
+      select 1 from public.profiles self
+      where self.id = auth.uid()
+        and self.relationship in ('primary', 'spouse')
+    )
+  );
+
+create policy "Household leaders can delete household member avatars"
+  on storage.objects for delete
+  using (
+    bucket_id = 'avatars'
+    and public.is_member()
+    and (storage.foldername(name))[1] in (
+      select p.id::text
+      from public.profiles p
+      where p.family_id = public.current_family_id()
+        and p.family_id is not null
+        and p.id != auth.uid()
+    )
+    and exists (
+      select 1 from public.profiles self
+      where self.id = auth.uid()
+        and self.relationship in ('primary', 'spouse')
+    )
+  );

--- a/supabase/migrations/20260706000002_household_policy_fixes.sql
+++ b/supabase/migrations/20260706000002_household_policy_fixes.sql
@@ -1,0 +1,26 @@
+-- Fix RLS: add WITH CHECK to the household leader profile update policy.
+-- The original policy had no WITH CHECK, which meant a crafted direct API
+-- call could change family_id, role, or other sensitive columns on a
+-- household member's profile. The WITH CHECK ensures the row stays in the
+-- current household after the update.
+
+drop policy if exists "Household leaders can update household member profiles" on public.profiles;
+
+create policy "Household leaders can update household member profiles"
+  on public.profiles for update
+  using (
+    auth.uid() != id
+    and family_id is not null
+    and family_id = public.current_family_id()
+    and exists (
+      select 1 from public.profiles self
+      where self.id = auth.uid()
+        and self.relationship in ('primary', 'spouse')
+        and self.role in ('member', 'content_editor', 'admin')
+    )
+  )
+  with check (
+    -- After update, the row must still belong to the current household.
+    -- Prevents moving a member to a different family via this policy.
+    family_id = public.current_family_id()
+  );

--- a/supabase/migrations/20260706000003_tighten_household_rls.sql
+++ b/supabase/migrations/20260706000003_tighten_household_rls.sql
@@ -1,0 +1,87 @@
+-- Tighten RLS so it matches what the API routes enforce:
+--
+-- 1. family_members INSERT/DELETE restricted to primary/spouse
+--    The original migration allowed any is_member() in the same household.
+--    Since the API routes now require primary/spouse, the DB policy should
+--    match so direct API calls can't bypass the restriction.
+--
+-- 2. profiles UPDATE WITH CHECK extended to block role and email changes.
+--    The previous WITH CHECK only ensured family_id stayed in the current
+--    household. A crafted direct call could still change role or email.
+--    New helper functions (security definer) let the WITH CHECK read the
+--    current values without RLS recursion.
+
+-- ==================
+-- FAMILY_MEMBERS: tighten to primary/spouse only
+-- ==================
+drop policy if exists "Members can insert own household family members" on public.family_members;
+drop policy if exists "Members can delete own household family members" on public.family_members;
+
+create policy "Household leaders can insert own household family members"
+  on public.family_members for insert
+  with check (
+    family_id = public.current_family_id()
+    and public.is_member()
+    and exists (
+      select 1 from public.profiles self
+      where self.id = auth.uid()
+        and self.relationship in ('primary', 'spouse')
+    )
+  );
+
+create policy "Household leaders can delete own household family members"
+  on public.family_members for delete
+  using (
+    family_id = public.current_family_id()
+    and public.is_member()
+    and exists (
+      select 1 from public.profiles self
+      where self.id = auth.uid()
+        and self.relationship in ('primary', 'spouse')
+    )
+  );
+
+-- ==================
+-- HELPERS: security-definer lookups for stable column values.
+-- Used by the profiles UPDATE WITH CHECK to compare new vs old without
+-- causing RLS recursion (the definer runs as the function owner, bypassing
+-- row-level security on the profiles table).
+-- ==================
+create or replace function public.get_profile_role(profile_id uuid)
+returns text as $$
+  select role from public.profiles where id = profile_id;
+$$ language sql security definer stable;
+
+create or replace function public.get_profile_email(profile_id uuid)
+returns text as $$
+  select email from public.profiles where id = profile_id;
+$$ language sql security definer stable;
+
+-- ==================
+-- PROFILES UPDATE: extend WITH CHECK to block role and email changes.
+-- relationship is intentionally left unrestricted — the household role picker
+-- uses this policy to update it.
+-- ==================
+drop policy if exists "Household leaders can update household member profiles" on public.profiles;
+
+create policy "Household leaders can update household member profiles"
+  on public.profiles for update
+  using (
+    auth.uid() != id
+    and family_id is not null
+    and family_id = public.current_family_id()
+    and exists (
+      select 1 from public.profiles self
+      where self.id = auth.uid()
+        and self.relationship in ('primary', 'spouse')
+        and self.role in ('member', 'content_editor', 'admin')
+    )
+  )
+  with check (
+    -- Must remain in the current household
+    family_id = public.current_family_id()
+    -- role cannot be changed (prevents privilege escalation)
+    and role = public.get_profile_role(id)
+    -- email cannot be changed (prevents account hijack via redirected notifications)
+    and (email is not distinct from public.get_profile_email(id))
+  );

--- a/supabase/migrations/20260706000004_tighten_household_rls_v2.sql
+++ b/supabase/migrations/20260706000004_tighten_household_rls_v2.sql
@@ -1,0 +1,49 @@
+-- Follow-up to 20260706000003:
+--
+-- 1. Tighten family_members UPDATE to primary/spouse only.
+--    The previous migration covered INSERT and DELETE but left the existing
+--    "Members can manage their own family members" UPDATE policy in place,
+--    which allows any household member to modify rows.
+--
+-- 2. Scope get_profile_role / get_profile_email to the caller's household.
+--    Both functions are SECURITY DEFINER and previously had no family_id
+--    guard, meaning any authenticated user could call them via RPC and read
+--    role/email for any profile. Scoping to current_family_id() limits
+--    exposure to profiles the caller already has SELECT access to.
+--    An explicit search_path is also set to prevent search-path injection.
+
+-- ==================
+-- FAMILY_MEMBERS UPDATE: replace any-member policy with leader-only
+-- ==================
+drop policy if exists "Members can manage their own family members" on public.family_members;
+
+create policy "Household leaders can update own household family members"
+  on public.family_members for update
+  using (
+    family_id = public.current_family_id()
+    and public.is_member()
+    and exists (
+      select 1 from public.profiles self
+      where self.id = auth.uid()
+        and self.relationship in ('primary', 'spouse')
+    )
+  );
+
+-- ==================
+-- HELPERS: scope to caller's household + explicit search_path
+-- ==================
+create or replace function public.get_profile_role(profile_id uuid)
+returns text as $$
+  select role
+  from public.profiles
+  where id = profile_id
+    and family_id = public.current_family_id();
+$$ language sql security definer stable set search_path = '';
+
+create or replace function public.get_profile_email(profile_id uuid)
+returns text as $$
+  select email
+  from public.profiles
+  where id = profile_id
+    and family_id = public.current_family_id();
+$$ language sql security definer stable set search_path = '';


### PR DESCRIPTION
## Summary

- Fixes a bug where the admin member edit page showed a raw UUID in the Family tab Select instead of the family name (Base UI doesn't register items until the dropdown is opened; fixed by using the render-function children API to look up the name from props directly)
- Fixes `TabsList` rendering a 5-column grid for 4 tabs on non-admin profile pages
- New `/household` page lets any enrolled household member (primary or spouse) manage their household info and family members — no admin required
- Full-parity editing for all household members: enrolled members get the complete ProfileForm (all 4 tabs), non-auth members (children, etc.) get a dedicated full-page form with all available fields
- Two-path "add member" flow: link an existing enrolled member who has no household yet (with relationship picker), or create a new non-auth family member
- Avatar upload fixed for spouse editing — new storage RLS policies allow primary/spouse to write to other household members' avatar paths
- Fixes `is_member()` to include `content_editor` role (was excluded, blocking directory access)

## Database migrations

| File | Purpose |
|---|---|
| `20260706000000_household_self_service.sql` | Fix `is_member()`, add `current_family_id()` helper, new RLS policies for household self-service |
| `20260706000001_household_avatar_storage.sql` | Storage policies for household member avatar uploads |
| `20260706000002_household_policy_fixes.sql` | Add `WITH CHECK` to household leader profile update policy; prevent cross-household family_id moves |

## New routes

| Route | Purpose |
|---|---|
| `GET/PATCH /api/household` | Read and update own family unit info |
| `GET/POST /api/household/members` | List and create non-auth family members |
| `PATCH/DELETE /api/household/members/[id]` | Edit and remove a non-auth family member |
| `POST /api/household/link-member` | Add an unassigned enrolled profile to the household (service client) |
| `GET /api/household/search-members` | Search enrolled profiles with no household (for the link dialog) |

## Test plan

- [ ] Admin member edit page: Family tab Select shows family name on load (not a UUID)
- [ ] Non-admin profile page: 4 tabs render correctly with no empty column gap
- [ ] Profile page: "Manage Household" button appears for members with a `family_id`
- [ ] `/household`: household info form saves; address, phone, privacy toggles all persist
- [ ] `/household`: enrolled member "Edit profile" opens full ProfileForm with all 4 tabs; saves without requiring birthday or contact if those aren't filled in
- [ ] `/household`: relationship picker on enrolled member edit page saves independently
- [ ] `/household/member/[id]`: redirects back to `/household` after saving
- [ ] `/household/member/fm/new`: create a family member with full fields; success toast mentions photo can be added later
- [ ] `/household/member/fm/[id]`: edit name, preferred name, relationship, birthday, class membership, avatar photo
- [ ] "Link member" dialog: relationship picker defaults to spouse; search respects `hide_email`; linking sets both `family_id` and `relationship`; new member appears after `router.refresh()`
- [ ] Non-primary/spouse household members cannot see "Add member" or "Link member" buttons; API routes 403 for structural changes
- [ ] `content_editor` role can access `/directory` (previously blocked by `is_member()` bug)

https://claude.ai/code/session_01MAK4wMMCwtiGAx3dYV7AwH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a household management area where eligible users can view, update, add, link existing enrolled accounts, search for members, and remove household members.
  * Introduced dedicated screens to add and edit household members, including relationship/role selection.
  * Added avatar upload support for household members.
* **Bug Fixes**
  * Tightened access controls so only authorized household leaders (primary/spouse) can edit household details and member relationships.
  * Improved input validation and normalized household profile/member fields (including names and birthdays).
  * Enhanced household data privacy during member search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->