### PR TITLE
fix(nav): mobile access to sidebar nav, admin highlight, pointer cursors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -151,4 +151,15 @@
     line-height: 1.35;
     font-weight: 600;
   }
+  /* Tailwind v4 resets buttons to cursor: default; restore pointer on
+     anything clickable so hover always signals interactivity. */
+  button:not(:disabled),
+  [role="button"]:not(:disabled),
+  input[type="submit"]:not(:disabled),
+  input[type="button"]:not(:disabled),
+  label[for],
+  select:not(:disabled),
+  summary {
+    cursor: pointer;
+  }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -153,8 +153,8 @@
   }
   /* Tailwind v4 resets buttons to cursor: default; restore pointer on
      anything clickable so hover always signals interactivity. */
-  button:not(:disabled),
-  [role="button"]:not(:disabled),
+  button:not(:disabled):not([aria-disabled="true"]),
+  [role="button"]:not(:disabled):not([aria-disabled="true"]),
   input[type="submit"]:not(:disabled),
   input[type="button"]:not(:disabled),
   label[for],

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { AppShell } from "@/components/layout/AppShell";
+import { SidebarProvider } from "@/components/layout/SidebarContext";
 import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { siteConfig } from "@/lib/config";
@@ -91,8 +92,10 @@ export default async function RootLayout({
         />
       </head>
       <body className={`${cormorant.variable} ${interTight.variable} ${jetbrainsMono.variable} antialiased min-h-screen flex flex-col`}>
-        <Header profile={profile} hasServingAccess={hasServingAccess} />
-        <AppShell profile={profile} hasServingAccess={hasServingAccess}>{children}</AppShell>
+        <SidebarProvider>
+          <Header profile={profile} hasServingAccess={hasServingAccess} />
+          <AppShell profile={profile} hasServingAccess={hasServingAccess}>{children}</AppShell>
+        </SidebarProvider>
         <Footer />
         <Toaster />
         <Analytics />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -91,7 +91,7 @@ export default async function RootLayout({
         />
       </head>
       <body className={`${cormorant.variable} ${interTight.variable} ${jetbrainsMono.variable} antialiased min-h-screen flex flex-col`}>
-        <Header profile={profile} />
+        <Header profile={profile} hasServingAccess={hasServingAccess} />
         <AppShell profile={profile} hasServingAccess={hasServingAccess}>{children}</AppShell>
         <Footer />
         <Toaster />

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -10,7 +10,7 @@ interface AppShellProps {
   children: React.ReactNode;
 }
 
-const SIDEBAR_ROUTES = [
+export const SIDEBAR_ROUTES = [
   "/dashboard",
   "/events",
   "/announcements",

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useState, useEffect } from "react";
 import { Menu, X, LogOut } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { siteConfig } from "@/lib/config";
@@ -37,7 +38,11 @@ export function Header({ profile, hasServingAccess }: HeaderProps) {
 
   const handleSignOut = async () => {
     setOpen(false);
-    await supabase.auth.signOut();
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      toast.error("Sign out failed — please try again.");
+      return;
+    }
     router.push("/");
     router.refresh();
   };
@@ -65,7 +70,7 @@ export function Header({ profile, hasServingAccess }: HeaderProps) {
       <div className="container mx-auto flex h-16 items-center justify-between px-4">
         <div className="flex items-center gap-1">
           {/* Menu button opens the navigation pane as a drawer */}
-          {isMember && (
+          {profile && isMember && (
             <Sheet open={open} onOpenChange={setOpen}>
               <SheetTrigger
                 render={
@@ -105,7 +110,7 @@ export function Header({ profile, hasServingAccess }: HeaderProps) {
                     className="flex-1 space-y-1"
                   >
                     <SidebarNav
-                      profile={profile!}
+                      profile={profile}
                       hasServingAccess={hasServingAccess}
                       onNavigate={() => setOpen(false)}
                     />

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -4,19 +4,23 @@ import Link from "next/link";
 import { useState, useEffect } from "react";
 import { Menu, X, LogOut } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { siteConfig } from "@/lib/config";
 import { createClient } from "@/lib/supabase/client";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { SidebarNav } from "./SidebarNav";
+import { SIDEBAR_ROUTES } from "./AppShell";
 import type { Profile } from "@/lib/types";
 
 interface HeaderProps {
   profile: Profile | null;
+  hasServingAccess: boolean;
 }
 
-export function Header({ profile }: HeaderProps) {
+export function Header({ profile, hasServingAccess }: HeaderProps) {
   const [open, setOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
+  const pathname = usePathname();
   const router = useRouter();
   const supabase = createClient();
 
@@ -26,23 +30,26 @@ export function Header({ profile }: HeaderProps) {
     return () => window.removeEventListener("scroll", handler);
   }, []);
 
+  // Safety net: close the drawer whenever the route changes.
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
   const handleSignOut = async () => {
+    setOpen(false);
     await supabase.auth.signOut();
     router.push("/");
     router.refresh();
   };
 
   const isAdmin = profile?.role === "admin";
-  const isMember = profile?.role === "member" || profile?.role === "content_editor" || isAdmin;
+  const isMember =
+    profile?.role === "member" || profile?.role === "content_editor" || isAdmin;
 
-  const memberLinks = [
-    { href: "/dashboard", label: "Dashboard" },
-    { href: "/events", label: "Calendar" },
-    { href: "/announcements", label: "Announcements" },
-    { href: "/lectures", label: "Lectures" },
-  ];
-
-  const links = isMember ? memberLinks : [];
+  // The desktop sidebar pane is only rendered on these routes; elsewhere
+  // (e.g. /household) the menu button stays available at all breakpoints.
+  const hasDesktopSidebar =
+    isMember && SIDEBAR_ROUTES.some((r) => pathname.startsWith(r));
 
   return (
     <header
@@ -56,121 +63,109 @@ export function Header({ profile }: HeaderProps) {
       <div className="h-1 w-full bg-gradient-to-r from-brand-primary-light via-brand-primary to-brand-accent" />
 
       <div className="container mx-auto flex h-16 items-center justify-between px-4">
-        <Link
-          href={isMember ? "/dashboard" : "/"}
-          className="flex items-center gap-2 group"
-        >
-          <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-brand-primary-light to-brand-primary flex items-center justify-center shadow-sm group-hover:shadow-md transition-shadow">
-            <span className="text-white font-bold text-sm font-display">{siteConfig.logoMonogram}</span>
-          </div>
-          <span className="text-xl font-bold font-display text-brand-primary tracking-tight">
-            {siteConfig.name}
-          </span>
-        </Link>
-
-        {/* Desktop nav */}
-        <nav className="hidden md:flex items-center gap-1">
-          {links.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className="px-4 py-2 text-base font-semibold text-slate-600 hover:text-brand-primary hover:bg-brand-bg-light rounded-lg transition-all duration-150"
-            >
-              {link.label}
-            </Link>
-          ))}
-          {isAdmin && (
-            <Link
-              href="/admin"
-              className="px-4 py-2 text-base font-semibold text-slate-600 hover:text-brand-primary hover:bg-brand-bg-light rounded-lg transition-all duration-150"
-            >
-              Admin
-            </Link>
-          )}
-          <div className="ml-3 flex items-center gap-2">
-            {profile ? (
-              <Button
-                variant="outline"
-                size="lg"
-                onClick={handleSignOut}
-                className="text-base border-slate-200 hover:border-destructive/30 hover:text-destructive hover:bg-destructive/10"
-              >
-                <LogOut className="mr-2 h-4 w-4" />
-                Sign Out
-              </Button>
-            ) : (
-              <Button
-                variant="ghost"
-                size="lg"
-                className="text-base text-slate-600 hover:text-brand-primary"
-                nativeButton={false}
-                render={<Link href="/login" />}
-              >
-                Sign In
-              </Button>
-            )}
-          </div>
-        </nav>
-
-        {/* Mobile nav */}
-        <Sheet open={open} onOpenChange={setOpen}>
-          <SheetTrigger render={<Button variant="ghost" size="icon" className="md:hidden text-slate-700" />}>
-            {open ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
-            <span className="sr-only">Toggle menu</span>
-          </SheetTrigger>
-          <SheetContent side="right" className="w-[300px] border-l border-border">
-            <div className="flex items-center gap-2 mb-8 mt-2">
-              <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-brand-primary-light to-brand-primary flex items-center justify-center">
-                <span className="text-white font-bold text-sm font-display">{siteConfig.logoMonogram}</span>
-              </div>
-              <span className="text-xl font-bold font-display text-brand-primary">{siteConfig.name}</span>
-            </div>
-            <nav className="flex flex-col gap-1">
-              {links.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  onClick={() => setOpen(false)}
-                  className="text-lg font-semibold px-4 py-3 rounded-xl text-slate-700 hover:text-brand-primary hover:bg-brand-bg-light transition-all"
-                >
-                  {link.label}
-                </Link>
-              ))}
-              {isAdmin && (
-                <Link
-                  href="/admin"
-                  onClick={() => setOpen(false)}
-                  className="text-lg font-semibold px-4 py-3 rounded-xl text-slate-700 hover:text-brand-primary hover:bg-brand-bg-light transition-all"
-                >
-                  Admin
-                </Link>
-              )}
-              <div className="border-t border-border pt-4 mt-4 flex flex-col gap-3">
-                {profile ? (
+        <div className="flex items-center gap-1">
+          {/* Menu button opens the navigation pane as a drawer */}
+          {isMember && (
+            <Sheet open={open} onOpenChange={setOpen}>
+              <SheetTrigger
+                render={
                   <Button
-                    variant="outline"
-                    size="lg"
-                    onClick={handleSignOut}
-                    className="w-full text-lg"
-                  >
-                    <LogOut className="mr-2 h-5 w-5" />
-                    Sign Out
-                  </Button>
+                    variant="ghost"
+                    size="icon"
+                    aria-label={open ? "Close navigation menu" : "Open navigation menu"}
+                    aria-expanded={open}
+                    className={`text-slate-700 ${hasDesktopSidebar ? "md:hidden" : ""}`}
+                  />
+                }
+              >
+                {open ? (
+                  <X className="h-6 w-6" aria-hidden="true" />
                 ) : (
-                  <Button
-                    variant="outline"
-                    size="lg"
-                    className="w-full text-lg border-border text-brand-primary"
-                    nativeButton={false}
-                    render={<Link href="/login" onClick={() => setOpen(false)} />}
-                  >
-                    Sign In
-                  </Button>
+                  <Menu className="h-6 w-6" aria-hidden="true" />
                 )}
-              </div>
-            </nav>
-          </SheetContent>
-        </Sheet>
+              </SheetTrigger>
+              <SheetContent
+                side="left"
+                className="w-[300px] border-r border-border overflow-y-auto"
+              >
+                <SheetTitle className="sr-only">Navigation menu</SheetTitle>
+                <div className="flex flex-col h-full p-4">
+                  <div className="flex items-center gap-2 mb-6 mt-1">
+                    <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-brand-primary-light to-brand-primary flex items-center justify-center">
+                      <span className="text-white font-bold text-sm font-display">
+                        {siteConfig.logoMonogram}
+                      </span>
+                    </div>
+                    <span className="text-xl font-bold font-display text-brand-primary">
+                      {siteConfig.name}
+                    </span>
+                  </div>
+                  <nav
+                    aria-label="Main navigation"
+                    className="flex-1 space-y-1"
+                  >
+                    <SidebarNav
+                      profile={profile!}
+                      hasServingAccess={hasServingAccess}
+                      onNavigate={() => setOpen(false)}
+                    />
+                  </nav>
+                  <div className="border-t border-border pt-4 mt-4">
+                    <Button
+                      variant="outline"
+                      size="lg"
+                      onClick={handleSignOut}
+                      className="w-full"
+                    >
+                      <LogOut className="mr-2 h-5 w-5" aria-hidden="true" />
+                      Sign Out
+                    </Button>
+                  </div>
+                </div>
+              </SheetContent>
+            </Sheet>
+          )}
+
+          <Link
+            href={isMember ? "/dashboard" : "/"}
+            className="flex items-center gap-2 group"
+          >
+            <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-brand-primary-light to-brand-primary flex items-center justify-center shadow-sm group-hover:shadow-md transition-shadow">
+              <span className="text-white font-bold text-sm font-display">
+                {siteConfig.logoMonogram}
+              </span>
+            </div>
+            <span className="text-xl font-bold font-display text-brand-primary tracking-tight">
+              {siteConfig.name}
+            </span>
+          </Link>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {profile ? (
+            <Button
+              variant="outline"
+              size="lg"
+              onClick={handleSignOut}
+              className={`text-base border-slate-200 hover:border-destructive/30 hover:text-destructive hover:bg-destructive/10 ${
+                isMember ? "hidden md:inline-flex" : ""
+              }`}
+            >
+              <LogOut className="mr-2 h-4 w-4" aria-hidden="true" />
+              Sign Out
+            </Button>
+          ) : (
+            <Button
+              variant="ghost"
+              size="lg"
+              className="text-base text-slate-600 hover:text-brand-primary"
+              nativeButton={false}
+              render={<Link href="/login" />}
+            >
+              Sign In
+            </Button>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -11,6 +11,7 @@ import { createClient } from "@/lib/supabase/client";
 import { usePathname, useRouter } from "next/navigation";
 import { SidebarNav } from "./SidebarNav";
 import { SIDEBAR_ROUTES } from "./AppShell";
+import { useSidebar } from "./SidebarContext";
 import type { Profile } from "@/lib/types";
 
 interface HeaderProps {
@@ -21,6 +22,7 @@ interface HeaderProps {
 export function Header({ profile, hasServingAccess }: HeaderProps) {
   const [open, setOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
+  const { collapsed, setCollapsed } = useSidebar();
   const pathname = usePathname();
   const router = useRouter();
   const supabase = createClient();
@@ -58,18 +60,29 @@ export function Header({ profile, hasServingAccess }: HeaderProps) {
 
   return (
     <header
-      className={`sticky top-0 z-50 w-full transition-all duration-300 ${
-        scrolled
-          ? "bg-white/95 backdrop-blur shadow-sm border-b border-border"
-          : "bg-white border-b border-transparent"
+      className={`sticky top-0 z-50 w-full border-b border-border transition-all duration-300 ${
+        scrolled ? "bg-white/95 backdrop-blur shadow-sm" : "bg-white"
       }`}
     >
       {/* Top accent bar */}
       <div className="h-1 w-full bg-gradient-to-r from-brand-primary-light via-brand-primary to-brand-accent" />
 
-      <div className="container mx-auto flex h-16 items-center justify-between px-4">
+      <div className="flex h-16 w-full items-center justify-between px-4">
         <div className="flex items-center gap-1">
-          {/* Menu button opens the navigation pane as a drawer */}
+          {/* Desktop: menu button collapses/expands the sidebar pane */}
+          {hasDesktopSidebar && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setCollapsed(!collapsed)}
+              aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+              aria-expanded={!collapsed}
+              className="hidden md:inline-flex text-slate-700"
+            >
+              <Menu className="h-6 w-6" aria-hidden="true" />
+            </Button>
+          )}
+          {/* Mobile (or no sidebar): menu button opens the nav drawer */}
           {profile && isMember && (
             <Sheet open={open} onOpenChange={setOpen}>
               <SheetTrigger

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import { useState } from "react";
 import type { Profile } from "@/lib/types";
 import { SidebarNav } from "./SidebarNav";
+import { useSidebar } from "./SidebarContext";
 
 interface SidebarProps {
   profile: Profile;
@@ -11,7 +10,7 @@ interface SidebarProps {
 }
 
 export function Sidebar({ profile, hasServingAccess }: SidebarProps) {
-  const [collapsed, setCollapsed] = useState(false);
+  const { collapsed } = useSidebar();
 
   return (
     <aside
@@ -29,20 +28,6 @@ export function Sidebar({ profile, hasServingAccess }: SidebarProps) {
           collapsed={collapsed}
         />
       </nav>
-
-      <button
-        onClick={() => setCollapsed(!collapsed)}
-        aria-expanded={!collapsed}
-        aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-        title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-        className="flex items-center justify-center py-3 border-t border-border text-slate-400 hover:text-brand-primary transition-colors"
-      >
-        {collapsed ? (
-          <ChevronRight className="h-4 w-4" aria-hidden="true" />
-        ) : (
-          <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-        )}
-      </button>
     </aside>
   );
 }

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,82 +1,17 @@
 "use client";
 
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import {
-  LayoutDashboard,
-  Calendar,
-  CalendarDays,
-  Megaphone,
-  BookOpen,
-  FileText,
-  Settings,
-  Users,
-  UserCircle,
-  Home,
-  ChevronLeft,
-  ChevronRight,
-  MailPlus,
-  HandHelping,
-  BarChart2,
-} from "lucide-react";
-import { useState, useEffect } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useState } from "react";
 import type { Profile } from "@/lib/types";
-import type { PageContent } from "@/lib/types";
-import { createClient } from "@/lib/supabase/client";
+import { SidebarNav } from "./SidebarNav";
 
 interface SidebarProps {
   profile: Profile;
   hasServingAccess: boolean;
 }
 
-const memberNav = [
-  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { href: "/events", label: "Calendar", icon: Calendar },
-  { href: "/announcements", label: "Announcements", icon: Megaphone },
-  { href: "/lectures", label: "Lectures", icon: BookOpen },
-  { href: "/directory", label: "Directory", icon: Users },
-  { href: "/serving", label: "Serving", icon: HandHelping },
-  { href: "/profile", label: "My Profile", icon: UserCircle },
-];
-
-const adminNav = [
-  { href: "/admin", label: "Admin", icon: Settings },
-  { href: "/admin/members", label: "Members", icon: Users },
-  { href: "/admin/families", label: "Families", icon: Home },
-  { href: "/admin/groups", label: "Groups", icon: Users },
-  { href: "/admin/invite", label: "Bulk Invite", icon: MailPlus },
-  { href: "/admin/calendars", label: "Calendars", icon: CalendarDays },
-  { href: "/admin/serving", label: "Serving Stats", icon: BarChart2 },
-  { href: "/admin/pages", label: "Manage Pages", icon: FileText },
-];
-
 export function Sidebar({ profile, hasServingAccess }: SidebarProps) {
-  const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
-  const [pages, setPages] = useState<PageContent[]>([]);
-  const isAdmin = profile.role === "admin";
-  const isEditor = profile.role === "content_editor" || isAdmin;
-
-  useEffect(() => {
-    const supabase = createClient();
-    supabase
-      .from("page_content")
-      .select("slug, title")
-      .order("title")
-      .then(({ data }) => {
-        if (data) setPages(data as PageContent[]);
-      });
-  }, [pathname]);
-
-  const isActive = (href: string) =>
-    pathname === href || pathname.startsWith(href + "/");
-
-  const linkClass = (href: string) =>
-    `flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-      isActive(href)
-        ? "bg-brand-bg-light text-brand-primary"
-        : "text-slate-600 hover:text-brand-primary hover:bg-brand-bg-light/50"
-    }`;
 
   return (
     <aside
@@ -84,65 +19,28 @@ export function Sidebar({ profile, hasServingAccess }: SidebarProps) {
         collapsed ? "w-16" : "w-60"
       }`}
     >
-      <nav className="flex-1 overflow-y-auto py-4 px-2 space-y-1">
-        {memberNav
-          .filter((item) => item.href !== "/serving" || hasServingAccess)
-          .map((item) => (
-            <Link key={item.href} href={item.href} className={linkClass(item.href)}>
-              <item.icon className="h-5 w-5 shrink-0" />
-              {!collapsed && <span>{item.label}</span>}
-            </Link>
-          ))}
-
-        {pages.length > 0 && (
-          <>
-            {!collapsed && (
-              <p className="px-3 pt-4 pb-1 text-xs font-semibold uppercase text-slate-400 tracking-wider">
-                Pages
-              </p>
-            )}
-            {collapsed && <div className="border-t border-border my-2" />}
-            {pages.map((page) => (
-              <Link
-                key={page.slug}
-                href={`/pages/${page.slug}`}
-                className={linkClass(`/pages/${page.slug}`)}
-              >
-                <FileText className="h-5 w-5 shrink-0" />
-                {!collapsed && <span className="truncate">{page.title}</span>}
-              </Link>
-            ))}
-          </>
-        )}
-
-        {isEditor && (
-          <>
-            {!collapsed && (
-              <p className="px-3 pt-4 pb-1 text-xs font-semibold uppercase text-slate-400 tracking-wider">
-                Admin
-              </p>
-            )}
-            {collapsed && <div className="border-t border-border my-2" />}
-            {adminNav
-              .filter((item) => isAdmin || item.href === "/admin/pages")
-              .map((item) => (
-                <Link key={item.href} href={item.href} className={linkClass(item.href)}>
-                  <item.icon className="h-5 w-5 shrink-0" />
-                  {!collapsed && <span>{item.label}</span>}
-                </Link>
-              ))}
-          </>
-        )}
+      <nav
+        aria-label="Main navigation"
+        className="flex-1 overflow-y-auto py-4 px-2 space-y-1"
+      >
+        <SidebarNav
+          profile={profile}
+          hasServingAccess={hasServingAccess}
+          collapsed={collapsed}
+        />
       </nav>
 
       <button
         onClick={() => setCollapsed(!collapsed)}
+        aria-expanded={!collapsed}
+        aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+        title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
         className="flex items-center justify-center py-3 border-t border-border text-slate-400 hover:text-brand-primary transition-colors"
       >
         {collapsed ? (
-          <ChevronRight className="h-4 w-4" />
+          <ChevronRight className="h-4 w-4" aria-hidden="true" />
         ) : (
-          <ChevronLeft className="h-4 w-4" />
+          <ChevronLeft className="h-4 w-4" aria-hidden="true" />
         )}
       </button>
     </aside>

--- a/components/layout/SidebarContext.tsx
+++ b/components/layout/SidebarContext.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+
+interface SidebarContextValue {
+  collapsed: boolean;
+  setCollapsed: (collapsed: boolean) => void;
+}
+
+const SidebarContext = createContext<SidebarContextValue | null>(null);
+
+export function SidebarProvider({ children }: { children: React.ReactNode }) {
+  const [collapsed, setCollapsed] = useState(false);
+  return (
+    <SidebarContext.Provider value={{ collapsed, setCollapsed }}>
+      {children}
+    </SidebarContext.Provider>
+  );
+}
+
+export function useSidebar() {
+  const ctx = useContext(SidebarContext);
+  if (!ctx) throw new Error("useSidebar must be used within SidebarProvider");
+  return ctx;
+}

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -17,10 +17,11 @@ import {
   HandHelping,
   BarChart2,
 } from "lucide-react";
-import { useState, useEffect } from "react";
-import type { Profile } from "@/lib/types";
-import type { PageContent } from "@/lib/types";
+import { useState, useEffect, type ComponentType } from "react";
+import type { PageContent, Profile } from "@/lib/types";
 import { createClient } from "@/lib/supabase/client";
+
+type PageLink = Pick<PageContent, "slug" | "title">;
 
 interface SidebarNavProps {
   profile: Profile;
@@ -57,7 +58,7 @@ export function SidebarNav({
   onNavigate,
 }: SidebarNavProps) {
   const pathname = usePathname();
-  const [pages, setPages] = useState<PageContent[]>([]);
+  const [pages, setPages] = useState<PageLink[]>([]);
   const isAdmin = profile.role === "admin";
   const isEditor = profile.role === "content_editor" || isAdmin;
 
@@ -67,8 +68,12 @@ export function SidebarNav({
       .from("page_content")
       .select("slug, title")
       .order("title")
-      .then(({ data }) => {
-        if (data) setPages(data as PageContent[]);
+      .then(({ data, error }) => {
+        if (error) {
+          console.error("Failed to load pages for navigation:", error.message);
+          return;
+        }
+        if (data) setPages(data);
       });
   }, [pathname]);
 
@@ -83,7 +88,7 @@ export function SidebarNav({
     }`;
 
   const renderLink = (
-    item: { href: string; label: string; icon: React.ComponentType<{ className?: string }>; exact?: boolean },
+    item: { href: string; label: string; icon: ComponentType<{ className?: string }>; exact?: boolean },
   ) => {
     const active = isActive(item.href, item.exact);
     return (

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  LayoutDashboard,
+  Calendar,
+  CalendarDays,
+  Megaphone,
+  BookOpen,
+  FileText,
+  Settings,
+  Users,
+  UserCircle,
+  Home,
+  MailPlus,
+  HandHelping,
+  BarChart2,
+} from "lucide-react";
+import { useState, useEffect } from "react";
+import type { Profile } from "@/lib/types";
+import type { PageContent } from "@/lib/types";
+import { createClient } from "@/lib/supabase/client";
+
+interface SidebarNavProps {
+  profile: Profile;
+  hasServingAccess: boolean;
+  collapsed?: boolean;
+  onNavigate?: () => void;
+}
+
+const memberNav = [
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/events", label: "Calendar", icon: Calendar },
+  { href: "/announcements", label: "Announcements", icon: Megaphone },
+  { href: "/lectures", label: "Lectures", icon: BookOpen },
+  { href: "/directory", label: "Directory", icon: Users },
+  { href: "/serving", label: "Serving", icon: HandHelping },
+  { href: "/profile", label: "My Profile", icon: UserCircle },
+];
+
+const adminNav = [
+  { href: "/admin", label: "Admin", icon: Settings, exact: true },
+  { href: "/admin/members", label: "Members", icon: Users },
+  { href: "/admin/families", label: "Families", icon: Home },
+  { href: "/admin/groups", label: "Groups", icon: Users },
+  { href: "/admin/invite", label: "Bulk Invite", icon: MailPlus },
+  { href: "/admin/calendars", label: "Calendars", icon: CalendarDays },
+  { href: "/admin/serving", label: "Serving Stats", icon: BarChart2 },
+  { href: "/admin/pages", label: "Manage Pages", icon: FileText },
+];
+
+export function SidebarNav({
+  profile,
+  hasServingAccess,
+  collapsed = false,
+  onNavigate,
+}: SidebarNavProps) {
+  const pathname = usePathname();
+  const [pages, setPages] = useState<PageContent[]>([]);
+  const isAdmin = profile.role === "admin";
+  const isEditor = profile.role === "content_editor" || isAdmin;
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase
+      .from("page_content")
+      .select("slug, title")
+      .order("title")
+      .then(({ data }) => {
+        if (data) setPages(data as PageContent[]);
+      });
+  }, [pathname]);
+
+  const isActive = (href: string, exact = false) =>
+    exact ? pathname === href : pathname === href || pathname.startsWith(href + "/");
+
+  const linkClass = (active: boolean) =>
+    `flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+      active
+        ? "bg-brand-bg-light text-brand-primary"
+        : "text-slate-600 hover:text-brand-primary hover:bg-brand-bg-light/50"
+    }`;
+
+  const renderLink = (
+    item: { href: string; label: string; icon: React.ComponentType<{ className?: string }>; exact?: boolean },
+  ) => {
+    const active = isActive(item.href, item.exact);
+    return (
+      <Link
+        key={item.href}
+        href={item.href}
+        className={linkClass(active)}
+        aria-current={active ? "page" : undefined}
+        title={collapsed ? item.label : undefined}
+        onClick={onNavigate}
+      >
+        <item.icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+        {!collapsed && <span>{item.label}</span>}
+      </Link>
+    );
+  };
+
+  return (
+    <>
+      {memberNav
+        .filter((item) => item.href !== "/serving" || hasServingAccess)
+        .map(renderLink)}
+
+      {pages.length > 0 && (
+        <>
+          {!collapsed && (
+            <p className="px-3 pt-4 pb-1 text-xs font-semibold uppercase text-slate-400 tracking-wider">
+              Pages
+            </p>
+          )}
+          {collapsed && <div className="border-t border-border my-2" role="separator" />}
+          {pages.map((page) => {
+            const href = `/pages/${page.slug}`;
+            const active = isActive(href);
+            return (
+              <Link
+                key={page.slug}
+                href={href}
+                className={linkClass(active)}
+                aria-current={active ? "page" : undefined}
+                title={collapsed ? page.title : undefined}
+                onClick={onNavigate}
+              >
+                <FileText className="h-5 w-5 shrink-0" aria-hidden="true" />
+                {!collapsed && <span className="truncate">{page.title}</span>}
+              </Link>
+            );
+          })}
+        </>
+      )}
+
+      {isEditor && (
+        <>
+          {!collapsed && (
+            <p className="px-3 pt-4 pb-1 text-xs font-semibold uppercase text-slate-400 tracking-wider">
+              Admin
+            </p>
+          )}
+          {collapsed && <div className="border-t border-border my-2" role="separator" />}
+          {adminNav
+            .filter((item) => isAdmin || item.href === "/admin/pages")
+            .map(renderLink)}
+        </>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes several navigation bugs and makes the left pane accessible on mobile.

- **Mobile nav was unreachable**: the sidebar was `hidden md:flex` and the old header sheet only duplicated 4 links, so Directory, Serving, My Profile, custom Pages, and all admin subpages had no mobile entry point. Nav items are now extracted into a shared `SidebarNav` component, and the header menu button opens the full pane as a left drawer that closes on navigation.
- **Removed duplicated top nav buttons**: the pane is the single navigation source; the header keeps only the logo and Sign In/Out. On member pages without a sidebar (e.g. `/household`) the menu button stays available on desktop too.
- **Admin link highlighted on every `/admin/*` subpage**: now exact-matches `/admin` only; subpages highlight their own entry.
- **Pointer cursor on clickables**: Tailwind v4 resets buttons to `cursor: default`; a base rule restores `cursor: pointer` on enabled buttons, `[role="button"]`, submit inputs, labels, selects, and summaries.
- **Accessibility pass**: `aria-current="page"` on active links, labelled menu/collapse buttons with `aria-expanded`, screen-reader title on the drawer, tooltips on collapsed icon-only links, larger touch targets.

## Testing

- `tsc --noEmit`, `eslint`, and `next build` all pass.
- Verified in-browser (390×844 and 1440×900): drawer opens/closes, closes on navigation, active states follow the route, sidebar collapse/expand works, computed cursor is `pointer` on all enabled buttons.

https://claude.ai/code/session_01MAK4wMMCwtiGAx3dYV7AwH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed navigation experience with a shared sidebar menu, including active-route highlighting and cleaner collapsed/expanded behavior.
  * Updated the header to show navigation options based on access level.

* **Bug Fixes**
  * Navigation drawer now closes when moving between pages.
  * Sign-out flow now closes the menu first and returns you to the home page more reliably.
  * Clickable controls now show the expected pointer cursor again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->