### PR TITLE
feat(prayer): prayer wall with audience-scoped requests and synced call sessions

### DIFF
--- a/app/admin/groups/page.tsx
+++ b/app/admin/groups/page.tsx
@@ -25,6 +25,7 @@ import {
   ArrowDown,
   Users,
   Filter,
+  HandHeart,
 } from "lucide-react";
 import type { MemberGroup } from "@/lib/types";
 import { GroupRosterDialog } from "./GroupRosterDialog";
@@ -36,6 +37,7 @@ interface GroupFormState {
   color: string;
   icon: string;
   show_in_directory_filter: boolean;
+  is_serving_role: boolean;
 }
 
 const EMPTY_FORM: GroupFormState = {
@@ -44,6 +46,7 @@ const EMPTY_FORM: GroupFormState = {
   color: "#2F6BA8",
   icon: "users",
   show_in_directory_filter: true,
+  is_serving_role: false,
 };
 
 function fromGroup(g: MemberGroup): GroupFormState {
@@ -53,6 +56,7 @@ function fromGroup(g: MemberGroup): GroupFormState {
     color: g.color || "#2F6BA8",
     icon: g.icon || "users",
     show_in_directory_filter: g.show_in_directory_filter ?? true,
+    is_serving_role: g.is_serving_role ?? false,
   };
 }
 
@@ -128,6 +132,7 @@ export default function GroupsPage() {
       color: form.color || null,
       icon: form.icon || null,
       show_in_directory_filter: form.show_in_directory_filter,
+      is_serving_role: form.is_serving_role,
     };
 
     setSaving(true);
@@ -275,6 +280,12 @@ export default function GroupsPage() {
                           Directory filter
                         </Badge>
                       )}
+                      {group.is_serving_role && (
+                        <Badge variant="secondary" className="text-xs gap-1">
+                          <HandHeart className="h-3 w-3" />
+                          Serving role
+                        </Badge>
+                      )}
                     </div>
                     {group.description && (
                       <p className="text-sm text-muted-foreground">
@@ -418,6 +429,23 @@ export default function GroupsPage() {
                 checked={form.show_in_directory_filter}
                 onCheckedChange={(v) =>
                   setForm({ ...form, show_in_directory_filter: v })
+                }
+              />
+            </div>
+
+            <div className="flex items-center justify-between rounded-lg border p-3">
+              <div className="space-y-0.5">
+                <Label htmlFor="g_serving">Serving role</Label>
+                <p className="text-xs text-muted-foreground">
+                  Lists this group on the Serving page with a roster everyone
+                  can see. Turn on Sunday signups separately from that page.
+                </p>
+              </div>
+              <Switch
+                id="g_serving"
+                checked={form.is_serving_role}
+                onCheckedChange={(v) =>
+                  setForm({ ...form, is_serving_role: v })
                 }
               />
             </div>

--- a/app/prayer/page.tsx
+++ b/app/prayer/page.tsx
@@ -23,24 +23,35 @@ export default async function PrayerPage() {
   if (!profile || profile.role === "pending") redirect("/dashboard");
   const isAdmin = profile.role === "admin";
 
-  const [{ data: requests }, { data: sessions }, { members }, { data: calSetting }] =
-    await Promise.all([
-      supabase
-        .from("prayer_wall")
-        .select("*")
-        .order("created_at", { ascending: false }),
-      supabase
-        .from("prayer_call_sessions")
-        .select("*")
-        .order("display_order")
-        .order("created_at"),
-      loadFundFormData(supabase),
-      supabase
-        .from("site_settings")
-        .select("value")
-        .eq("key", "prayer_calendar_id")
-        .maybeSingle(),
-    ]);
+  const [
+    { data: requests, error: requestsError },
+    { data: sessions, error: sessionsError },
+    { members },
+    { data: calSetting },
+  ] = await Promise.all([
+    supabase
+      .from("prayer_wall")
+      .select("*")
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("prayer_call_sessions")
+      .select("*")
+      .order("display_order")
+      .order("created_at"),
+    loadFundFormData(supabase),
+    supabase
+      .from("site_settings")
+      .select("value")
+      .eq("key", "prayer_calendar_id")
+      .maybeSingle(),
+  ]);
+  if (requestsError) {
+    console.error("Failed to fetch prayer requests:", requestsError);
+    throw new Error("Failed to load the prayer wall.");
+  }
+  if (sessionsError) {
+    console.error("Failed to fetch prayer call sessions:", sessionsError);
+  }
 
   return (
     <div className="container mx-auto px-4 py-12 max-w-6xl">

--- a/app/prayer/page.tsx
+++ b/app/prayer/page.tsx
@@ -4,7 +4,7 @@ import { siteConfig } from "@/lib/config";
 import { displayName, initials } from "@/lib/names";
 import { loadFundFormData } from "@/lib/giving/server";
 import { PrayerBoard } from "@/components/prayer/PrayerBoard";
-import type { PrayerCallSession, PrayerWallRow } from "@/lib/types";
+import type { PrayerCallSession, PrayerWallRow, PrayerWarrior } from "@/lib/types";
 
 export const metadata = { title: `Prayer | ${siteConfig.name}` };
 
@@ -27,6 +27,7 @@ export default async function PrayerPage() {
     { data: requests, error: requestsError },
     { data: sessions, error: sessionsError },
     { members },
+    { data: warriors },
     { data: calSetting },
   ] = await Promise.all([
     supabase
@@ -39,6 +40,13 @@ export default async function PrayerPage() {
       .order("display_order")
       .order("created_at"),
     loadFundFormData(supabase),
+    // Roster of the Prayer Warriors group so posters can see who a
+    // warrior-restricted request will reach. RLS trims this to listed profiles.
+    supabase
+      .from("profiles")
+      .select("id, first_name, last_name, preferred_name, avatar_url")
+      .eq("is_prayer_warrior", true)
+      .order("first_name"),
     supabase
       .from("site_settings")
       .select("value")
@@ -75,6 +83,7 @@ export default async function PrayerPage() {
           }}
           isAdmin={isAdmin}
           members={members}
+          warriors={(warriors ?? []) as PrayerWarrior[]}
           prayerCalendarId={calSetting?.value ?? null}
         />
       </div>

--- a/app/prayer/page.tsx
+++ b/app/prayer/page.tsx
@@ -1,0 +1,72 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { siteConfig } from "@/lib/config";
+import { displayName, initials } from "@/lib/names";
+import { loadFundFormData } from "@/lib/giving/server";
+import { PrayerBoard } from "@/components/prayer/PrayerBoard";
+import type { PrayerCallSession, PrayerWallRow } from "@/lib/types";
+
+export const metadata = { title: `Prayer | ${siteConfig.name}` };
+
+export default async function PrayerPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role, first_name, last_name, preferred_name, avatar_url")
+    .eq("id", user.id)
+    .single();
+  if (!profile || profile.role === "pending") redirect("/dashboard");
+  const isAdmin = profile.role === "admin";
+
+  const [{ data: requests }, { data: sessions }, { members }, { data: calSetting }] =
+    await Promise.all([
+      supabase
+        .from("prayer_wall")
+        .select("*")
+        .order("created_at", { ascending: false }),
+      supabase
+        .from("prayer_call_sessions")
+        .select("*")
+        .order("display_order")
+        .order("created_at"),
+      loadFundFormData(supabase),
+      supabase
+        .from("site_settings")
+        .select("value")
+        .eq("key", "prayer_calendar_id")
+        .maybeSingle(),
+    ]);
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-6xl">
+      <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-2">
+        Prayer
+      </h1>
+      <p className="text-lg text-muted-foreground max-w-2xl">
+        Post a request with your name or anonymously, and choose who can see
+        it.
+      </p>
+
+      <div className="mt-10">
+        <PrayerBoard
+          initialRequests={(requests ?? []) as PrayerWallRow[]}
+          sessions={(sessions ?? []) as PrayerCallSession[]}
+          me={{
+            id: user.id,
+            name: displayName(profile),
+            initials: initials(profile),
+            avatarUrl: profile.avatar_url,
+          }}
+          isAdmin={isAdmin}
+          members={members}
+          prayerCalendarId={calSetting?.value ?? null}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/serving/[groupId]/page.tsx
+++ b/app/serving/[groupId]/page.tsx
@@ -69,8 +69,9 @@ export default async function ServingSchedulePage({
 
   const isMember = !!membership;
   const isLeader = membership?.is_leader === true;
-
-  if (!isMember && !isLeader && !isAdmin) redirect("/serving");
+  // Everyone can view the schedule/roster read-only; only team members,
+  // leaders, and admins can actually claim a Sunday.
+  const canSignUp = isMember || isLeader || isAdmin;
 
   const { data: memberRows } = await supabase
     .from("profile_groups")
@@ -261,6 +262,13 @@ export default async function ServingSchedulePage({
         </div>
       )}
 
+      {!canSignUp && (
+        <p className="text-sm text-muted-foreground mb-6">
+          You&apos;re viewing this team&apos;s schedule. Only team members can
+          sign up — ask an admin to be added.
+        </p>
+      )}
+
       <ServingSchedule
         groupId={groupId}
         teamName={group.name}
@@ -268,7 +276,7 @@ export default async function ServingSchedulePage({
         entries={entries}
         userId={user.id}
         spouse={spouse}
-        canSignUp={isMember || isLeader || isAdmin}
+        canSignUp={canSignUp}
         canManage={isLeader || isAdmin}
       />
 

--- a/app/serving/page.tsx
+++ b/app/serving/page.tsx
@@ -6,12 +6,23 @@ import { ChevronRight } from "lucide-react";
 import { siteConfig } from "@/lib/config";
 import { toDateString, upcomingSundays } from "@/lib/serving/sundays";
 import { AdminServingSetup } from "@/components/serving/AdminServingSetup";
+import { RoleRoster, type RosterMember } from "@/components/serving/RoleRoster";
+import { displayName } from "@/lib/names";
 import type { MemberGroup, ServingTeamSettings } from "@/lib/types";
 
 export const metadata = { title: `Serving | ${siteConfig.name}` };
 
-type SettingsWithGroup = ServingTeamSettings & {
-  member_groups: Pick<MemberGroup, "id" | "name" | "description" | "color"> | null;
+// PostgREST embeds the joined profile as a to-one object.
+type RosterRow = {
+  group_id: string;
+  is_leader: boolean;
+  profiles: {
+    id: string;
+    first_name: string | null;
+    last_name: string | null;
+    preferred_name: string | null;
+    avatar_url: string | null;
+  } | null;
 };
 
 export default async function ServingPage() {
@@ -31,58 +42,87 @@ export default async function ServingPage() {
   if (!profile || profile.role === "pending") redirect("/dashboard");
   const isAdmin = profile.role === "admin";
 
-  const [{ data: settingsRows }, { data: memberships }] = await Promise.all([
+  const [
+    { data: groupRows },
+    { data: settingsRows },
+    { data: rosterRows },
+    { data: memberships },
+  ] = await Promise.all([
+    supabase.from("member_groups").select("*").order("display_order"),
+    supabase.from("serving_team_settings").select("*"),
     supabase
-      .from("serving_team_settings")
-      .select("*, member_groups(id, name, description, color)")
-      .eq("enabled", true),
+      .from("profile_groups")
+      .select(
+        "group_id, is_leader, profiles(id, first_name, last_name, preferred_name, avatar_url)"
+      ),
     supabase
       .from("profile_groups")
       .select("group_id, is_leader")
       .eq("profile_id", user.id),
   ]);
 
+  const groups = (groupRows ?? []) as MemberGroup[];
+  const settingsMap = new Map(
+    ((settingsRows ?? []) as ServingTeamSettings[]).map((s) => [s.group_id, s])
+  );
   const membershipMap = new Map(
     (memberships ?? []).map((m) => [m.group_id, m.is_leader as boolean])
   );
-  const teams = ((settingsRows ?? []) as SettingsWithGroup[]).filter(
-    (s) => s.member_groups && (isAdmin || membershipMap.has(s.group_id))
-  );
 
-  // Coverage counts for each team's upcoming window
+  // Roster per group (RLS already hides unlisted / non-member profiles).
+  // Leaders float to the top, then alphabetical by display name.
+  const rosters = new Map<string, RosterMember[]>();
+  for (const row of (rosterRows ?? []) as unknown as RosterRow[]) {
+    if (!row.profiles) continue;
+    const list = rosters.get(row.group_id) ?? [];
+    list.push({ ...row.profiles, is_leader: row.is_leader });
+    rosters.set(row.group_id, list);
+  }
+  for (const list of rosters.values()) {
+    list.sort((a, b) =>
+      a.is_leader !== b.is_leader
+        ? a.is_leader
+          ? -1
+          : 1
+        : displayName(a).localeCompare(displayName(b))
+    );
+  }
+
+  const isEnabled = (id: string) => settingsMap.get(id)?.enabled === true;
+  // Signup teams (Sunday signups on) and roster-only standing roles.
+  const signupTeams = groups.filter((g) => isEnabled(g.id));
+  const roleGroups = groups.filter((g) => g.is_serving_role && !isEnabled(g.id));
+
+  // Coverage counts for each signup team's upcoming window
   const today = toDateString(new Date());
   const coverage = new Map<string, number>();
-  if (teams.length > 0) {
+  if (signupTeams.length > 0) {
     const { data: signups } = await supabase
       .from("serving_signups")
       .select("group_id, service_date")
       .in(
         "group_id",
-        teams.map((t) => t.group_id)
+        signupTeams.map((g) => g.id)
       )
       .gte("service_date", today);
 
-    for (const team of teams) {
-      const window = new Set(upcomingSundays(team.window_weeks));
+    for (const g of signupTeams) {
+      const window = new Set(upcomingSundays(settingsMap.get(g.id)!.window_weeks));
       coverage.set(
-        team.group_id,
+        g.id,
         (signups ?? []).filter(
-          (s) => s.group_id === team.group_id && window.has(s.service_date)
+          (s) => s.group_id === g.id && window.has(s.service_date)
         ).length
       );
     }
   }
 
-  // Teams admins could still turn on
-  let candidateGroups: Pick<MemberGroup, "id" | "name" | "color">[] = [];
-  if (isAdmin) {
-    const { data: allGroups } = await supabase
-      .from("member_groups")
-      .select("id, name, color")
-      .order("display_order");
-    const enabledIds = new Set(teams.map((t) => t.group_id));
-    candidateGroups = (allGroups ?? []).filter((g) => !enabledIds.has(g.id));
-  }
+  // Groups an admin could still turn signups on for
+  const candidateGroups: Pick<MemberGroup, "id" | "name" | "color">[] = isAdmin
+    ? groups.filter((g) => !isEnabled(g.id))
+    : [];
+
+  const nothingToShow = signupTeams.length === 0 && roleGroups.length === 0;
 
   return (
     <div className="container mx-auto px-4 py-12 max-w-3xl">
@@ -90,49 +130,110 @@ export default async function ServingPage() {
         Serving
       </h1>
       <p className="text-lg text-muted-foreground mb-10">
-        Take a Sunday to serve — sign up in one tap and we&apos;ll remind you
-        when it&apos;s close.
+        Sign up to serve on a Sunday, and see the teams and roles that keep our
+        class running.
       </p>
 
-      {teams.length > 0 ? (
-        <div className="space-y-4">
-          {teams.map((team) => {
-            const group = team.member_groups!;
-            const covered = coverage.get(team.group_id) ?? 0;
-            const isLeader = membershipMap.get(team.group_id) === true;
-            const isMember = membershipMap.has(team.group_id);
-            return (
-              <Link key={team.group_id} href={`/serving/${team.group_id}`}>
-                <Card className="mb-4 hover:border-brand-primary/50 transition-colors">
-                  <CardContent className="py-5 flex items-center gap-4">
-                    <span
-                      className="inline-block w-4 h-4 rounded-full shrink-0"
-                      style={{ backgroundColor: group.color ?? "#2F6BA8" }}
-                    />
-                    <div className="flex-1 min-w-0">
-                      <p className="text-xl font-semibold flex items-center gap-2">
-                        {group.name}
-                        {isLeader && (
-                          <span className="text-xs font-medium uppercase tracking-wider text-brand-accent border border-brand-accent/40 rounded px-1.5 py-0.5">
-                            Leader
-                          </span>
+      {signupTeams.length > 0 && (
+        <section className="mb-12">
+          <h2 className="text-sm font-bold uppercase tracking-widest text-muted-foreground mb-4">
+            Sign up to serve
+          </h2>
+          <div className="space-y-4">
+            {signupTeams.map((group) => {
+              const settings = settingsMap.get(group.id)!;
+              const covered = coverage.get(group.id) ?? 0;
+              const isLeader = membershipMap.get(group.id) === true;
+              const isMember = membershipMap.has(group.id);
+              const members = rosters.get(group.id) ?? [];
+              return (
+                <Link key={group.id} href={`/serving/${group.id}`}>
+                  <Card className="mb-4 hover:border-brand-primary/50 transition-colors">
+                    <CardContent className="py-5">
+                      <div className="flex items-center gap-4">
+                        <span
+                          className="inline-block w-4 h-4 rounded-full shrink-0"
+                          style={{ backgroundColor: group.color ?? "#2F6BA8" }}
+                        />
+                        <div className="flex-1 min-w-0">
+                          <p className="text-xl font-semibold flex items-center gap-2">
+                            {group.name}
+                            {isLeader && (
+                              <span className="text-xs font-medium uppercase tracking-wider text-brand-accent border border-brand-accent/40 rounded px-1.5 py-0.5">
+                                Leader
+                              </span>
+                            )}
+                          </p>
+                          <p className="text-muted-foreground">
+                            {covered} of the next {settings.window_weeks} Sundays
+                            covered
+                            {isMember && !isLeader ? " · You're on this team" : ""}
+                            {!isMember && !isAdmin ? " · Members sign up" : ""}
+                          </p>
+                        </div>
+                        <ChevronRight className="h-6 w-6 text-muted-foreground shrink-0" />
+                      </div>
+                      {members.length > 0 && (
+                        <div className="mt-4 pl-8">
+                          <RoleRoster members={members} />
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
+                </Link>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {roleGroups.length > 0 && (
+        <section className="mb-12">
+          <h2 className="text-sm font-bold uppercase tracking-widest text-muted-foreground mb-4">
+            Teams &amp; roles
+          </h2>
+          <div className="space-y-4">
+            {roleGroups.map((group) => {
+              const members = rosters.get(group.id) ?? [];
+              const isMember = membershipMap.has(group.id);
+              return (
+                <Card key={group.id}>
+                  <CardContent className="py-5">
+                    <div className="flex items-center gap-4">
+                      <span
+                        className="inline-block w-4 h-4 rounded-full shrink-0"
+                        style={{ backgroundColor: group.color ?? "#2F6BA8" }}
+                      />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-xl font-semibold flex items-center gap-2">
+                          {group.name}
+                          {isMember && (
+                            <span className="text-xs font-medium uppercase tracking-wider text-brand-accent border border-brand-accent/40 rounded px-1.5 py-0.5">
+                              You&apos;re in this group
+                            </span>
+                          )}
+                        </p>
+                        {group.description && (
+                          <p className="text-muted-foreground">
+                            {group.description}
+                          </p>
                         )}
-                      </p>
-                      <p className="text-muted-foreground">
-                        {covered} of the next {team.window_weeks} Sundays covered
-                        {isMember && !isLeader ? " · You're on this team" : ""}
-                      </p>
+                      </div>
                     </div>
-                    <ChevronRight className="h-6 w-6 text-muted-foreground shrink-0" />
+                    <div className="mt-4 pl-8">
+                      <RoleRoster members={members} />
+                    </div>
                   </CardContent>
                 </Card>
-              </Link>
-            );
-          })}
-        </div>
-      ) : (
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {nothingToShow && (
         <p className="text-xl text-muted-foreground">
-          No serving teams are set up yet.
+          No serving teams or roles are set up yet.
         </p>
       )}
 

--- a/app/serving/page.tsx
+++ b/app/serving/page.tsx
@@ -18,6 +18,7 @@ type RosterRow = {
   is_leader: boolean;
   profiles: {
     id: string;
+    role: string | null;
     first_name: string | null;
     last_name: string | null;
     preferred_name: string | null;
@@ -53,7 +54,7 @@ export default async function ServingPage() {
     supabase
       .from("profile_groups")
       .select(
-        "group_id, is_leader, profiles(id, first_name, last_name, preferred_name, avatar_url)"
+        "group_id, is_leader, profiles(id, role, first_name, last_name, preferred_name, avatar_url)"
       ),
     supabase
       .from("profile_groups")
@@ -73,7 +74,8 @@ export default async function ServingPage() {
   // Leaders float to the top, then alphabetical by display name.
   const rosters = new Map<string, RosterMember[]>();
   for (const row of (rosterRows ?? []) as unknown as RosterRow[]) {
-    if (!row.profiles) continue;
+    // Skip un-onboarded household peers (no name yet, not real roster members).
+    if (!row.profiles || row.profiles.role === "pending") continue;
     const list = rosters.get(row.group_id) ?? [];
     list.push({ ...row.profiles, is_leader: row.is_leader });
     rosters.set(row.group_id, list);

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -19,6 +19,7 @@ export const SIDEBAR_ROUTES = [
   "/admin",
   "/directory",
   "/serving",
+  "/prayer",
   "/profile",
 ];
 

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -16,6 +16,7 @@ import {
   MailPlus,
   HandHelping,
   HandCoins,
+  HeartHandshake,
   BarChart2,
 } from "lucide-react";
 import { useState, useEffect, type ComponentType } from "react";
@@ -38,6 +39,7 @@ const memberNav = [
   { href: "/lectures", label: "Lectures", icon: BookOpen },
   { href: "/directory", label: "Directory", icon: Users },
   { href: "/serving", label: "Serving", icon: HandHelping },
+  { href: "/prayer", label: "Prayer", icon: HeartHandshake },
   { href: "/give", label: "Give", icon: HandCoins },
   { href: "/profile", label: "My Profile", icon: UserCircle },
 ];

--- a/components/prayer/PrayerBoard.tsx
+++ b/components/prayer/PrayerBoard.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Search, X } from "lucide-react";
+import { toast } from "sonner";
+import { createClient } from "@/lib/supabase/client";
+import { displayName } from "@/lib/names";
+import {
+  isRestricted,
+  PRAYER_CATEGORIES,
+  PRAYER_CATEGORY_KEYS,
+  type PrayerAudience,
+} from "@/lib/prayer";
+import { PrayerCard } from "@/components/prayer/PrayerCard";
+import { PrayerComposer } from "@/components/prayer/PrayerComposer";
+import { PrayerCallCard } from "@/components/prayer/PrayerCallCard";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { MemberOption } from "@/components/giving/FundForm";
+import type { PrayerCallSession, PrayerCategory, PrayerWallRow } from "@/lib/types";
+
+export interface Me {
+  id: string;
+  name: string;
+  initials: string;
+  avatarUrl: string | null;
+}
+
+const STATUS_FILTERS = [
+  "All",
+  "My requests",
+  "Everyone",
+  "Restricted",
+  "Answered",
+] as const;
+type StatusFilter = (typeof STATUS_FILTERS)[number];
+
+const TYPE_ITEMS = [
+  { value: "all", label: "All types" },
+  ...PRAYER_CATEGORY_KEYS.map((key) => ({
+    value: key,
+    label: PRAYER_CATEGORIES[key].label,
+  })),
+];
+
+export function PrayerBoard({
+  initialRequests,
+  sessions,
+  me,
+  isAdmin,
+  members,
+  prayerCalendarId,
+}: {
+  initialRequests: PrayerWallRow[];
+  sessions: PrayerCallSession[];
+  me: Me;
+  isAdmin: boolean;
+  members: MemberOption[];
+  prayerCalendarId: string | null;
+}) {
+  const [requests, setRequests] = useState(initialRequests);
+  const [status, setStatus] = useState<StatusFilter>("All");
+  const [category, setCategory] = useState<PrayerCategory | null>(null);
+  const [query, setQuery] = useState("");
+
+  const handlePost = async (draft: {
+    body: string;
+    category: PrayerCategory;
+    is_anonymous: boolean;
+  } & PrayerAudience) => {
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from("prayer_requests")
+      .insert({ author_id: me.id, ...draft })
+      .select("id, created_at")
+      .single();
+    if (error || !data) {
+      toast.error("Couldn't post your request. Please try again.");
+      return false;
+    }
+    setRequests((prev) => [
+      {
+        id: data.id,
+        body: draft.body,
+        category: draft.category,
+        is_anonymous: draft.is_anonymous,
+        visible_to_warriors: draft.visible_to_warriors,
+        visible_to_leaders: draft.visible_to_leaders,
+        visible_to_admins: draft.visible_to_admins,
+        is_answered: false,
+        created_at: data.created_at,
+        mine: true,
+        first_name: null,
+        last_name: null,
+        preferred_name: me.name,
+        avatar_url: me.avatarUrl,
+        praying_count: 0,
+        i_am_praying: false,
+      },
+      ...prev,
+    ]);
+    return true;
+  };
+
+  const patchRequest = (id: string, patch: Partial<PrayerWallRow>) =>
+    setRequests((prev) =>
+      prev.map((r) => (r.id === id ? { ...r, ...patch } : r))
+    );
+
+  const handlePray = async (row: PrayerWallRow) => {
+    const supabase = createClient();
+    const praying = !row.i_am_praying;
+    patchRequest(row.id, {
+      i_am_praying: praying,
+      praying_count: row.praying_count + (praying ? 1 : -1),
+    });
+    const { error } = praying
+      ? await supabase
+          .from("prayer_responses")
+          .insert({ request_id: row.id, profile_id: me.id })
+      : await supabase
+          .from("prayer_responses")
+          .delete()
+          .eq("request_id", row.id)
+          .eq("profile_id", me.id);
+    if (error) {
+      patchRequest(row.id, {
+        i_am_praying: row.i_am_praying,
+        praying_count: row.praying_count,
+      });
+      toast.error("Couldn't save that. Please try again.");
+    }
+  };
+
+  const handleToggleAnswered = async (row: PrayerWallRow) => {
+    const supabase = createClient();
+    const answered = !row.is_answered;
+    patchRequest(row.id, { is_answered: answered });
+    const { error } = await supabase
+      .from("prayer_requests")
+      .update({ is_answered: answered })
+      .eq("id", row.id);
+    if (error) {
+      patchRequest(row.id, { is_answered: row.is_answered });
+      toast.error("Couldn't save that. Please try again.");
+    }
+  };
+
+  const shown = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return requests.filter((r) => {
+      if (status === "My requests" && !r.mine) return false;
+      if (status === "Everyone" && isRestricted(r)) return false;
+      if (status === "Restricted" && !isRestricted(r)) return false;
+      if (status === "Answered" && !r.is_answered) return false;
+      if (category && r.category !== category) return false;
+      if (!q) return true;
+      const author = r.is_anonymous && !r.mine ? "anonymous" : displayName(r);
+      return (
+        r.body.toLowerCase().includes(q) ||
+        PRAYER_CATEGORIES[r.category].label.toLowerCase().includes(q) ||
+        author.toLowerCase().includes(q)
+      );
+    });
+  }, [requests, status, category, query]);
+
+  // RLS already trims the wall to what this member may see, so the chip only
+  // appears when at least one visible request is actually restricted.
+  const statusFilters = STATUS_FILTERS.filter(
+    (f) => f !== "Restricted" || requests.some(isRestricted)
+  );
+
+  const typeMeta = category ? PRAYER_CATEGORIES[category] : null;
+
+  const wall = (
+    <div>
+      {/* Search */}
+      <div className="flex items-center gap-2.5 rounded-full border border-border bg-card px-4 py-2.5">
+        <Search className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search requests…"
+          aria-label="Search requests"
+          className="w-full bg-transparent text-[15px] outline-none placeholder:text-muted-foreground"
+        />
+        {query && (
+          <button
+            type="button"
+            aria-label="Clear search"
+            onClick={() => setQuery("")}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+
+      {/* Status filters + prayer type dropdown */}
+      <div className="mt-3.5 flex flex-wrap items-center gap-2">
+        {statusFilters.map((f) => {
+          const active = f === status;
+          return (
+            <button
+              key={f}
+              type="button"
+              onClick={() => setStatus(f)}
+              className={`rounded-full border px-3.5 py-1.5 text-sm transition-colors ${
+                active
+                  ? "border-foreground bg-foreground font-semibold text-background"
+                  : "border-border bg-card font-medium text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {f}
+            </button>
+          );
+        })}
+        <Select
+          items={TYPE_ITEMS}
+          value={category ?? "all"}
+          onValueChange={(v) =>
+            setCategory(!v || v === "all" ? null : (v as PrayerCategory))
+          }
+        >
+          <SelectTrigger
+            aria-label="Filter by prayer type"
+            className={`h-auto! rounded-full! px-3.5 py-1.5 text-sm transition-colors ${
+              typeMeta
+                ? "font-semibold [&_svg]:text-white"
+                : "border-border bg-card font-medium text-muted-foreground hover:text-foreground"
+            }`}
+            style={
+              typeMeta
+                ? {
+                    backgroundColor: typeMeta.color,
+                    borderColor: typeMeta.color,
+                    color: "#fff",
+                  }
+                : undefined
+            }
+          >
+            {typeMeta && (
+              <span
+                aria-hidden="true"
+                className="h-1.5 w-1.5 shrink-0 rounded-full bg-white"
+              />
+            )}
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {TYPE_ITEMS.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.value !== "all" && (
+                  <span
+                    aria-hidden="true"
+                    className="h-1.5 w-1.5 shrink-0 self-center rounded-full"
+                    style={{
+                      backgroundColor:
+                        PRAYER_CATEGORIES[item.value as PrayerCategory].color,
+                    }}
+                  />
+                )}
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <span className="ml-auto text-sm text-muted-foreground">
+          {shown.length} shown
+        </span>
+      </div>
+
+      {/* Wall */}
+      {shown.length > 0 ? (
+        <div className="mt-4 space-y-3">
+          {shown.map((r) => (
+            <PrayerCard
+              key={r.id}
+              row={r}
+              onPray={() => handlePray(r)}
+              onToggleAnswered={() => handleToggleAnswered(r)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="mt-4 rounded-2xl border border-dashed border-border bg-card px-6 py-12 text-center text-muted-foreground">
+          {requests.length === 0
+            ? "No requests yet. Share the first one."
+            : "No requests match your filters."}
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="grid gap-8 lg:grid-cols-[1.55fr_1fr] lg:items-start">
+      <div className="order-2 lg:order-1">{wall}</div>
+      <div className="order-1 space-y-6 lg:sticky lg:top-6 lg:order-2">
+        <PrayerComposer me={me} onPost={handlePost} />
+        <PrayerCallCard
+          initialSessions={sessions}
+          isAdmin={isAdmin}
+          members={members}
+          prayerCalendarId={prayerCalendarId}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/prayer/PrayerBoard.tsx
+++ b/components/prayer/PrayerBoard.tsx
@@ -5,12 +5,7 @@ import { Search, X } from "lucide-react";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
 import { displayName } from "@/lib/names";
-import {
-  isRestricted,
-  PRAYER_CATEGORIES,
-  PRAYER_CATEGORY_KEYS,
-  type PrayerAudience,
-} from "@/lib/prayer";
+import { PRAYER_CATEGORIES, PRAYER_CATEGORY_KEYS } from "@/lib/prayer";
 import { PrayerCard } from "@/components/prayer/PrayerCard";
 import { PrayerComposer } from "@/components/prayer/PrayerComposer";
 import { PrayerCallCard } from "@/components/prayer/PrayerCallCard";
@@ -22,7 +17,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { MemberOption } from "@/components/giving/FundForm";
-import type { PrayerCallSession, PrayerCategory, PrayerWallRow } from "@/lib/types";
+import type {
+  PrayerCallSession,
+  PrayerCategory,
+  PrayerWallRow,
+  PrayerWarrior,
+} from "@/lib/types";
 
 export interface Me {
   id: string;
@@ -54,6 +54,7 @@ export function PrayerBoard({
   me,
   isAdmin,
   members,
+  warriors,
   prayerCalendarId,
 }: {
   initialRequests: PrayerWallRow[];
@@ -61,6 +62,7 @@ export function PrayerBoard({
   me: Me;
   isAdmin: boolean;
   members: MemberOption[];
+  warriors: PrayerWarrior[];
   prayerCalendarId: string | null;
 }) {
   const [requests, setRequests] = useState(initialRequests);
@@ -73,7 +75,8 @@ export function PrayerBoard({
     body: string;
     category: PrayerCategory;
     is_anonymous: boolean;
-  } & PrayerAudience) => {
+    visible_to_warriors: boolean;
+  }) => {
     const supabase = createClient();
     const { data, error } = await supabase
       .from("prayer_requests")
@@ -91,8 +94,6 @@ export function PrayerBoard({
         category: draft.category,
         is_anonymous: draft.is_anonymous,
         visible_to_warriors: draft.visible_to_warriors,
-        visible_to_leaders: draft.visible_to_leaders,
-        visible_to_admins: draft.visible_to_admins,
         is_answered: false,
         created_at: data.created_at,
         mine: true,
@@ -165,8 +166,8 @@ export function PrayerBoard({
     const q = query.trim().toLowerCase();
     return requests.filter((r) => {
       if (status === "My requests" && !r.mine) return false;
-      if (status === "Everyone" && isRestricted(r)) return false;
-      if (status === "Restricted" && !isRestricted(r)) return false;
+      if (status === "Everyone" && r.visible_to_warriors) return false;
+      if (status === "Restricted" && !r.visible_to_warriors) return false;
       if (status === "Answered" && !r.is_answered) return false;
       if (category && r.category !== category) return false;
       if (!q) return true;
@@ -182,7 +183,7 @@ export function PrayerBoard({
   // RLS already trims the wall to what this member may see, so the chip only
   // appears when at least one visible request is actually restricted.
   const statusFilters = STATUS_FILTERS.filter(
-    (f) => f !== "Restricted" || requests.some(isRestricted)
+    (f) => f !== "Restricted" || requests.some((r) => r.visible_to_warriors)
   );
 
   const typeMeta = category ? PRAYER_CATEGORIES[category] : null;
@@ -312,7 +313,7 @@ export function PrayerBoard({
     <div className="grid gap-8 lg:grid-cols-[1.55fr_1fr] lg:items-start">
       <div className="order-2 lg:order-1">{wall}</div>
       <div className="order-1 space-y-6 lg:sticky lg:top-6 lg:order-2">
-        <PrayerComposer me={me} onPost={handlePost} />
+        <PrayerComposer me={me} onPost={handlePost} warriors={warriors} />
         <PrayerCallCard
           initialSessions={sessions}
           isAdmin={isAdmin}

--- a/components/prayer/PrayerBoard.tsx
+++ b/components/prayer/PrayerBoard.tsx
@@ -67,6 +67,7 @@ export function PrayerBoard({
   const [status, setStatus] = useState<StatusFilter>("All");
   const [category, setCategory] = useState<PrayerCategory | null>(null);
   const [query, setQuery] = useState("");
+  const [prayPending, setPrayPending] = useState<Set<string>>(new Set());
 
   const handlePost = async (draft: {
     body: string;
@@ -112,7 +113,11 @@ export function PrayerBoard({
       prev.map((r) => (r.id === id ? { ...r, ...patch } : r))
     );
 
+  // One write per request at a time — a double-click would otherwise reuse
+  // stale row data and let the count drift from the database.
   const handlePray = async (row: PrayerWallRow) => {
+    if (prayPending.has(row.id)) return;
+    setPrayPending((prev) => new Set(prev).add(row.id));
     const supabase = createClient();
     const praying = !row.i_am_praying;
     patchRequest(row.id, {
@@ -135,6 +140,11 @@ export function PrayerBoard({
       });
       toast.error("Couldn't save that. Please try again.");
     }
+    setPrayPending((prev) => {
+      const next = new Set(prev);
+      next.delete(row.id);
+      return next;
+    });
   };
 
   const handleToggleAnswered = async (row: PrayerWallRow) => {
@@ -282,6 +292,7 @@ export function PrayerBoard({
             <PrayerCard
               key={r.id}
               row={r}
+              prayPending={prayPending.has(r.id)}
               onPray={() => handlePray(r)}
               onToggleAnswered={() => handleToggleAnswered(r)}
             />

--- a/components/prayer/PrayerCallCard.tsx
+++ b/components/prayer/PrayerCallCard.tsx
@@ -133,6 +133,18 @@ export function PrayerCallCard({
     setSaving(false);
 
     if (errMsg || fetchError) {
+      // Carry the ids of rows that did get written back into the drafts, so
+      // retrying updates them instead of inserting duplicates.
+      setDrafts((cur) =>
+        cur
+          ? cur.map((d) => {
+              const i = kept.indexOf(d);
+              if (i === -1) return d;
+              const saved = sessionDrafts[i];
+              return { ...d, id: saved.id, event_id: saved.event_id };
+            })
+          : cur
+      );
       toast.error(errMsg ?? "Couldn't save the call details. Please try again.");
       return;
     }

--- a/components/prayer/PrayerCallCard.tsx
+++ b/components/prayer/PrayerCallCard.tsx
@@ -1,0 +1,396 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Pencil, Phone, Plus } from "lucide-react";
+import { toast } from "sonner";
+import { createClient } from "@/lib/supabase/client";
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxPopup,
+  ComboboxList,
+  ComboboxItem,
+  ComboboxEmpty,
+} from "@/components/ui/combobox";
+import { sessionLabel, telHref, WEEKDAY_LABELS } from "@/lib/prayer";
+import { savePrayerCallSessions, type SessionDraft } from "@/lib/prayerCalls";
+import type { MemberOption } from "@/components/giving/FundForm";
+import type { PrayerCallSession } from "@/lib/types";
+
+interface Draft {
+  id: string | null;
+  /** stringified weekday for the select */
+  weekday: string;
+  /** "HH:MM" */
+  start_time: string;
+  end_time: string;
+  leader_id: string;
+  dial_in: string;
+  pin: string;
+  join_url: string;
+  event_id: string | null;
+}
+
+const NONE = "none";
+
+const toDraft = (s: PrayerCallSession): Draft => ({
+  id: s.id,
+  weekday: String(s.weekday),
+  start_time: s.start_time.slice(0, 5),
+  end_time: s.end_time?.slice(0, 5) ?? "",
+  leader_id: s.leader_id ?? NONE,
+  dial_in: s.dial_in ?? "",
+  pin: s.pin ?? "",
+  join_url: s.join_url ?? "",
+  event_id: s.event_id,
+});
+
+const EMPTY_DRAFT: Draft = {
+  id: null,
+  weekday: "3",
+  start_time: "",
+  end_time: "",
+  leader_id: NONE,
+  dial_in: "",
+  pin: "",
+  join_url: "",
+  event_id: null,
+};
+
+const inputClass =
+  "w-full rounded-lg border border-white/25 bg-white/10 px-2.5 py-2 text-sm text-background outline-none placeholder:text-background/40 focus:border-white/50";
+
+export function PrayerCallCard({
+  initialSessions,
+  isAdmin,
+  members,
+  prayerCalendarId,
+}: {
+  initialSessions: PrayerCallSession[];
+  isAdmin: boolean;
+  members: MemberOption[];
+  prayerCalendarId: string | null;
+}) {
+  const [sessions, setSessions] = useState(initialSessions);
+  const [drafts, setDrafts] = useState<Draft[] | null>(null);
+  const [saving, setSaving] = useState(false);
+  const editing = drafts !== null;
+
+  if (sessions.length === 0 && !isAdmin) return null;
+
+  const memberName = (id: string | null) =>
+    id ? members.find((m) => m.id === id)?.name ?? null : null;
+  const memberLabel = (id: string) =>
+    id === NONE ? "No leader" : members.find((m) => m.id === id)?.name ?? "";
+  const leaderIds = [NONE, ...members.map((m) => m.id)];
+
+  const startEditing = () =>
+    setDrafts(sessions.length > 0 ? sessions.map(toDraft) : [{ ...EMPTY_DRAFT }]);
+
+  const setField = (i: number, key: keyof Draft, value: string) =>
+    setDrafts((d) =>
+      d ? d.map((x, j) => (j === i ? { ...x, [key]: value } : x)) : d
+    );
+
+  const save = async () => {
+    if (!drafts) return;
+    const kept = drafts.filter(
+      (d) => d.start_time || d.dial_in.trim() || d.join_url.trim()
+    );
+    if (kept.some((d) => !d.start_time)) {
+      toast.error("Each session needs a start time.");
+      return;
+    }
+    setSaving(true);
+    const supabase = createClient();
+    const keptIds = new Set(kept.map((d) => d.id).filter(Boolean));
+    const removed = sessions.filter((s) => !keptIds.has(s.id));
+
+    const sessionDrafts: SessionDraft[] = kept.map((d, i) => ({
+      id: d.id,
+      weekday: Number(d.weekday),
+      start_time: d.start_time,
+      end_time: d.end_time || null,
+      leader_id: d.leader_id === NONE ? null : d.leader_id,
+      dial_in: d.dial_in.trim() || null,
+      pin: d.pin.trim() || null,
+      join_url: d.join_url.trim() || null,
+      event_id: d.event_id,
+      display_order: i,
+    }));
+
+    const errMsg = await savePrayerCallSessions(
+      supabase,
+      sessionDrafts,
+      removed,
+      prayerCalendarId
+    );
+    const { data: fresh, error: fetchError } = await supabase
+      .from("prayer_call_sessions")
+      .select("*")
+      .order("display_order")
+      .order("created_at");
+    setSaving(false);
+
+    if (errMsg || fetchError) {
+      toast.error(errMsg ?? "Couldn't save the call details. Please try again.");
+      return;
+    }
+    setSessions((fresh ?? []) as PrayerCallSession[]);
+    setDrafts(null);
+  };
+
+  const joinUrl = sessions.find((s) => s.join_url)?.join_url ?? null;
+  const dialSession = sessions.find((s) => s.dial_in) ?? null;
+
+  return (
+    <div className="overflow-hidden rounded-2xl bg-foreground p-6 text-background">
+      <div className="flex items-start justify-between gap-3">
+        <div className="mb-3 flex items-center gap-2 text-[11px] font-bold uppercase tracking-[0.2em] text-brand-accent">
+          <span aria-hidden="true" className="h-px w-5 bg-brand-accent" />
+          Weekly prayer
+        </div>
+        {isAdmin && (
+          <button
+            type="button"
+            onClick={() => (editing ? save() : startEditing())}
+            disabled={saving}
+            className={`flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-bold transition-colors disabled:opacity-50 ${
+              editing
+                ? "bg-brand-accent text-foreground"
+                : "bg-white/10 text-background hover:bg-white/20"
+            }`}
+          >
+            {editing ? (
+              <>
+                <Check className="h-3 w-3" aria-hidden="true" />
+                {saving ? "Saving…" : "Save"}
+              </>
+            ) : (
+              <>
+                <Pencil className="h-3 w-3" aria-hidden="true" />
+                Edit
+              </>
+            )}
+          </button>
+        )}
+      </div>
+
+      <h2 className="font-serif text-2xl text-background">The prayer call</h2>
+      <p className="mt-2 mb-4 text-sm leading-relaxed text-background/80">
+        We gather by phone to pray through the wall. Everyone is welcome to
+        join. Each call is also on the group calendar.
+      </p>
+
+      {editing ? (
+        <div className="flex flex-col gap-3">
+          {drafts.map((d, i) => (
+            <div
+              key={d.id ?? `new-${i}`}
+              className="flex flex-col gap-3 rounded-xl border border-white/20 p-3.5"
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-[11px] font-bold uppercase tracking-widest text-background/60">
+                  Session {i + 1}
+                </span>
+                {drafts.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setDrafts((cur) =>
+                        cur ? cur.filter((_, j) => j !== i) : cur
+                      )
+                    }
+                    className="text-xs font-semibold text-background/60 hover:text-background"
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+              <div className="grid grid-cols-2 gap-2.5">
+                <label className="col-span-2 block">
+                  <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
+                    Day
+                  </span>
+                  <select
+                    value={d.weekday}
+                    onChange={(e) => setField(i, "weekday", e.target.value)}
+                    className={inputClass}
+                  >
+                    {WEEKDAY_LABELS.map((label, w) => (
+                      <option key={label} value={w} className="text-foreground">
+                        {label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
+                    Starts
+                  </span>
+                  <input
+                    type="time"
+                    value={d.start_time}
+                    onChange={(e) => setField(i, "start_time", e.target.value)}
+                    className={inputClass}
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
+                    Ends (optional)
+                  </span>
+                  <input
+                    type="time"
+                    value={d.end_time}
+                    onChange={(e) => setField(i, "end_time", e.target.value)}
+                    className={inputClass}
+                  />
+                </label>
+                <div className="col-span-2">
+                  <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
+                    Call leader
+                  </span>
+                  <Combobox
+                    items={leaderIds}
+                    itemToStringLabel={memberLabel}
+                    value={d.leader_id}
+                    onValueChange={(v) => setField(i, "leader_id", v ?? NONE)}
+                  >
+                    <ComboboxInput
+                      placeholder="Search members…"
+                      className={inputClass}
+                    />
+                    <ComboboxPopup>
+                      <ComboboxEmpty />
+                      <ComboboxList>
+                        {(id: string) => (
+                          <ComboboxItem key={id} value={id}>
+                            {memberLabel(id)}
+                          </ComboboxItem>
+                        )}
+                      </ComboboxList>
+                    </ComboboxPopup>
+                  </Combobox>
+                </div>
+                <label className="block">
+                  <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
+                    Dial in
+                  </span>
+                  <input
+                    value={d.dial_in}
+                    onChange={(e) => setField(i, "dial_in", e.target.value)}
+                    placeholder="(770) 555-0170"
+                    className={inputClass}
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
+                    PIN
+                  </span>
+                  <input
+                    value={d.pin}
+                    onChange={(e) => setField(i, "pin", e.target.value)}
+                    placeholder="4412#"
+                    className={inputClass}
+                  />
+                </label>
+                <label className="col-span-2 block">
+                  <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
+                    Join link (optional)
+                  </span>
+                  <input
+                    value={d.join_url}
+                    onChange={(e) => setField(i, "join_url", e.target.value)}
+                    placeholder="https://…"
+                    className={inputClass}
+                  />
+                </label>
+              </div>
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() =>
+              setDrafts((cur) => (cur ? [...cur, { ...EMPTY_DRAFT }] : cur))
+            }
+            className="flex items-center justify-center gap-2 rounded-xl border border-dashed border-white/30 py-2.5 text-sm font-semibold text-background/80 hover:text-background"
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            Add another session
+          </button>
+        </div>
+      ) : sessions.length > 0 ? (
+        <>
+          <div className="flex flex-col gap-2.5">
+            {sessions.map((s) => {
+              const leaderName = memberName(s.leader_id);
+              return (
+                <div
+                  key={s.id}
+                  className="flex items-center gap-3.5 rounded-xl border border-white/15 px-4 py-3"
+                >
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-white/10">
+                    <Phone
+                      className="h-4 w-4 text-brand-accent"
+                      aria-hidden="true"
+                    />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-[15px] font-bold">{sessionLabel(s)}</div>
+                    {leaderName && (
+                      <div className="mt-0.5 text-xs text-background/70">
+                        Led by {leaderName}
+                      </div>
+                    )}
+                    {(s.dial_in || s.pin) && (
+                      <div className="mt-0.5 font-mono text-xs text-background/70">
+                        {s.dial_in && (
+                          <a
+                            href={telHref(s.dial_in, s.pin)}
+                            className="hover:underline"
+                          >
+                            {s.dial_in}
+                          </a>
+                        )}
+                        {s.dial_in && s.pin && " · "}
+                        {s.pin && `PIN ${s.pin}`}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          {joinUrl ? (
+            <a
+              href={joinUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 block rounded-lg bg-brand-accent px-4 py-3 text-center text-sm font-bold text-foreground"
+            >
+              Join the call
+            </a>
+          ) : dialSession?.dial_in ? (
+            // tel: with DTMF pauses enters the PIN automatically on a phone;
+            // on desktop the link is harmless, so it shows everywhere.
+            <a
+              href={telHref(dialSession.dial_in, dialSession.pin)}
+              className="mt-4 block rounded-lg bg-brand-accent px-4 py-3 text-center text-sm font-bold text-foreground"
+            >
+              Call in
+            </a>
+          ) : null}
+        </>
+      ) : (
+        <button
+          type="button"
+          onClick={startEditing}
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-white/30 py-3 text-sm font-semibold text-background/80 hover:text-background"
+        >
+          <Plus className="h-4 w-4" aria-hidden="true" />
+          Add call details
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/prayer/PrayerCard.tsx
+++ b/components/prayer/PrayerCard.tsx
@@ -15,10 +15,12 @@ const ANSWERED = "#3E8E5A";
 
 export function PrayerCard({
   row,
+  prayPending,
   onPray,
   onToggleAnswered,
 }: {
   row: PrayerWallRow;
+  prayPending: boolean;
   onPray: () => void;
   onToggleAnswered: () => void;
 }) {
@@ -115,6 +117,7 @@ export function PrayerCard({
           <button
             type="button"
             onClick={onPray}
+            disabled={prayPending}
             aria-pressed={row.i_am_praying}
             className={`flex items-center gap-2 rounded-full px-3.5 py-2 text-sm font-semibold transition-colors ${
               row.i_am_praying

--- a/components/prayer/PrayerCard.tsx
+++ b/components/prayer/PrayerCard.tsx
@@ -3,12 +3,7 @@
 import { Check, HandHeart, Lock, UserRound } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { displayName, initials } from "@/lib/names";
-import {
-  audienceSummary,
-  isRestricted,
-  PRAYER_CATEGORIES,
-  timeAgo,
-} from "@/lib/prayer";
+import { PRAYER_CATEGORIES, timeAgo } from "@/lib/prayer";
 import type { PrayerWallRow } from "@/lib/types";
 
 const ANSWERED = "#3E8E5A";
@@ -34,7 +29,7 @@ export function PrayerCard({
     : hasName
       ? displayName(row)
       : "A member";
-  const restricted = isRestricted(row);
+  const restricted = row.visible_to_warriors;
   const barColor = row.is_answered ? ANSWERED : restricted ? "#E8A93C" : null;
 
   return (
@@ -82,7 +77,7 @@ export function PrayerCard({
             {restricted && (
               <span className="flex items-center gap-1 rounded-full bg-brand-bg-light px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-[#8a6412]">
                 <Lock className="h-2.5 w-2.5" aria-hidden="true" />
-                {audienceSummary(row)}
+                Prayer warriors
               </span>
             )}
             {row.is_answered && (

--- a/components/prayer/PrayerCard.tsx
+++ b/components/prayer/PrayerCard.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { Check, HandHeart, Lock, UserRound } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { displayName, initials } from "@/lib/names";
+import {
+  audienceSummary,
+  isRestricted,
+  PRAYER_CATEGORIES,
+  timeAgo,
+} from "@/lib/prayer";
+import type { PrayerWallRow } from "@/lib/types";
+
+const ANSWERED = "#3E8E5A";
+
+export function PrayerCard({
+  row,
+  onPray,
+  onToggleAnswered,
+}: {
+  row: PrayerWallRow;
+  onPray: () => void;
+  onToggleAnswered: () => void;
+}) {
+  const meta = PRAYER_CATEGORIES[row.category];
+  const anonToOthers = row.is_anonymous;
+  const hasName = row.first_name || row.last_name || row.preferred_name;
+  // Anonymous rows show no name to anyone; the poster still sees the "You"
+  // badge. A null name on a non-anonymous row means the author is unlisted.
+  const authorName = anonToOthers
+    ? "Anonymous"
+    : hasName
+      ? displayName(row)
+      : "A member";
+  const restricted = isRestricted(row);
+  const barColor = row.is_answered ? ANSWERED : restricted ? "#E8A93C" : null;
+
+  return (
+    <div
+      className={`relative overflow-hidden rounded-2xl border bg-card p-5 ${
+        row.is_answered
+          ? "border-[#3E8E5A]/40"
+          : restricted
+            ? "border-brand-accent/50"
+            : "border-border"
+      }`}
+    >
+      {barColor && (
+        <div
+          aria-hidden="true"
+          className="absolute inset-y-0 left-0 w-1"
+          style={{ backgroundColor: barColor }}
+        />
+      )}
+
+      <div className="flex items-center gap-3">
+        {anonToOthers || !hasName ? (
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-dashed border-muted-foreground/40 bg-background text-muted-foreground">
+            <UserRound className="h-5 w-5" aria-hidden="true" />
+          </div>
+        ) : (
+          <Avatar size="lg" className="shrink-0">
+            {row.avatar_url && <AvatarImage src={row.avatar_url} alt="" />}
+            <AvatarFallback className="bg-brand-warm font-semibold text-brand-primary">
+              {initials(row)}
+            </AvatarFallback>
+          </Avatar>
+        )}
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-serif text-lg text-foreground">
+              {authorName}
+            </span>
+            {row.mine && (
+              <span className="rounded-full bg-brand-warm px-2 py-0.5 text-[11px] font-bold text-brand-primary">
+                You
+              </span>
+            )}
+            {restricted && (
+              <span className="flex items-center gap-1 rounded-full bg-brand-bg-light px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-[#8a6412]">
+                <Lock className="h-2.5 w-2.5" aria-hidden="true" />
+                {audienceSummary(row)}
+              </span>
+            )}
+            {row.is_answered && (
+              <span
+                className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide"
+                style={{ backgroundColor: `${ANSWERED}1A`, color: ANSWERED }}
+              >
+                <Check className="h-2.5 w-2.5" aria-hidden="true" />
+                Answered
+              </span>
+            )}
+          </div>
+          <div className="text-sm text-muted-foreground">
+            {timeAgo(row.created_at)}
+          </div>
+        </div>
+
+        <span
+          className="shrink-0 rounded-full px-2.5 py-0.5 text-xs font-bold"
+          style={{ backgroundColor: `${meta.color}18`, color: meta.color }}
+        >
+          {meta.label}
+        </span>
+      </div>
+
+      <p className="mt-3 whitespace-pre-wrap text-[15px] leading-relaxed text-foreground/80">
+        {row.body}
+      </p>
+
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onPray}
+            aria-pressed={row.i_am_praying}
+            className={`flex items-center gap-2 rounded-full px-3.5 py-2 text-sm font-semibold transition-colors ${
+              row.i_am_praying
+                ? "bg-brand-primary text-white"
+                : "bg-brand-warm text-brand-primary hover:bg-brand-primary/15"
+            }`}
+          >
+            <HandHeart className="h-4 w-4" aria-hidden="true" />
+            {row.i_am_praying ? "You're praying" : "I'm praying"}
+          </button>
+
+          {row.mine && (
+            <button
+              type="button"
+              onClick={onToggleAnswered}
+              className={`flex items-center gap-1.5 rounded-full border px-3.5 py-2 text-sm font-medium transition-colors ${
+                row.is_answered
+                  ? "border-[#3E8E5A] bg-[#3E8E5A] text-white"
+                  : "border-border bg-card text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <Check className="h-3.5 w-3.5" aria-hidden="true" />
+              {row.is_answered ? "Answered" : "Mark answered"}
+            </button>
+          )}
+        </div>
+        <span className="text-sm text-muted-foreground">
+          <strong className="font-semibold text-foreground/80">
+            {row.praying_count}
+          </strong>{" "}
+          praying
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/components/prayer/PrayerComposer.tsx
+++ b/components/prayer/PrayerComposer.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { HandHeart, Lock, Phone, Shield, UserCog, UserRound } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  audienceSummary,
+  isRestricted,
+  PRAYER_CATEGORIES,
+  PRAYER_CATEGORY_KEYS,
+  type PrayerAudience,
+} from "@/lib/prayer";
+import type { PrayerCategory } from "@/lib/types";
+import type { Me } from "@/components/prayer/PrayerBoard";
+
+function SwitchRow({
+  on,
+  onToggle,
+  title,
+  sub,
+  icon,
+}: {
+  on: boolean;
+  onToggle: () => void;
+  title: string;
+  sub: string;
+  icon: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      onClick={onToggle}
+      className={`flex w-full items-center gap-3 rounded-xl border p-3 text-left transition-colors ${
+        on
+          ? "border-brand-primary/40 bg-brand-warm"
+          : "border-border bg-card hover:border-brand-primary/30"
+      }`}
+    >
+      <span
+        className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${
+          on
+            ? "bg-brand-primary text-white"
+            : "bg-background text-muted-foreground"
+        }`}
+      >
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-semibold text-foreground">
+          {title}
+        </span>
+        <span className="block text-[13px] leading-snug text-muted-foreground">
+          {sub}
+        </span>
+      </span>
+      <span
+        aria-hidden="true"
+        className={`h-[23px] w-10 shrink-0 rounded-full p-0.5 transition-colors ${
+          on ? "bg-brand-primary" : "bg-muted"
+        }`}
+      >
+        <span
+          className={`block h-[19px] w-[19px] rounded-full bg-white shadow transition-transform ${
+            on ? "translate-x-[17px]" : ""
+          }`}
+        />
+      </span>
+    </button>
+  );
+}
+
+const NO_AUDIENCE: PrayerAudience = {
+  visible_to_warriors: false,
+  visible_to_leaders: false,
+  visible_to_admins: false,
+};
+
+export function PrayerComposer({
+  me,
+  onPost,
+}: {
+  me: Me;
+  onPost: (draft: {
+    body: string;
+    category: PrayerCategory;
+    is_anonymous: boolean;
+  } & PrayerAudience) => Promise<boolean>;
+}) {
+  const [body, setBody] = useState("");
+  const [category, setCategory] = useState<PrayerCategory>("health");
+  const [anonymous, setAnonymous] = useState(false);
+  const [audience, setAudience] = useState<PrayerAudience>(NO_AUDIENCE);
+  const [submitting, setSubmitting] = useState(false);
+
+  const restricted = isRestricted(audience);
+  const canPost = body.trim().length > 0 && !submitting;
+
+  const toggleAudience = (key: keyof PrayerAudience) =>
+    setAudience((a) => ({ ...a, [key]: !a[key] }));
+
+  const submit = async () => {
+    if (!canPost) return;
+    setSubmitting(true);
+    const ok = await onPost({
+      body: body.trim(),
+      category,
+      is_anonymous: anonymous,
+      ...audience,
+    });
+    setSubmitting(false);
+    if (ok) {
+      setBody("");
+      setAnonymous(false);
+      setAudience(NO_AUDIENCE);
+      setCategory("health");
+    }
+  };
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-border bg-card">
+      <div className="p-5 pb-0">
+        <div className="mb-3.5 flex items-center gap-2.5">
+          <Avatar
+            size="lg"
+            className={`shrink-0 transition-opacity ${anonymous ? "opacity-25" : ""}`}
+          >
+            {me.avatarUrl && <AvatarImage src={me.avatarUrl} alt="" />}
+            <AvatarFallback className="bg-brand-bg-light font-bold text-foreground">
+              {me.initials}
+            </AvatarFallback>
+          </Avatar>
+          <h2 className="font-serif text-xl text-foreground">
+            Share a request
+          </h2>
+        </div>
+
+        <Textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="What can we pray with you about?"
+          rows={4}
+          maxLength={2000}
+          className="bg-background text-[15px]"
+        />
+
+        <div className="mt-4 mb-2 text-[11px] font-bold uppercase tracking-widest text-muted-foreground">
+          Category
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {PRAYER_CATEGORY_KEYS.map((key) => {
+            const meta = PRAYER_CATEGORIES[key];
+            const active = key === category;
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setCategory(key)}
+                className="rounded-full border px-3 py-1.5 text-[13px] font-semibold transition-colors"
+                style={
+                  active
+                    ? { backgroundColor: meta.color, borderColor: meta.color, color: "#fff" }
+                    : undefined
+                }
+              >
+                {meta.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 p-5">
+        <SwitchRow
+          on={anonymous}
+          onToggle={() => setAnonymous((v) => !v)}
+          title="Share anonymously"
+          sub="Your name is hidden — only the request is shown."
+          icon={<UserRound className="h-4 w-4" aria-hidden="true" />}
+        />
+
+        <div className="mt-2 mb-0.5 text-[11px] font-bold uppercase tracking-widest text-muted-foreground">
+          Who can see this
+        </div>
+        <SwitchRow
+          on={audience.visible_to_warriors}
+          onToggle={() => toggleAudience("visible_to_warriors")}
+          title="Prayer warriors"
+          sub="Members in the Prayer Warriors group."
+          icon={<Shield className="h-4 w-4" aria-hidden="true" />}
+        />
+        <SwitchRow
+          on={audience.visible_to_leaders}
+          onToggle={() => toggleAudience("visible_to_leaders")}
+          title="Prayer call leaders"
+          sub="Members who lead a prayer call."
+          icon={<Phone className="h-4 w-4" aria-hidden="true" />}
+        />
+        <SwitchRow
+          on={audience.visible_to_admins}
+          onToggle={() => toggleAudience("visible_to_admins")}
+          title="Admins"
+          sub="Group admins."
+          icon={<UserCog className="h-4 w-4" aria-hidden="true" />}
+        />
+        {!restricted && (
+          <p className="px-1 text-[13px] text-muted-foreground">
+            All off — everyone in the group can see it.
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border bg-background px-5 py-3.5">
+        <p className="flex items-center gap-1.5 text-[13px] text-muted-foreground">
+          {restricted && (
+            <Lock
+              className="h-3.5 w-3.5 shrink-0 text-brand-primary"
+              aria-hidden="true"
+            />
+          )}
+          <span>
+            Posting as{" "}
+            <strong className="font-semibold text-foreground">
+              {anonymous ? "Anonymous" : me.name}
+            </strong>{" "}
+            · visible to{" "}
+            <strong className="font-semibold text-foreground">
+              {audienceSummary(audience)}
+            </strong>
+          </span>
+        </p>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={!canPost}
+          className="flex items-center gap-2 rounded-lg bg-brand-primary px-4 py-2.5 text-sm font-bold text-white transition-opacity disabled:opacity-40"
+        >
+          <HandHeart className="h-4 w-4" aria-hidden="true" />
+          {submitting ? "Posting…" : "Post request"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/prayer/PrayerComposer.tsx
+++ b/components/prayer/PrayerComposer.tsx
@@ -158,6 +158,7 @@ export function PrayerComposer({
                 key={key}
                 type="button"
                 onClick={() => setCategory(key)}
+                aria-pressed={active}
                 className="rounded-full border px-3 py-1.5 text-[13px] font-semibold transition-colors"
                 style={
                   active

--- a/components/prayer/PrayerComposer.tsx
+++ b/components/prayer/PrayerComposer.tsx
@@ -1,17 +1,12 @@
 "use client";
 
 import { useState, type ReactNode } from "react";
-import { HandHeart, Lock, Phone, Shield, UserCog, UserRound } from "lucide-react";
+import { ChevronDown, HandHeart, Lock, Shield, UserRound } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  audienceSummary,
-  isRestricted,
-  PRAYER_CATEGORIES,
-  PRAYER_CATEGORY_KEYS,
-  type PrayerAudience,
-} from "@/lib/prayer";
-import type { PrayerCategory } from "@/lib/types";
+import { displayName, initials } from "@/lib/names";
+import { PRAYER_CATEGORIES, PRAYER_CATEGORY_KEYS } from "@/lib/prayer";
+import type { PrayerCategory, PrayerWarrior } from "@/lib/types";
 import type { Me } from "@/components/prayer/PrayerBoard";
 
 function SwitchRow({
@@ -72,34 +67,69 @@ function SwitchRow({
   );
 }
 
-const NO_AUDIENCE: PrayerAudience = {
-  visible_to_warriors: false,
-  visible_to_leaders: false,
-  visible_to_admins: false,
-};
+/**
+ * Expandable roster of the Prayer Warriors group, so a poster can see exactly
+ * who will get a request they restrict to warriors. Only lists members the
+ * viewer is allowed to see (unlisted profiles are hidden by RLS).
+ */
+function WarriorRoster({ warriors }: { warriors: PrayerWarrior[] }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded-xl border border-border bg-card">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-[13px] font-medium text-muted-foreground hover:text-foreground"
+      >
+        <ChevronDown
+          className={`h-4 w-4 shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
+          aria-hidden="true"
+        />
+        {warriors.length === 0
+          ? "No prayer warriors yet"
+          : `See who's in the group (${warriors.length})`}
+      </button>
+      {open && warriors.length > 0 && (
+        <ul className="flex flex-col gap-2 px-3 pb-3">
+          {warriors.map((w) => (
+            <li key={w.id} className="flex items-center gap-2.5">
+              <Avatar size="sm" className="shrink-0">
+                {w.avatar_url && <AvatarImage src={w.avatar_url} alt="" />}
+                <AvatarFallback className="bg-brand-warm text-xs font-semibold text-brand-primary">
+                  {initials(w)}
+                </AvatarFallback>
+              </Avatar>
+              <span className="text-sm text-foreground">{displayName(w)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
 
 export function PrayerComposer({
   me,
   onPost,
+  warriors,
 }: {
   me: Me;
   onPost: (draft: {
     body: string;
     category: PrayerCategory;
     is_anonymous: boolean;
-  } & PrayerAudience) => Promise<boolean>;
+    visible_to_warriors: boolean;
+  }) => Promise<boolean>;
+  warriors: PrayerWarrior[];
 }) {
   const [body, setBody] = useState("");
   const [category, setCategory] = useState<PrayerCategory>("health");
   const [anonymous, setAnonymous] = useState(false);
-  const [audience, setAudience] = useState<PrayerAudience>(NO_AUDIENCE);
+  const [toWarriors, setToWarriors] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
-  const restricted = isRestricted(audience);
   const canPost = body.trim().length > 0 && !submitting;
-
-  const toggleAudience = (key: keyof PrayerAudience) =>
-    setAudience((a) => ({ ...a, [key]: !a[key] }));
 
   const submit = async () => {
     if (!canPost) return;
@@ -108,13 +138,13 @@ export function PrayerComposer({
       body: body.trim(),
       category,
       is_anonymous: anonymous,
-      ...audience,
+      visible_to_warriors: toWarriors,
     });
     setSubmitting(false);
     if (ok) {
       setBody("");
       setAnonymous(false);
-      setAudience(NO_AUDIENCE);
+      setToWarriors(false);
       setCategory("health");
     }
   };
@@ -186,36 +216,24 @@ export function PrayerComposer({
           Who can see this
         </div>
         <SwitchRow
-          on={audience.visible_to_warriors}
-          onToggle={() => toggleAudience("visible_to_warriors")}
-          title="Prayer warriors"
-          sub="Members in the Prayer Warriors group."
+          on={toWarriors}
+          onToggle={() => setToWarriors((v) => !v)}
+          title="Prayer warriors only"
+          sub="Off — everyone in the class can see it."
           icon={<Shield className="h-4 w-4" aria-hidden="true" />}
         />
-        <SwitchRow
-          on={audience.visible_to_leaders}
-          onToggle={() => toggleAudience("visible_to_leaders")}
-          title="Prayer call leaders"
-          sub="Members who lead a prayer call."
-          icon={<Phone className="h-4 w-4" aria-hidden="true" />}
-        />
-        <SwitchRow
-          on={audience.visible_to_admins}
-          onToggle={() => toggleAudience("visible_to_admins")}
-          title="Admins"
-          sub="Group admins."
-          icon={<UserCog className="h-4 w-4" aria-hidden="true" />}
-        />
-        {!restricted && (
-          <p className="px-1 text-[13px] text-muted-foreground">
-            All off — everyone in the group can see it.
+        <WarriorRoster warriors={warriors} />
+        {toWarriors && warriors.length === 0 && (
+          <p className="px-1 text-[13px] text-brand-primary">
+            No one is in the Prayer Warriors group yet, so only you will see
+            this request.
           </p>
         )}
       </div>
 
       <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border bg-background px-5 py-3.5">
         <p className="flex items-center gap-1.5 text-[13px] text-muted-foreground">
-          {restricted && (
+          {toWarriors && (
             <Lock
               className="h-3.5 w-3.5 shrink-0 text-brand-primary"
               aria-hidden="true"
@@ -228,7 +246,7 @@ export function PrayerComposer({
             </strong>{" "}
             · visible to{" "}
             <strong className="font-semibold text-foreground">
-              {audienceSummary(audience)}
+              {toWarriors ? "prayer warriors" : "everyone"}
             </strong>
           </span>
         </p>

--- a/components/prayer/PrayerComposer.tsx
+++ b/components/prayer/PrayerComposer.tsx
@@ -134,13 +134,17 @@ export function PrayerComposer({
   const submit = async () => {
     if (!canPost) return;
     setSubmitting(true);
-    const ok = await onPost({
-      body: body.trim(),
-      category,
-      is_anonymous: anonymous,
-      visible_to_warriors: toWarriors,
-    });
-    setSubmitting(false);
+    let ok = false;
+    try {
+      ok = await onPost({
+        body: body.trim(),
+        category,
+        is_anonymous: anonymous,
+        visible_to_warriors: toWarriors,
+      });
+    } finally {
+      setSubmitting(false);
+    }
     if (ok) {
       setBody("");
       setAnonymous(false);

--- a/components/serving/RoleRoster.tsx
+++ b/components/serving/RoleRoster.tsx
@@ -1,0 +1,47 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { displayName, initials } from "@/lib/names";
+
+export interface RosterMember {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  preferred_name: string | null;
+  avatar_url: string | null;
+  is_leader: boolean;
+}
+
+/**
+ * Read-only roster of a serving role — who's in the group. Shown to every
+ * member so they can see (e.g.) who the prayer warriors are. Unlisted profiles
+ * are already filtered out upstream by RLS.
+ */
+export function RoleRoster({ members }: { members: RosterMember[] }) {
+  if (members.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">No one assigned yet.</p>
+    );
+  }
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {members.map((m) => (
+        <span
+          key={m.id}
+          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-background py-0.5 pl-0.5 pr-2.5 text-sm"
+        >
+          <Avatar size="sm">
+            {m.avatar_url && <AvatarImage src={m.avatar_url} alt="" />}
+            <AvatarFallback className="bg-brand-warm text-xs font-semibold text-brand-primary">
+              {initials(m)}
+            </AvatarFallback>
+          </Avatar>
+          <span className="text-foreground">{displayName(m)}</span>
+          {m.is_leader && (
+            <span className="text-[10px] font-bold uppercase tracking-wide text-brand-accent">
+              Leader
+            </span>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/lib/memberGroups.ts
+++ b/lib/memberGroups.ts
@@ -4,10 +4,11 @@ import type { MemberGroup } from "@/lib/types";
 /** Map a functional role to its denormalized boolean column on profiles */
 const ROLE_COLUMNS: Record<
   NonNullable<MemberGroup["functional_role"]>,
-  "is_prayer_team" | "is_greeter_team"
+  "is_prayer_team" | "is_greeter_team" | "is_prayer_warrior"
 > = {
   prayer_team: "is_prayer_team",
   greeter_team: "is_greeter_team",
+  prayer_warriors: "is_prayer_warrior",
 };
 
 /**

--- a/lib/prayer.ts
+++ b/lib/prayer.ts
@@ -17,32 +17,6 @@ export const PRAYER_CATEGORY_KEYS = Object.keys(
   PRAYER_CATEGORIES
 ) as PrayerCategory[];
 
-/** Audience toggles on a request; all false = visible to every member */
-export interface PrayerAudience {
-  visible_to_warriors: boolean;
-  visible_to_leaders: boolean;
-  visible_to_admins: boolean;
-}
-
-export const PRAYER_AUDIENCES: {
-  key: keyof PrayerAudience;
-  label: string;
-}[] = [
-  { key: "visible_to_warriors", label: "prayer warriors" },
-  { key: "visible_to_leaders", label: "call leaders" },
-  { key: "visible_to_admins", label: "admins" },
-];
-
-export function isRestricted(a: PrayerAudience): boolean {
-  return a.visible_to_warriors || a.visible_to_leaders || a.visible_to_admins;
-}
-
-/** "everyone", "prayer warriors", "prayer warriors + admins", … */
-export function audienceSummary(a: PrayerAudience): string {
-  const on = PRAYER_AUDIENCES.filter(({ key }) => a[key]).map((x) => x.label);
-  return on.length === 0 ? "everyone" : on.join(" + ");
-}
-
 /** Plural weekday names, indexed by PrayerCallSession.weekday (0 = Sunday) */
 export const WEEKDAY_LABELS = [
   "Sundays",

--- a/lib/prayer.ts
+++ b/lib/prayer.ts
@@ -114,8 +114,12 @@ export function timeAgo(iso: string): string {
   const days = Math.floor(hours / 24);
   if (days === 1) return "Yesterday";
   if (days < 7) return `${days} days ago`;
-  return new Date(iso).toLocaleDateString("en-US", {
+  const date = new Date(iso);
+  return date.toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
+    ...(date.getFullYear() !== new Date().getFullYear()
+      ? { year: "numeric" }
+      : {}),
   });
 }

--- a/lib/prayer.ts
+++ b/lib/prayer.ts
@@ -1,0 +1,121 @@
+import type { PrayerCategory, PrayerCallSession } from "@/lib/types";
+
+/** Display metadata for each prayer category (the "prayer type") */
+export const PRAYER_CATEGORIES: Record<
+  PrayerCategory,
+  { label: string; color: string }
+> = {
+  health: { label: "Health", color: "#2F6BA8" },
+  family: { label: "Family", color: "#C4704A" },
+  thanksgiving: { label: "Thanksgiving", color: "#B8821F" },
+  prodigal: { label: "Prodigal", color: "#5F8A6E" },
+  guidance: { label: "Guidance", color: "#8A6BB5" },
+  grief: { label: "Grief", color: "#6E7E94" },
+};
+
+export const PRAYER_CATEGORY_KEYS = Object.keys(
+  PRAYER_CATEGORIES
+) as PrayerCategory[];
+
+/** Audience toggles on a request; all false = visible to every member */
+export interface PrayerAudience {
+  visible_to_warriors: boolean;
+  visible_to_leaders: boolean;
+  visible_to_admins: boolean;
+}
+
+export const PRAYER_AUDIENCES: {
+  key: keyof PrayerAudience;
+  label: string;
+}[] = [
+  { key: "visible_to_warriors", label: "prayer warriors" },
+  { key: "visible_to_leaders", label: "call leaders" },
+  { key: "visible_to_admins", label: "admins" },
+];
+
+export function isRestricted(a: PrayerAudience): boolean {
+  return a.visible_to_warriors || a.visible_to_leaders || a.visible_to_admins;
+}
+
+/** "everyone", "prayer warriors", "prayer warriors + admins", … */
+export function audienceSummary(a: PrayerAudience): string {
+  const on = PRAYER_AUDIENCES.filter(({ key }) => a[key]).map((x) => x.label);
+  return on.length === 0 ? "everyone" : on.join(" + ");
+}
+
+/** Plural weekday names, indexed by PrayerCallSession.weekday (0 = Sunday) */
+export const WEEKDAY_LABELS = [
+  "Sundays",
+  "Mondays",
+  "Tuesdays",
+  "Wednesdays",
+  "Thursdays",
+  "Fridays",
+  "Saturdays",
+] as const;
+
+/** "20:00:00" → "8:00 PM" (drop the meridiem when told to share it) */
+function formatTime(time: string, withMeridiem = true): string {
+  const [h, m] = time.split(":").map(Number);
+  const meridiem = h < 12 ? "AM" : "PM";
+  const hour12 = h % 12 === 0 ? 12 : h % 12;
+  const base = `${hour12}:${String(m).padStart(2, "0")}`;
+  return withMeridiem ? `${base} ${meridiem}` : base;
+}
+
+/** "Wednesdays · 8:00 – 8:30 PM" */
+export function sessionLabel(s: Pick<PrayerCallSession, "weekday" | "start_time" | "end_time">): string {
+  const day = WEEKDAY_LABELS[s.weekday] ?? "";
+  if (!s.end_time) return `${day} · ${formatTime(s.start_time)}`;
+  const sameMeridiem =
+    (Number(s.start_time.split(":")[0]) < 12) ===
+    (Number(s.end_time.split(":")[0]) < 12);
+  return `${day} · ${formatTime(s.start_time, !sameMeridiem)} – ${formatTime(s.end_time)}`;
+}
+
+/**
+ * tel: link that dials in and enters the PIN after two DTMF pauses,
+ * e.g. "tel:+17705550170,,4412#". Formatting characters are stripped so the
+ * link is reliable regardless of how the admin typed the number.
+ */
+export function telHref(dialIn: string, pin: string | null): string {
+  const digits = dialIn.replace(/[^\d+]/g, "");
+  const pinDigits = pin ? pin.replace(/[^\d#*]/g, "") : "";
+  return pinDigits ? `tel:${digits},,${pinDigits}` : `tel:${digits}`;
+}
+
+/**
+ * The next occurrence of a weekly session (today counts if the start time is
+ * still ahead), in the browser's timezone — the same site-wide-local
+ * assumption the events pages already make.
+ */
+export function nextOccurrence(
+  weekday: number,
+  time: string,
+  from: Date = new Date()
+): Date {
+  const [h, m] = time.split(":").map(Number);
+  const d = new Date(from);
+  d.setHours(h, m, 0, 0);
+  let daysAhead = (weekday - d.getDay() + 7) % 7;
+  if (daysAhead === 0 && d <= from) daysAhead = 7;
+  d.setDate(d.getDate() + daysAhead);
+  return d;
+}
+
+/** "Just now", "2 hours ago", "Yesterday", then a plain date */
+export function timeAgo(iso: string): string {
+  const then = new Date(iso).getTime();
+  const minutes = Math.floor((Date.now() - then) / 60_000);
+  if (minutes < 1) return "Just now";
+  if (minutes < 60) return minutes === 1 ? "1 minute ago" : `${minutes} minutes ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return hours === 1 ? "1 hour ago" : `${hours} hours ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return "Yesterday";
+  if (days < 7) return `${days} days ago`;
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/lib/prayerCalls.ts
+++ b/lib/prayerCalls.ts
@@ -83,6 +83,10 @@ function eventFields(draft: SessionDraft, calendarId: string | null) {
  * sessions get theirs updated (or re-created if an admin deleted the event
  * from the calendar directly).
  *
+ * Mutates each draft's `id`/`event_id` as rows are created, so on partial
+ * failure the caller can carry the assigned ids back into its edit state and
+ * a retry updates the already-written rows instead of inserting duplicates.
+ *
  * @returns an error message to show the user, or null on success
  */
 export async function savePrayerCallSessions(
@@ -127,6 +131,7 @@ export async function savePrayerCallSessions(
         .single();
       eventId = data?.id ?? null;
     }
+    draft.event_id = eventId;
 
     const row = {
       weekday: draft.weekday,
@@ -139,10 +144,23 @@ export async function savePrayerCallSessions(
       event_id: eventId,
       display_order: draft.display_order,
     };
-    const { error } = draft.id
-      ? await supabase.from("prayer_call_sessions").update(row).eq("id", draft.id)
-      : await supabase.from("prayer_call_sessions").insert(row);
-    if (error) return "Couldn't save the call details. Please try again.";
+    if (draft.id) {
+      const { error } = await supabase
+        .from("prayer_call_sessions")
+        .update(row)
+        .eq("id", draft.id);
+      if (error) return "Couldn't save the call details. Please try again.";
+    } else {
+      const { data, error } = await supabase
+        .from("prayer_call_sessions")
+        .insert(row)
+        .select("id")
+        .single();
+      if (error || !data) {
+        return "Couldn't save the call details. Please try again.";
+      }
+      draft.id = data.id;
+    }
   }
 
   return null;

--- a/lib/prayerCalls.ts
+++ b/lib/prayerCalls.ts
@@ -1,0 +1,149 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { nextOccurrence } from "@/lib/prayer";
+import type { PrayerCallSession } from "@/lib/types";
+
+/** Editable fields of a prayer call session, as collected by the card's edit mode */
+export interface SessionDraft {
+  id: string | null;
+  weekday: number;
+  /** "HH:MM" */
+  start_time: string;
+  end_time: string | null;
+  leader_id: string | null;
+  dial_in: string | null;
+  pin: string | null;
+  join_url: string | null;
+  event_id: string | null;
+  display_order: number;
+}
+
+/**
+ * Find the designated Prayer calendar via the prayer_calendar_id site
+ * setting, re-creating the calendar (and repointing the setting) if an admin
+ * deleted it. Returns null only if creation fails — the synced events then
+ * land uncategorized rather than not at all.
+ */
+async function ensurePrayerCalendar(
+  supabase: SupabaseClient,
+  settingId: string | null
+): Promise<string | null> {
+  if (settingId) {
+    const { data } = await supabase
+      .from("event_calendars")
+      .select("id")
+      .eq("id", settingId)
+      .maybeSingle();
+    if (data) return data.id;
+  }
+  const { data: created, error } = await supabase
+    .from("event_calendars")
+    .insert({ name: "Prayer", color: "#2F6BA8" })
+    .select("id")
+    .single();
+  if (error || !created) return null;
+  await supabase
+    .from("site_settings")
+    .update({ value: created.id })
+    .eq("key", "prayer_calendar_id");
+  return created.id;
+}
+
+function eventFields(draft: SessionDraft, calendarId: string | null) {
+  const start = nextOccurrence(draft.weekday, draft.start_time);
+  let end: Date | null = null;
+  if (draft.end_time) {
+    end = new Date(start);
+    const [h, m] = draft.end_time.split(":").map(Number);
+    end.setHours(h, m, 0, 0);
+    if (end <= start) end.setDate(end.getDate() + 1);
+  }
+
+  const lines: string[] = [];
+  if (draft.dial_in) {
+    lines.push(`Dial in: ${draft.dial_in}${draft.pin ? ` · PIN ${draft.pin}` : ""}`);
+  }
+  if (draft.join_url) lines.push(`Join: ${draft.join_url}`);
+
+  return {
+    title: "Prayer call",
+    description: lines.length > 0 ? lines.join("\n") : null,
+    start_time: start.toISOString(),
+    end_time: end ? end.toISOString() : null,
+    calendar_id: calendarId,
+    is_rsvp_enabled: false,
+    recurrence_frequency: "weekly",
+    recurrence_interval: 1,
+    recurrence_end_mode: "never",
+  };
+}
+
+/**
+ * Persist the edited session list and keep each session's weekly recurring
+ * calendar event in step: removed sessions take their event with them, kept
+ * sessions get theirs updated (or re-created if an admin deleted the event
+ * from the calendar directly).
+ *
+ * @returns an error message to show the user, or null on success
+ */
+export async function savePrayerCallSessions(
+  supabase: SupabaseClient,
+  drafts: SessionDraft[],
+  removed: PrayerCallSession[],
+  calendarSettingId: string | null
+): Promise<string | null> {
+  const calendarId = await ensurePrayerCalendar(supabase, calendarSettingId);
+
+  for (const s of removed) {
+    const { error } = await supabase
+      .from("prayer_call_sessions")
+      .delete()
+      .eq("id", s.id);
+    if (error) return "Couldn't remove a session. Please try again.";
+    if (s.event_id) {
+      await supabase.from("events").delete().eq("id", s.event_id);
+    }
+  }
+
+  for (const draft of drafts) {
+    const fields = eventFields(draft, calendarId);
+
+    // Sync the event first so the session row can point at it. An update that
+    // matches no rows means the event was deleted out from under us — the FK
+    // already nulled event_id in the DB, so fall through and re-create.
+    let eventId = draft.event_id;
+    if (eventId) {
+      const { data } = await supabase
+        .from("events")
+        .update(fields)
+        .eq("id", eventId)
+        .select("id");
+      if (!data || data.length === 0) eventId = null;
+    }
+    if (!eventId) {
+      const { data } = await supabase
+        .from("events")
+        .insert(fields)
+        .select("id")
+        .single();
+      eventId = data?.id ?? null;
+    }
+
+    const row = {
+      weekday: draft.weekday,
+      start_time: draft.start_time,
+      end_time: draft.end_time,
+      leader_id: draft.leader_id,
+      dial_in: draft.dial_in,
+      pin: draft.pin,
+      join_url: draft.join_url,
+      event_id: eventId,
+      display_order: draft.display_order,
+    };
+    const { error } = draft.id
+      ? await supabase.from("prayer_call_sessions").update(row).eq("id", draft.id)
+      : await supabase.from("prayer_call_sessions").insert(row);
+    if (error) return "Couldn't save the call details. Please try again.";
+  }
+
+  return null;
+}

--- a/lib/prayerCalls.ts
+++ b/lib/prayerCalls.ts
@@ -98,38 +98,53 @@ export async function savePrayerCallSessions(
   const calendarId = await ensurePrayerCalendar(supabase, calendarSettingId);
 
   for (const s of removed) {
+    // Delete the synced event first — if that fails we bail before touching
+    // the session row, so a retry sees the same state and no event is
+    // orphaned on the calendar.
+    if (s.event_id) {
+      const { error } = await supabase
+        .from("events")
+        .delete()
+        .eq("id", s.event_id);
+      if (error) return "Couldn't remove a session. Please try again.";
+    }
     const { error } = await supabase
       .from("prayer_call_sessions")
       .delete()
       .eq("id", s.id);
     if (error) return "Couldn't remove a session. Please try again.";
-    if (s.event_id) {
-      await supabase.from("events").delete().eq("id", s.event_id);
-    }
   }
 
   for (const draft of drafts) {
     const fields = eventFields(draft, calendarId);
 
-    // Sync the event first so the session row can point at it. An update that
-    // matches no rows means the event was deleted out from under us — the FK
-    // already nulled event_id in the DB, so fall through and re-create.
+    // Sync the event first so the session row can point at it. Only an
+    // error-free update that matches no rows means the event was deleted out
+    // from under us (the FK already nulled event_id in the DB) — fall through
+    // and re-create. A failed update must not fall through, or a transient
+    // error would duplicate the event.
     let eventId = draft.event_id;
     if (eventId) {
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from("events")
         .update(fields)
         .eq("id", eventId)
         .select("id");
-      if (!data || data.length === 0) eventId = null;
+      if (error) {
+        return "Couldn't update the calendar event. Please try again.";
+      }
+      if (data.length === 0) eventId = null;
     }
     if (!eventId) {
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from("events")
         .insert(fields)
         .select("id")
         .single();
-      eventId = data?.id ?? null;
+      if (error || !data) {
+        return "Couldn't create the calendar event. Please try again.";
+      }
+      eventId = data.id;
     }
     draft.event_id = eventId;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -224,6 +224,8 @@ export interface MemberGroup {
   display_order: number;
   functional_role: "prayer_team" | "greeter_team" | "prayer_warriors" | null;
   show_in_directory_filter: boolean;
+  /** Listed on the Serve page as a standing role/team (vs. a directory-only tag) */
+  is_serving_role: boolean;
   created_by: string | null;
   created_at: string;
   updated_at: string;
@@ -396,9 +398,9 @@ export type PrayerCategory =
 
 /**
  * Row from the prayer_wall view. Author name/avatar come back null on
- * anonymous posts (unless it's the caller's own post — `mine` is true) and
- * audience-restricted rows are filtered out by RLS for members outside the
- * toggled audiences (prayer warriors / call leaders / admins).
+ * anonymous posts (unless it's the caller's own post — `mine` is true), and
+ * warrior-restricted rows are filtered out by RLS for members who aren't
+ * prayer warriors.
  */
 export interface PrayerWallRow {
   id: string;
@@ -406,8 +408,6 @@ export interface PrayerWallRow {
   category: PrayerCategory;
   is_anonymous: boolean;
   visible_to_warriors: boolean;
-  visible_to_leaders: boolean;
-  visible_to_admins: boolean;
   is_answered: boolean;
   created_at: string;
   mine: boolean;
@@ -417,6 +417,19 @@ export interface PrayerWallRow {
   avatar_url: string | null;
   praying_count: number;
   i_am_praying: boolean;
+}
+
+/**
+ * A member of the Prayer Warriors group, listed on the Prayer page so posters
+ * can see who a warrior-restricted request will reach. Only listed profiles
+ * come through (RLS hides unlisted members).
+ */
+export interface PrayerWarrior {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  preferred_name: string | null;
+  avatar_url: string | null;
 }
 
 /** One weekly prayer call session shown on the Prayer Call card */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -42,6 +42,7 @@ export interface Profile {
   relationship: FamilyMemberRelationship;
   is_prayer_team: boolean;
   is_greeter_team: boolean;
+  is_prayer_warrior: boolean;
   setup_completed: boolean;
   approved_at: string | null;
   approved_by: string | null;
@@ -221,7 +222,7 @@ export interface MemberGroup {
   color: string | null;
   icon: string | null;
   display_order: number;
-  functional_role: "prayer_team" | "greeter_team" | null;
+  functional_role: "prayer_team" | "greeter_team" | "prayer_warriors" | null;
   show_in_directory_filter: boolean;
   created_by: string | null;
   created_at: string;
@@ -383,6 +384,58 @@ export interface GivingFundMethod {
   method: PaymentMethodKey;
   custom_handle: string;
   display_order: number;
+}
+
+export type PrayerCategory =
+  | "health"
+  | "family"
+  | "thanksgiving"
+  | "prodigal"
+  | "guidance"
+  | "grief";
+
+/**
+ * Row from the prayer_wall view. Author name/avatar come back null on
+ * anonymous posts (unless it's the caller's own post — `mine` is true) and
+ * audience-restricted rows are filtered out by RLS for members outside the
+ * toggled audiences (prayer warriors / call leaders / admins).
+ */
+export interface PrayerWallRow {
+  id: string;
+  body: string;
+  category: PrayerCategory;
+  is_anonymous: boolean;
+  visible_to_warriors: boolean;
+  visible_to_leaders: boolean;
+  visible_to_admins: boolean;
+  is_answered: boolean;
+  created_at: string;
+  mine: boolean;
+  first_name: string | null;
+  last_name: string | null;
+  preferred_name: string | null;
+  avatar_url: string | null;
+  praying_count: number;
+  i_am_praying: boolean;
+}
+
+/** One weekly prayer call session shown on the Prayer Call card */
+export interface PrayerCallSession {
+  id: string;
+  /** 0 = Sunday … 6 = Saturday */
+  weekday: number;
+  /** "HH:MM:SS" from Postgres time */
+  start_time: string;
+  end_time: string | null;
+  leader_id: string | null;
+  dial_in: string | null;
+  pin: string | null;
+  join_url: string | null;
+  /** The synced weekly recurring calendar event, kept in step on save */
+  event_id: string | null;
+  display_order: number;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface SiteSetting {

--- a/supabase/migrations/20260708000000_prayer.sql
+++ b/supabase/migrations/20260708000000_prayer.sql
@@ -64,19 +64,19 @@ alter table public.prayer_call_sessions enable row level security;
 
 create policy "Members can view prayer call sessions"
   on public.prayer_call_sessions for select
-  using (public.is_member());
+  using ((select public.is_member()));
 
 create policy "Admins can insert prayer call sessions"
   on public.prayer_call_sessions for insert
-  with check (public.is_admin());
+  with check ((select public.is_admin()));
 
 create policy "Admins can update prayer call sessions"
   on public.prayer_call_sessions for update
-  using (public.is_admin());
+  using ((select public.is_admin()));
 
 create policy "Admins can delete prayer call sessions"
   on public.prayer_call_sessions for delete
-  using (public.is_admin());
+  using ((select public.is_admin()));
 
 -- ==================
 -- AUDIENCE HELPERS
@@ -87,14 +87,14 @@ returns boolean as $$
     select 1 from public.profiles
     where id = auth.uid() and is_prayer_warrior
   );
-$$ language sql security definer;
+$$ language sql security definer stable set search_path = '';
 
 create or replace function public.is_prayer_call_leader()
 returns boolean as $$
   select exists (
     select 1 from public.prayer_call_sessions where leader_id = auth.uid()
   );
-$$ language sql security definer;
+$$ language sql security definer stable set search_path = '';
 
 -- ==================
 -- PRAYER_REQUESTS
@@ -123,30 +123,32 @@ create trigger prayer_requests_touch_updated_at
 
 alter table public.prayer_requests enable row level security;
 
+-- Helper calls are wrapped in scalar subqueries so the planner evaluates them
+-- once per statement (initPlan) instead of per row.
 create policy "Members can view visible prayer requests"
   on public.prayer_requests for select
   using (
-    public.is_member()
+    (select public.is_member())
     and (
       author_id = auth.uid()
       or not (visible_to_warriors or visible_to_leaders or visible_to_admins)
-      or (visible_to_warriors and public.is_prayer_warrior())
-      or (visible_to_leaders and public.is_prayer_call_leader())
-      or (visible_to_admins and public.is_admin())
+      or (visible_to_warriors and (select public.is_prayer_warrior()))
+      or (visible_to_leaders and (select public.is_prayer_call_leader()))
+      or (visible_to_admins and (select public.is_admin()))
     )
   );
 
 create policy "Members can post own prayer requests"
   on public.prayer_requests for insert
-  with check (public.is_member() and author_id = auth.uid());
+  with check ((select public.is_member()) and author_id = auth.uid());
 
 create policy "Posters and admins can update prayer requests"
   on public.prayer_requests for update
-  using (author_id = auth.uid() or public.is_admin());
+  using (author_id = auth.uid() or (select public.is_admin()));
 
 create policy "Posters and admins can delete prayer requests"
   on public.prayer_requests for delete
-  using (author_id = auth.uid() or public.is_admin());
+  using (author_id = auth.uid() or (select public.is_admin()));
 
 -- ==================
 -- PRAYER_RESPONSES: one row = one member praying for one request
@@ -160,16 +162,22 @@ create table public.prayer_responses (
 
 alter table public.prayer_responses enable row level security;
 
+-- The exists() runs under the caller's RLS on prayer_requests, so responses
+-- to a restricted request are only visible to members who can see the
+-- request itself — otherwise the rows would leak who is praying for it.
 create policy "Members can view prayer responses"
   on public.prayer_responses for select
-  using (public.is_member());
+  using (
+    (select public.is_member())
+    and exists (select 1 from public.prayer_requests r where r.id = request_id)
+  );
 
--- The exists() runs under the caller's RLS, so nobody can respond to a
--- restricted request they can't see.
+-- Same guard on insert: nobody can respond to a restricted request they
+-- can't see.
 create policy "Members can pray for visible requests"
   on public.prayer_responses for insert
   with check (
-    public.is_member()
+    (select public.is_member())
     and profile_id = auth.uid()
     and exists (select 1 from public.prayer_requests r where r.id = request_id)
   );

--- a/supabase/migrations/20260708000000_prayer.sql
+++ b/supabase/migrations/20260708000000_prayer.sql
@@ -1,15 +1,14 @@
--- Prayer wall: members post requests with independent privacy controls —
--- is_anonymous hides the author's name from everyone; three audience toggles
--- (visible_to_warriors / visible_to_leaders / visible_to_admins) limit who can
--- see the whole request. All toggles off = visible to every member. Audiences
--- are exactly what's toggled — admins get no implicit access. The author is
--- always recorded (RLS + "My requests" need it); anonymity is applied at read
--- time by the prayer_wall view, mirroring how profiles_directory applies
--- field-level privacy.
+-- Prayer wall: members post requests with two independent privacy controls —
+-- is_anonymous hides the author's name from everyone; visible_to_warriors
+-- limits the whole request to prayer warriors. Off = visible to every member.
+-- The author is always recorded (RLS + "My requests" need it); anonymity is
+-- applied at read time by the prayer_wall view, mirroring how
+-- profiles_directory applies field-level privacy.
 --
 -- Prayer warriors are a profile-level role (distinct from the serving-page
--- prayer team) managed through the member-groups system. Prayer call leaders
--- are derived: anyone set as leader_id on a prayer_call_sessions row.
+-- prayer team) managed through the member-groups system; the Prayer page lists
+-- who's in the group so posters know who they're sharing a restricted request
+-- with. Prayer call leaders (leader_id on a session) get no special read access.
 
 -- ==================
 -- ROLE: prayer warriors (profile flag + seeded member group)
@@ -89,13 +88,6 @@ returns boolean as $$
   );
 $$ language sql security definer stable set search_path = '';
 
-create or replace function public.is_prayer_call_leader()
-returns boolean as $$
-  select exists (
-    select 1 from public.prayer_call_sessions where leader_id = auth.uid()
-  );
-$$ language sql security definer stable set search_path = '';
-
 -- ==================
 -- PRAYER_REQUESTS
 -- ==================
@@ -108,8 +100,6 @@ create table public.prayer_requests (
   ),
   is_anonymous boolean not null default false,
   visible_to_warriors boolean not null default false,
-  visible_to_leaders boolean not null default false,
-  visible_to_admins boolean not null default false,
   is_answered boolean not null default false,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
@@ -131,10 +121,8 @@ create policy "Members can view visible prayer requests"
     (select public.is_member())
     and (
       author_id = auth.uid()
-      or not (visible_to_warriors or visible_to_leaders or visible_to_admins)
+      or not visible_to_warriors
       or (visible_to_warriors and (select public.is_prayer_warrior()))
-      or (visible_to_leaders and (select public.is_prayer_call_leader()))
-      or (visible_to_admins and (select public.is_admin()))
     )
   );
 
@@ -202,8 +190,6 @@ select
   r.category,
   r.is_anonymous,
   r.visible_to_warriors,
-  r.visible_to_leaders,
-  r.visible_to_admins,
   r.is_answered,
   r.created_at,
   (r.author_id = auth.uid()) as mine,

--- a/supabase/migrations/20260708000000_prayer.sql
+++ b/supabase/migrations/20260708000000_prayer.sql
@@ -1,0 +1,232 @@
+-- Prayer wall: members post requests with independent privacy controls —
+-- is_anonymous hides the author's name from everyone; three audience toggles
+-- (visible_to_warriors / visible_to_leaders / visible_to_admins) limit who can
+-- see the whole request. All toggles off = visible to every member. Audiences
+-- are exactly what's toggled — admins get no implicit access. The author is
+-- always recorded (RLS + "My requests" need it); anonymity is applied at read
+-- time by the prayer_wall view, mirroring how profiles_directory applies
+-- field-level privacy.
+--
+-- Prayer warriors are a profile-level role (distinct from the serving-page
+-- prayer team) managed through the member-groups system. Prayer call leaders
+-- are derived: anyone set as leader_id on a prayer_call_sessions row.
+
+-- ==================
+-- ROLE: prayer warriors (profile flag + seeded member group)
+-- ==================
+alter table public.profiles
+  add column is_prayer_warrior boolean not null default false;
+
+alter table public.member_groups
+  drop constraint member_groups_functional_role_check;
+alter table public.member_groups
+  add constraint member_groups_functional_role_check
+  check (functional_role in ('prayer_team', 'greeter_team', 'prayer_warriors'));
+
+insert into public.member_groups (name, description, color, icon, display_order, functional_role)
+select
+  'Prayer Warriors',
+  'Sees prayer requests shared with prayer warriors',
+  '#8A6BB5',
+  'shield',
+  coalesce((select max(display_order) + 1 from public.member_groups), 0),
+  'prayer_warriors'
+where not exists (
+  select 1 from public.member_groups where functional_role = 'prayer_warriors'
+);
+
+-- ==================
+-- PRAYER_CALL_SESSIONS: the weekly prayer call card (supports multiple sessions)
+-- ==================
+-- Structured schedule (weekday 0 = Sunday, times in the group's local time)
+-- so each session can sync to a real weekly recurring event on the calendar.
+-- event_id points at that synced event; app code keeps the two in step.
+create table public.prayer_call_sessions (
+  id uuid primary key default gen_random_uuid(),
+  weekday int not null check (weekday between 0 and 6),
+  start_time time not null,
+  end_time time,
+  leader_id uuid references public.profiles(id) on delete set null,
+  dial_in text check (dial_in is null or char_length(dial_in) <= 40),
+  pin text check (pin is null or char_length(pin) <= 20),
+  join_url text check (join_url is null or char_length(join_url) <= 500),
+  event_id uuid references public.events(id) on delete set null,
+  display_order int not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create trigger prayer_call_sessions_touch_updated_at
+  before update on public.prayer_call_sessions
+  for each row execute function public.touch_updated_at();
+
+alter table public.prayer_call_sessions enable row level security;
+
+create policy "Members can view prayer call sessions"
+  on public.prayer_call_sessions for select
+  using (public.is_member());
+
+create policy "Admins can insert prayer call sessions"
+  on public.prayer_call_sessions for insert
+  with check (public.is_admin());
+
+create policy "Admins can update prayer call sessions"
+  on public.prayer_call_sessions for update
+  using (public.is_admin());
+
+create policy "Admins can delete prayer call sessions"
+  on public.prayer_call_sessions for delete
+  using (public.is_admin());
+
+-- ==================
+-- AUDIENCE HELPERS
+-- ==================
+create or replace function public.is_prayer_warrior()
+returns boolean as $$
+  select exists (
+    select 1 from public.profiles
+    where id = auth.uid() and is_prayer_warrior
+  );
+$$ language sql security definer;
+
+create or replace function public.is_prayer_call_leader()
+returns boolean as $$
+  select exists (
+    select 1 from public.prayer_call_sessions where leader_id = auth.uid()
+  );
+$$ language sql security definer;
+
+-- ==================
+-- PRAYER_REQUESTS
+-- ==================
+create table public.prayer_requests (
+  id uuid primary key default gen_random_uuid(),
+  author_id uuid not null references public.profiles(id) on delete cascade,
+  body text not null check (char_length(body) between 1 and 2000),
+  category text not null check (
+    category in ('health', 'family', 'thanksgiving', 'prodigal', 'guidance', 'grief')
+  ),
+  is_anonymous boolean not null default false,
+  visible_to_warriors boolean not null default false,
+  visible_to_leaders boolean not null default false,
+  visible_to_admins boolean not null default false,
+  is_answered boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index prayer_requests_created_at_idx on public.prayer_requests(created_at desc);
+
+create trigger prayer_requests_touch_updated_at
+  before update on public.prayer_requests
+  for each row execute function public.touch_updated_at();
+
+alter table public.prayer_requests enable row level security;
+
+create policy "Members can view visible prayer requests"
+  on public.prayer_requests for select
+  using (
+    public.is_member()
+    and (
+      author_id = auth.uid()
+      or not (visible_to_warriors or visible_to_leaders or visible_to_admins)
+      or (visible_to_warriors and public.is_prayer_warrior())
+      or (visible_to_leaders and public.is_prayer_call_leader())
+      or (visible_to_admins and public.is_admin())
+    )
+  );
+
+create policy "Members can post own prayer requests"
+  on public.prayer_requests for insert
+  with check (public.is_member() and author_id = auth.uid());
+
+create policy "Posters and admins can update prayer requests"
+  on public.prayer_requests for update
+  using (author_id = auth.uid() or public.is_admin());
+
+create policy "Posters and admins can delete prayer requests"
+  on public.prayer_requests for delete
+  using (author_id = auth.uid() or public.is_admin());
+
+-- ==================
+-- PRAYER_RESPONSES: one row = one member praying for one request
+-- ==================
+create table public.prayer_responses (
+  request_id uuid not null references public.prayer_requests(id) on delete cascade,
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (request_id, profile_id)
+);
+
+alter table public.prayer_responses enable row level security;
+
+create policy "Members can view prayer responses"
+  on public.prayer_responses for select
+  using (public.is_member());
+
+-- The exists() runs under the caller's RLS, so nobody can respond to a
+-- restricted request they can't see.
+create policy "Members can pray for visible requests"
+  on public.prayer_responses for insert
+  with check (
+    public.is_member()
+    and profile_id = auth.uid()
+    and exists (select 1 from public.prayer_requests r where r.id = request_id)
+  );
+
+create policy "Members can withdraw own prayer responses"
+  on public.prayer_responses for delete
+  using (profile_id = auth.uid());
+
+-- ==================
+-- VIEW: prayer_wall — nulls the author for anonymous posts
+-- ==================
+-- security_invoker=true keeps the base-table RLS in force (restricted rows
+-- stay hidden). Author fields are nulled on anonymous rows for everyone but
+-- the poster; `mine` lets the poster find their own anonymous requests. The
+-- left join means an unlisted author's name simply comes back null (the
+-- profiles RLS hides their row from other members) — the request still shows.
+create view public.prayer_wall
+with (security_invoker = true) as
+select
+  r.id,
+  r.body,
+  r.category,
+  r.is_anonymous,
+  r.visible_to_warriors,
+  r.visible_to_leaders,
+  r.visible_to_admins,
+  r.is_answered,
+  r.created_at,
+  (r.author_id = auth.uid()) as mine,
+  case when r.is_anonymous and r.author_id <> auth.uid() then null else p.first_name end as first_name,
+  case when r.is_anonymous and r.author_id <> auth.uid() then null else p.last_name end as last_name,
+  case when r.is_anonymous and r.author_id <> auth.uid() then null else p.preferred_name end as preferred_name,
+  case when r.is_anonymous and r.author_id <> auth.uid() then null else p.avatar_url end as avatar_url,
+  (select count(*)::int from public.prayer_responses pr where pr.request_id = r.id) as praying_count,
+  exists (
+    select 1 from public.prayer_responses pr
+    where pr.request_id = r.id and pr.profile_id = auth.uid()
+  ) as i_am_praying
+from public.prayer_requests r
+left join public.profiles p on p.id = r.author_id;
+
+grant select on public.prayer_wall to authenticated;
+
+-- ==================
+-- CALENDAR: designated Prayer calendar for synced call events
+-- ==================
+-- The calendar's id is stored in site_settings so app code finds it without
+-- matching on a rename-able name.
+do $$
+declare
+  _cal_id uuid;
+begin
+  insert into public.event_calendars (name, color)
+  values ('Prayer', '#2F6BA8')
+  returning id into _cal_id;
+
+  insert into public.site_settings (key, value)
+  values ('prayer_calendar_id', _cal_id::text)
+  on conflict (key) do update set value = excluded.value;
+end $$;

--- a/supabase/migrations/20260708000001_serving_roles.sql
+++ b/supabase/migrations/20260708000001_serving_roles.sql
@@ -1,0 +1,19 @@
+-- Serving roles: mark which member groups appear on the Serve page as standing
+-- roles/teams (vs. plain directory tags like "Young Adults"). A serving role
+-- shows a public roster to every member; if the group also has
+-- serving_team_settings.enabled, its members can additionally claim Sunday
+-- slots. Membership is always admin-assigned — this flag only controls where a
+-- group surfaces, never how someone joins it.
+--
+-- The Serve page lists a group when it's a serving role OR it has signups
+-- enabled (enabling signups implies it's a serving team). is_serving_role is
+-- what surfaces roster-only roles like Prayer Warriors.
+
+alter table public.member_groups
+  add column is_serving_role boolean not null default false;
+
+-- Seed the functional-role groups the app ships with — prayer team, greeters,
+-- and prayer warriors are all standing serving roles.
+update public.member_groups
+  set is_serving_role = true
+  where functional_role in ('prayer_team', 'greeter_team', 'prayer_warriors');


### PR DESCRIPTION
## Summary

Adds a `/prayer` page implementing the prayer wall from the brand-sketch design (Morning direction).

- Members post requests with independent privacy controls:
  - **Share anonymously** — name hidden from everyone, applied read-time by the `prayer_wall` `security_invoker` view (same pattern as `profiles_directory`). The author is always stored, so "My requests" still works for your own anonymous posts.
  - **Audience toggles** — three switches limit who can see the whole request: **prayer warriors** (new `is_prayer_warrior` profile role, managed through a seeded "Prayer Warriors" member group), **prayer call leaders** (derived: anyone set as leader on a call session), and **admins**. All off = every member. Audiences are exactly what's toggled — no implicit admin access. Enforced by RLS.
- Wall supports free-text search (body, author, type name), status filters (All / My requests / Everyone / Restricted / Answered), and a **prayer-type dropdown filter** (Health, Family, Thanksgiving, Prodigal, Guidance, Grief) that takes the type's color when active.
- "I'm praying" toggle with per-request counts (`prayer_responses`), and poster-only "Mark answered".
- Weekly **prayer call card**: admin-editable inline, supports multiple structured sessions (weekday, start/end time, per-session call leader picked via searchable member combobox, dial-in, PIN, optional join link).
- **Calendar sync**: each session upserts a weekly recurring "Prayer call" event on a designated Prayer calendar (id kept in `site_settings.prayer_calendar_id`, self-healing if the calendar is deleted), so the events page, per-event ICS download, and subscribable feed cover prayer calls with no new calendar code. Removing a session removes its event.
- **Join button**: uses the join URL when present, otherwise falls back to a `tel:` link that dials in and enters the PIN via DTMF pauses (`tel:7705550170,,4412#`).
- Sidebar nav link + `/prayer` added to `SIDEBAR_ROUTES`.

## Database

New migration `20260708000000_prayer.sql`: `prayer_requests` (audience-toggle columns), `prayer_responses`, `prayer_call_sessions` (structured schedule, `leader_id`, `event_id`), the `prayer_wall` view, `is_prayer_warrior()` / `is_prayer_call_leader()` helpers, the `prayer_warriors` functional role on `member_groups` with a seeded group, and the seeded Prayer calendar. RLS on all three tables.

## Testing

- eslint, `tsc`, and `next build` clean; schema delta applied to the local DB by hand (no reset).
- RLS probed with simulated JWTs across the full audience matrix: admins cannot see warriors-only or leaders-only rows; each role sees exactly its toggled audiences plus its own posts; anonymous author fields NULL for every non-author viewer; responses to invisible requests rejected.
- Verified end to end in the browser: posting with audience combinations, restricted badge, type-dropdown filtering, session save creating the recurring event (visible on /events, in the ICS feed, and the per-event ICS download), leader display, and the tel: fallback link.

## Notes

- The legacy `weekly_prayer_call_url` / `weekly_prayer_call_time` site-settings keys are now redundant; left untouched for a follow-up.
- Session times use the admin's browser timezone, matching how events are created today (site-wide-local assumption).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Prayer** page with a composer, searchable prayer wall, status + category filters, and clearer empty states.
  * Enabled interactions for posting, marking “I’m praying,” and toggling “Answered,” including restricted visibility for “prayer warriors only.”
  * Added weekly **Prayer Call** cards with admin-only add/edit/save and dial-in/join links.
  * Updated the sidebar to include **Prayer**, and introduced read-only serving-role roster support on the Serve experience.
* **Bug Fixes**
  * Improved access handling: unauthenticated users are redirected, and Prayer/Serving visibility now matches the user’s profile status and signup eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->