### PR TITLE
feat(events): time-aware Zoom join button on dashboard and event page

### DIFF
--- a/app/admin/events/[id]/edit/page.tsx
+++ b/app/admin/events/[id]/edit/page.tsx
@@ -100,14 +100,19 @@ export default function EditEventPage() {
       return;
     }
 
+    const isRecurringSeries = !!event?.recurrence_frequency && !event?.series_id;
+    const isSingleOccurrenceEdit = isRecurringSeries && !!occurrenceISO && editScope === "this";
+
     const trimmedMeetingUrl = meetingUrl.trim();
-    if (trimmedMeetingUrl && !/^https?:\/\//i.test(trimmedMeetingUrl)) {
-      toast.error("Meeting link must start with https://");
-      return;
-    }
-    if (!trimmedMeetingUrl && (meetingId.trim() || meetingPasscode.trim())) {
-      toast.error("Add the meeting link to go with the meeting ID and passcode.");
-      return;
+    if (!isSingleOccurrenceEdit) {
+      if (trimmedMeetingUrl && !/^https:\/\//i.test(trimmedMeetingUrl)) {
+        toast.error("Meeting link must start with https://");
+        return;
+      }
+      if (!trimmedMeetingUrl && (meetingId.trim() || meetingPasscode.trim())) {
+        toast.error("Add the meeting link to go with the meeting ID and passcode.");
+        return;
+      }
     }
 
     setLoading(true);
@@ -116,8 +121,6 @@ export default function EditEventPage() {
     const nextLocation = (formData.get("location") as string)?.trim() ?? "";
     const title = formData.get("title") as string;
     const description = (formData.get("description") as string) || null;
-
-    const isRecurringSeries = !!event?.recurrence_frequency && !event?.series_id;
 
     if (isRecurringSeries && occurrenceISO && editScope === "this") {
       // Create a one-off exception row for just this occurrence.

--- a/app/admin/events/[id]/edit/page.tsx
+++ b/app/admin/events/[id]/edit/page.tsx
@@ -19,6 +19,7 @@ import {
 import { toast } from "sonner";
 import { GoogleMapsScript } from "@/components/GoogleMapsScript";
 import { LocationInput } from "@/components/events/LocationInput";
+import { MeetingFieldsSection } from "@/components/events/MeetingFieldsSection";
 import { addHour, formatDateTimeLocal, isValidEndTime } from "@/lib/datetime-local";
 import type { Event, EventCalendar } from "@/lib/types";
 
@@ -32,6 +33,11 @@ export default function EditEventPage() {
   const [location, setLocation] = useState("");
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
+  const [meetingUrl, setMeetingUrl] = useState("");
+  const [meetingId, setMeetingId] = useState("");
+  const [meetingPasscode, setMeetingPasscode] = useState("");
+  const [meetingShowOnDashboard, setMeetingShowOnDashboard] = useState(true);
+  const [meetingLeadMinutes, setMeetingLeadMinutes] = useState("15");
   const [loading, setLoading] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [editScope, setEditScope] = useState<EditScope>("all");
@@ -58,6 +64,11 @@ export default function EditEventPage() {
       setCalendarId(eventData.calendar_id ?? null);
       setIsRsvpEnabled(eventData.is_rsvp_enabled ?? true);
       setLocation(eventData.location ?? "");
+      setMeetingUrl(eventData.meeting_url ?? "");
+      setMeetingId(eventData.meeting_id ?? "");
+      setMeetingPasscode(eventData.meeting_passcode ?? "");
+      setMeetingShowOnDashboard(eventData.meeting_show_on_dashboard ?? true);
+      setMeetingLeadMinutes(String(eventData.meeting_lead_minutes ?? 15));
       let nextStartTime: string;
       let nextEndTime: string;
       if (occurrenceISO) {
@@ -86,6 +97,16 @@ export default function EditEventPage() {
 
     if (!isValidEndTime(startTime, endTime)) {
       toast.error("End time must be after start time.");
+      return;
+    }
+
+    const trimmedMeetingUrl = meetingUrl.trim();
+    if (trimmedMeetingUrl && !/^https?:\/\//i.test(trimmedMeetingUrl)) {
+      toast.error("Meeting link must start with https://");
+      return;
+    }
+    if (!trimmedMeetingUrl && (meetingId.trim() || meetingPasscode.trim())) {
+      toast.error("Add the meeting link to go with the meeting ID and passcode.");
       return;
     }
 
@@ -154,6 +175,11 @@ export default function EditEventPage() {
             : null,
           calendar_id: calendarId || null,
           is_rsvp_enabled: isRsvpEnabled,
+          meeting_url: trimmedMeetingUrl || null,
+          meeting_id: meetingId.trim() || null,
+          meeting_passcode: meetingPasscode.trim() || null,
+          meeting_show_on_dashboard: meetingShowOnDashboard,
+          meeting_lead_minutes: Number(meetingLeadMinutes),
         })
         .eq("id", params.id);
 
@@ -348,6 +374,24 @@ export default function EditEventPage() {
               />
               <Label htmlFor="is_rsvp_enabled" className="text-lg">RSVP enabled</Label>
             </div>
+
+            {/* Meeting lives on the series anchor — hidden when saving a single
+                occurrence, which inherits the series meeting. */}
+            {!(showScopeChoice && editScope === "this") && (
+              <MeetingFieldsSection
+                meetingUrl={meetingUrl}
+                onMeetingUrlChange={setMeetingUrl}
+                meetingId={meetingId}
+                onMeetingIdChange={setMeetingId}
+                passcode={meetingPasscode}
+                onPasscodeChange={setMeetingPasscode}
+                showOnDashboard={meetingShowOnDashboard}
+                onShowOnDashboardChange={setMeetingShowOnDashboard}
+                leadMinutes={meetingLeadMinutes}
+                onLeadMinutesChange={setMeetingLeadMinutes}
+                isRecurring={isRecurringSeries}
+              />
+            )}
 
             <div className="flex gap-3">
               <Button

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,7 +6,10 @@ import Link from "next/link";
 import { siteConfig } from "@/lib/config";
 import { formatServiceDate, toDateString } from "@/lib/serving/sundays";
 import { RsvpSegmented } from "./RsvpSegmented";
-import type { Rsvp } from "@/lib/types";
+import { JoinMeetingBlock } from "@/components/events/JoinMeetingBlock";
+import { expandUpcomingEvents } from "@/lib/recurrence";
+import { meetingEndMs, ENDED_GRACE_MS, type MeetingFields } from "@/lib/meetings";
+import type { Event, Rsvp } from "@/lib/types";
 
 export const metadata = { title: `Dashboard | ${siteConfig.name}` };
 
@@ -105,17 +108,48 @@ export default async function DashboardPage() {
 
   // ── data fetching ──────────────────────────────────────────────────────────
 
-  const now = new Date().toISOString();
+  const nowDate = new Date();
+  const now = nowDate.toISOString();
 
-  // Upcoming events (5 max; first = hero)
-  const { data: events } = await supabase
+  // Next event for the hero. Recurring series are stored as a single anchor
+  // row and expanded at render time, so fetch a window that also includes
+  // anchors and recently-started occurrences (for the live/ended join states).
+  const windowStart = new Date(nowDate.getTime() - 24 * 60 * 60 * 1000);
+  const windowStartISO = windowStart.toISOString();
+  const { data: rawEvents } = await supabase
     .from("events")
     .select("*")
-    .gte("start_time", now)
+    .or(
+      `start_time.gte.${windowStartISO},` +
+      `and(recurrence_frequency.not.is.null,or(recurrence_until.is.null,recurrence_until.gte.${windowStartISO}))`
+    )
     .order("start_time", { ascending: true })
-    .limit(5);
+    .limit(500);
 
-  const nextEvent = events?.[0] ?? null;
+  // Keep the current occurrence on the hero through its live window plus a
+  // short grace period (ended state points to the recording), then roll over.
+  const occurrences = expandUpcomingEvents((rawEvents ?? []) as Event[], windowStart);
+  const nextEvent =
+    occurrences.find(
+      (e) => meetingEndMs(e.start_time, e.end_time) + ENDED_GRACE_MS > nowDate.getTime()
+    ) ?? null;
+
+  // Meeting fields live on the series anchor; exception rows inherit them.
+  let meeting: MeetingFields | null = null;
+  if (nextEvent) {
+    let source: MeetingFields = nextEvent;
+    if (nextEvent.series_id) {
+      const { data: anchor } = await supabase
+        .from("events")
+        .select(
+          "meeting_url, meeting_id, meeting_passcode, meeting_show_on_dashboard, meeting_lead_minutes"
+        )
+        .eq("id", nextEvent.series_id)
+        .maybeSingle();
+      if (anchor) source = anchor;
+    }
+    if (source.meeting_url && source.meeting_show_on_dashboard) meeting = source;
+  }
 
   // User RSVPs
   let userRsvps: Record<string, Rsvp> = {};
@@ -386,6 +420,21 @@ export default async function DashboardPage() {
                     currentStatus={userRsvps[nextEvent.id]?.status ?? null}
                   />
                 </div>
+
+                {/* Join the call — time-aware, set on the recurring event */}
+                {meeting?.meeting_url && (
+                  <div className="mt-4">
+                    <JoinMeetingBlock
+                      meetingUrl={meeting.meeting_url}
+                      meetingId={meeting.meeting_id}
+                      passcode={meeting.meeting_passcode}
+                      startTime={nextEvent.start_time}
+                      endTime={nextEvent.end_time}
+                      leadMinutes={meeting.meeting_lead_minutes}
+                      recordingsHref={lectureCount && lectureCount > 0 ? "/lectures" : null}
+                    />
+                  </div>
+                )}
               </div>
             </div>
           ) : (

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -5,6 +5,8 @@ import { EventRsvpPanel } from "./_components/EventRsvpPanel";
 import { AddToCalendarButton } from "@/components/events/AddToCalendarButton";
 import { SubscribeToEventButton } from "@/components/events/SubscribeToEventButton";
 import { AttendeeStrip, type Attendee } from "./_components/AttendeeStrip";
+import { JoinMeetingBlock } from "@/components/events/JoinMeetingBlock";
+import type { MeetingFields } from "@/lib/meetings";
 import { Button } from "@/components/ui/button";
 import { Pencil } from "lucide-react";
 import { siteConfig } from "@/lib/config";
@@ -165,6 +167,32 @@ export default async function EventDetailPage({
     } catch {
       // malformed percent-encoding — fall back to base event times
     }
+  }
+
+  // Meeting fields live on the series anchor; exception rows inherit them.
+  let meeting: MeetingFields | null = null;
+  if (isMember) {
+    let source: MeetingFields = event;
+    if (event.series_id) {
+      const { data: anchor } = await supabase
+        .from("events")
+        .select(
+          "meeting_url, meeting_id, meeting_passcode, meeting_show_on_dashboard, meeting_lead_minutes"
+        )
+        .eq("id", event.series_id)
+        .maybeSingle();
+      if (anchor) source = anchor;
+    }
+    if (source.meeting_url) meeting = source;
+  }
+
+  // Recordings link for the ended state — only when there's a library to point to
+  let hasLectures = false;
+  if (meeting) {
+    const { count } = await supabase
+      .from("lectures")
+      .select("id", { count: "exact", head: true });
+    hasLectures = (count ?? 0) > 0;
   }
 
   const startDate = new Date(displayStartTime);
@@ -372,6 +400,21 @@ export default async function EventDetailPage({
                     initialStatus={userRsvp?.status ?? null}
                   />
 
+                  {/* Join the call — time-aware, set once on the recurring event */}
+                  {meeting?.meeting_url && (
+                    <div className="mt-4">
+                      <JoinMeetingBlock
+                        meetingUrl={meeting.meeting_url}
+                        meetingId={meeting.meeting_id}
+                        passcode={meeting.meeting_passcode}
+                        startTime={displayStartTime}
+                        endTime={displayEndTime}
+                        leadMinutes={meeting.meeting_lead_minutes}
+                        recordingsHref={hasLectures ? "/lectures" : null}
+                      />
+                    </div>
+                  )}
+
                   {/* Calendar actions below RSVP */}
                   <div
                     className="flex flex-wrap gap-2 mt-4 pt-4"
@@ -390,6 +433,37 @@ export default async function EventDetailPage({
                       subscriptionToken={subscriptionToken}
                     />
                   </div>
+                </div>
+              </div>
+            )}
+
+            {/* Join card when RSVP is disabled but a meeting is set */}
+            {!(event.is_rsvp_enabled && isMember && user) && meeting?.meeting_url && (
+              <div
+                className="rounded-[18px] p-6 relative overflow-hidden"
+                style={{
+                  background: "#2F6BA8",
+                  boxShadow: "0 14px 40px rgba(47,107,168,0.2)",
+                }}
+              >
+                <div
+                  className="absolute inset-0 pointer-events-none"
+                  style={{
+                    opacity: 0.1,
+                    backgroundImage:
+                      "repeating-linear-gradient(0deg, rgba(255,255,255,0.4) 0px, rgba(255,255,255,0.4) 1px, transparent 1px, transparent 4px)",
+                  }}
+                />
+                <div className="relative">
+                  <JoinMeetingBlock
+                    meetingUrl={meeting.meeting_url}
+                    meetingId={meeting.meeting_id}
+                    passcode={meeting.meeting_passcode}
+                    startTime={displayStartTime}
+                    endTime={displayEndTime}
+                    leadMinutes={meeting.meeting_lead_minutes}
+                    recordingsHref={hasLectures ? "/lectures" : null}
+                  />
                 </div>
               </div>
             )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -107,6 +107,17 @@
   100% { background-position: 200% center; }
 }
 
+/* Live-now indicator on the Join meeting block */
+@keyframes join-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+@keyframes join-ring {
+  0% { transform: scale(1); opacity: 0.55; }
+  100% { transform: scale(2.8); opacity: 0; }
+}
+
 .animate-float { animation: float 6s ease-in-out infinite; }
 .animate-float-slow { animation: float-slow 9s ease-in-out infinite; }
 .animate-float-delayed { animation: float 7s ease-in-out 2s infinite; }

--- a/components/events/JoinMeetingBlock.tsx
+++ b/components/events/JoinMeetingBlock.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Video, Copy, Check, ArrowRight, Play } from "lucide-react";
+import {
+  getJoinState,
+  msUntilNextJoinTransition,
+  joinButtonLabel,
+  type JoinState,
+} from "@/lib/meetings";
+
+interface JoinMeetingBlockProps {
+  meetingUrl: string;
+  meetingId: string | null;
+  passcode: string | null;
+  /** Occurrence start/end (ISO) — not the series anchor's original date. */
+  startTime: string;
+  endTime: string | null;
+  leadMinutes: number;
+  /** Where "Watch the recording" points after the event ends; omit to hide. */
+  recordingsHref?: string | null;
+}
+
+function providerName(meetingUrl: string): string | null {
+  const label = joinButtonLabel(meetingUrl);
+  return label.startsWith("Join on ") ? label.slice("Join on ".length) : null;
+}
+
+function CopyField({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard unavailable — nothing useful to do
+    }
+  };
+
+  return (
+    <div
+      className="flex flex-1 min-w-0 items-center gap-2 rounded-[10px] py-2 pl-3 pr-2"
+      style={{ background: "rgba(0,0,0,0.20)", border: "1px solid rgba(255,255,255,0.22)" }}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="font-sans text-[9.5px] font-bold uppercase tracking-[1.2px] text-white/55">
+          {label}
+        </div>
+        <div className="font-mono text-[15px] text-white mt-0.5 tracking-[0.4px] whitespace-nowrap overflow-hidden text-ellipsis">
+          {value}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={`Copy ${label.toLowerCase()}`}
+        className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-lg transition-colors hover:bg-white/20"
+        style={{ background: "rgba(255,255,255,0.12)", border: "1px solid rgba(255,255,255,0.22)" }}
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5 text-white" />
+        ) : (
+          <Copy className="h-3.5 w-3.5 text-white/78" />
+        )}
+      </button>
+    </div>
+  );
+}
+
+export function JoinMeetingBlock({
+  meetingUrl,
+  meetingId,
+  passcode,
+  startTime,
+  endTime,
+  leadMinutes,
+  recordingsHref,
+}: JoinMeetingBlockProps) {
+  const [state, setState] = useState<JoinState>(() =>
+    getJoinState(new Date(), startTime, endTime, leadMinutes)
+  );
+
+  // Re-evaluate exactly when the state next changes (upcoming → live → ended).
+  useEffect(() => {
+    setState(getJoinState(new Date(), startTime, endTime, leadMinutes));
+    const ms = msUntilNextJoinTransition(new Date(), startTime, endTime, leadMinutes);
+    if (ms === null) return;
+    const timer = setTimeout(
+      () => setState(getJoinState(new Date(), startTime, endTime, leadMinutes)),
+      ms + 250
+    );
+    return () => clearTimeout(timer);
+  }, [state, startTime, endTime, leadMinutes]);
+
+  const provider = providerName(meetingUrl);
+  const buttonLabel = joinButtonLabel(meetingUrl);
+
+  const opensAt = new Date(
+    new Date(startTime).getTime() - leadMinutes * 60 * 1000
+  ).toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "America/New_York",
+  });
+
+  const creds = (meetingId || passcode) && (
+    <div className="flex gap-2 mt-3">
+      {meetingId && <CopyField label="Meeting ID" value={meetingId} />}
+      {passcode && <CopyField label="Passcode" value={passcode} />}
+    </div>
+  );
+
+  const outlineButtonClass =
+    "flex w-full items-center justify-center gap-2 mt-3 rounded-xl py-3 font-sans text-[15px] font-semibold text-white transition-colors hover:bg-white/20";
+  const outlineButtonStyle = {
+    background: "rgba(255,255,255,0.10)",
+    border: "1px solid rgba(255,255,255,0.4)",
+  };
+
+  const statusRowClass =
+    "flex items-center gap-2 font-sans text-[11px] font-bold uppercase tracking-[1.6px]";
+
+  // ── ENDED ──────────────────────────────────────────────
+  if (state === "ended") {
+    return (
+      <div
+        className="rounded-[14px] p-4"
+        style={{ background: "rgba(255,255,255,0.09)", border: "1px solid rgba(255,255,255,0.22)" }}
+      >
+        <div className={statusRowClass}>
+          <span className="h-2 w-2 rounded-full bg-white/55" />
+          <span className="text-white/55">This event has ended</span>
+        </div>
+        {recordingsHref && (
+          <>
+            <p className="font-sans text-sm text-white/78 leading-relaxed mt-2.5">
+              Missed it? The recording is posted to Lectures.
+            </p>
+            <a href={recordingsHref} className={outlineButtonClass} style={outlineButtonStyle}>
+              <Play className="h-4 w-4" /> Watch the recording
+            </a>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // ── UPCOMING ───────────────────────────────────────────
+  if (state === "upcoming") {
+    return (
+      <div
+        className="rounded-[14px] p-4"
+        style={{ background: "rgba(255,255,255,0.09)", border: "1px solid rgba(255,255,255,0.22)" }}
+      >
+        <div className={statusRowClass}>
+          <Video className="h-4 w-4" style={{ color: "#E8A93C" }} />
+          <span className="text-white">
+            Join online{provider ? ` · ${provider}` : ""}
+          </span>
+        </div>
+        <p className="font-sans text-[13.5px] text-white/78 leading-relaxed mt-2">
+          One-tap join opens at <strong className="text-white">{opensAt}</strong>,{" "}
+          {leadMinutes} minutes before start.
+        </p>
+        <a
+          href={meetingUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={outlineButtonClass}
+          style={outlineButtonStyle}
+        >
+          <Video className="h-4 w-4" /> {buttonLabel}
+        </a>
+        {creds}
+      </div>
+    );
+  }
+
+  // ── LIVE ───────────────────────────────────────────────
+  return (
+    <div
+      className="rounded-[14px] p-4"
+      style={{ background: "rgba(255,255,255,0.15)", border: "1px solid rgba(255,255,255,0.22)" }}
+    >
+      <div className={statusRowClass}>
+        <span className="relative inline-block h-[9px] w-[9px]">
+          <span
+            className="absolute inset-0 rounded-full"
+            style={{ background: "#E8A93C", animation: "join-ring 1.6s ease-out infinite" }}
+          />
+          <span
+            className="absolute inset-0 rounded-full"
+            style={{ background: "#E8A93C", animation: "join-pulse 1.6s ease-in-out infinite" }}
+          />
+        </span>
+        <span style={{ color: "#E8A93C" }}>Live now</span>
+      </div>
+      <a
+        href={meetingUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex w-full items-center justify-center gap-2.5 mt-3 rounded-xl py-[15px] font-sans text-base font-bold transition-opacity hover:opacity-90"
+        style={{
+          background: "#E8A93C",
+          color: "#15243A",
+          boxShadow: "0 8px 22px rgba(0,0,0,0.22)",
+        }}
+      >
+        <Video className="h-5 w-5" /> {buttonLabel}
+        <ArrowRight className="h-[18px] w-[18px]" />
+      </a>
+      {creds}
+    </div>
+  );
+}

--- a/components/events/MeetingFieldsSection.tsx
+++ b/components/events/MeetingFieldsSection.tsx
@@ -108,14 +108,14 @@ export function MeetingFieldsSection({
           </div>
 
           <div className="space-y-2">
-            <Label className="text-lg">Join opens before start</Label>
+            <Label htmlFor="meeting_lead_minutes" className="text-lg">Join opens before start</Label>
             <Select
               value={leadMinutes}
               onValueChange={(v) => {
                 if (v) onLeadMinutesChange(v);
               }}
             >
-              <SelectTrigger className="w-full text-lg py-6">
+              <SelectTrigger id="meeting_lead_minutes" className="w-full text-lg py-6">
                 <SelectValue>{LEAD_LABELS[leadMinutes] ?? `${leadMinutes} minutes`}</SelectValue>
               </SelectTrigger>
               <SelectContent>

--- a/components/events/MeetingFieldsSection.tsx
+++ b/components/events/MeetingFieldsSection.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const LEAD_OPTIONS = ["5", "15", "30", "60"] as const;
+
+const LEAD_LABELS: Record<string, string> = {
+  "5": "5 minutes",
+  "15": "15 minutes",
+  "30": "30 minutes",
+  "60": "1 hour",
+};
+
+interface MeetingFieldsSectionProps {
+  meetingUrl: string;
+  onMeetingUrlChange: (v: string) => void;
+  meetingId: string;
+  onMeetingIdChange: (v: string) => void;
+  passcode: string;
+  onPasscodeChange: (v: string) => void;
+  showOnDashboard: boolean;
+  onShowOnDashboardChange: (v: boolean) => void;
+  leadMinutes: string;
+  onLeadMinutesChange: (v: string) => void;
+  isRecurring: boolean;
+}
+
+export function MeetingFieldsSection({
+  meetingUrl,
+  onMeetingUrlChange,
+  meetingId,
+  onMeetingIdChange,
+  passcode,
+  onPasscodeChange,
+  showOnDashboard,
+  onShowOnDashboardChange,
+  leadMinutes,
+  onLeadMinutesChange,
+  isRecurring,
+}: MeetingFieldsSectionProps) {
+  return (
+    <div className="space-y-4 rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
+      <div>
+        <Label className="text-lg">Meeting</Label>
+        <p className="text-sm text-muted-foreground">
+          {isRecurring
+            ? "Set once — the Join button uses it for every date in this series."
+            : "Members get a time-aware Join button on the dashboard and event page."}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="meeting_url" className="text-lg">Meeting link</Label>
+        <Input
+          id="meeting_url"
+          type="url"
+          placeholder="https://us02web.zoom.us/j/…"
+          value={meetingUrl}
+          onChange={(e) => onMeetingUrlChange(e.target.value)}
+          className="text-lg py-6"
+        />
+        <p className="text-sm text-muted-foreground">
+          Use the invite link with the passcode embedded so one tap joins.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="meeting_id" className="text-lg">Meeting ID</Label>
+          <Input
+            id="meeting_id"
+            value={meetingId}
+            onChange={(e) => onMeetingIdChange(e.target.value)}
+            className="text-lg py-6"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="meeting_passcode" className="text-lg">Passcode</Label>
+          <Input
+            id="meeting_passcode"
+            value={passcode}
+            onChange={(e) => onPasscodeChange(e.target.value)}
+            className="text-lg py-6"
+          />
+        </div>
+      </div>
+
+      {meetingUrl.trim() && (
+        <>
+          <div className="flex items-center gap-3">
+            <Switch
+              id="meeting_show_on_dashboard"
+              checked={showOnDashboard}
+              onCheckedChange={onShowOnDashboardChange}
+            />
+            <Label htmlFor="meeting_show_on_dashboard" className="text-lg">
+              Show join button on dashboard
+            </Label>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-lg">Join opens before start</Label>
+            <Select
+              value={leadMinutes}
+              onValueChange={(v) => {
+                if (v) onLeadMinutesChange(v);
+              }}
+            >
+              <SelectTrigger className="w-full text-lg py-6">
+                <SelectValue>{LEAD_LABELS[leadMinutes] ?? `${leadMinutes} minutes`}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {LEAD_OPTIONS.map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {LEAD_LABELS[v]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/events/NewEventForm.tsx
+++ b/components/events/NewEventForm.tsx
@@ -143,7 +143,7 @@ export function NewEventForm() {
     }
 
     const trimmedMeetingUrl = meetingUrl.trim();
-    if (trimmedMeetingUrl && !/^https?:\/\//i.test(trimmedMeetingUrl)) {
+    if (trimmedMeetingUrl && !/^https:\/\//i.test(trimmedMeetingUrl)) {
       toast.error("Meeting link must start with https://");
       return;
     }

--- a/components/events/NewEventForm.tsx
+++ b/components/events/NewEventForm.tsx
@@ -19,6 +19,7 @@ import {
 import { toast } from "sonner";
 import { GoogleMapsScript } from "@/components/GoogleMapsScript";
 import { LocationInput } from "@/components/events/LocationInput";
+import { MeetingFieldsSection } from "@/components/events/MeetingFieldsSection";
 import { addHour, isValidEndTime } from "@/lib/datetime-local";
 import type { EventCalendar } from "@/lib/types";
 
@@ -73,6 +74,11 @@ export function NewEventForm() {
   const [recurrenceCount, setRecurrenceCount] = useState("4");
   const [recurrenceUntil, setRecurrenceUntil] = useState("");
   const [location, setLocation] = useState("");
+  const [meetingUrl, setMeetingUrl] = useState("");
+  const [meetingId, setMeetingId] = useState("");
+  const [meetingPasscode, setMeetingPasscode] = useState("");
+  const [meetingShowOnDashboard, setMeetingShowOnDashboard] = useState(true);
+  const [meetingLeadMinutes, setMeetingLeadMinutes] = useState("15");
   const router = useRouter();
   const searchParams = useSearchParams();
   const supabase = createClient();
@@ -136,6 +142,16 @@ export function NewEventForm() {
       }
     }
 
+    const trimmedMeetingUrl = meetingUrl.trim();
+    if (trimmedMeetingUrl && !/^https?:\/\//i.test(trimmedMeetingUrl)) {
+      toast.error("Meeting link must start with https://");
+      return;
+    }
+    if (!trimmedMeetingUrl && (meetingId.trim() || meetingPasscode.trim())) {
+      toast.error("Add the meeting link to go with the meeting ID and passcode.");
+      return;
+    }
+
     setLoading(true);
 
     const formData = new FormData(e.currentTarget);
@@ -164,6 +180,11 @@ export function NewEventForm() {
         isRecurring && recurrenceEndMode === "until"
           ? localToUTCISO(recurrenceUntil)
           : null,
+      meeting_url: trimmedMeetingUrl || null,
+      meeting_id: meetingId.trim() || null,
+      meeting_passcode: meetingPasscode.trim() || null,
+      meeting_show_on_dashboard: meetingShowOnDashboard,
+      meeting_lead_minutes: Number(meetingLeadMinutes),
     });
 
     setLoading(false);
@@ -379,6 +400,20 @@ export function NewEventForm() {
                 </>
               )}
             </div>
+
+            <MeetingFieldsSection
+              meetingUrl={meetingUrl}
+              onMeetingUrlChange={setMeetingUrl}
+              meetingId={meetingId}
+              onMeetingIdChange={setMeetingId}
+              passcode={meetingPasscode}
+              onPasscodeChange={setMeetingPasscode}
+              showOnDashboard={meetingShowOnDashboard}
+              onShowOnDashboardChange={setMeetingShowOnDashboard}
+              leadMinutes={meetingLeadMinutes}
+              onLeadMinutesChange={setMeetingLeadMinutes}
+              isRecurring={isRecurring}
+            />
 
             <Button
               type="submit"

--- a/lib/meetings.ts
+++ b/lib/meetings.ts
@@ -1,0 +1,71 @@
+import type { Event } from "@/lib/types";
+
+export type JoinState = "upcoming" | "live" | "ended";
+
+/** Assumed duration when an event has no end_time. */
+export const DEFAULT_EVENT_DURATION_MS = 2 * 60 * 60 * 1000;
+
+/** How long after an event ends the dashboard keeps showing it (ended state). */
+export const ENDED_GRACE_MS = 3 * 60 * 60 * 1000;
+
+export function meetingEndMs(startTime: string, endTime: string | null): number {
+  return endTime
+    ? new Date(endTime).getTime()
+    : new Date(startTime).getTime() + DEFAULT_EVENT_DURATION_MS;
+}
+
+export function getJoinState(
+  now: Date,
+  startTime: string,
+  endTime: string | null,
+  leadMinutes: number
+): JoinState {
+  const nowMs = now.getTime();
+  const opensMs = new Date(startTime).getTime() - leadMinutes * 60 * 1000;
+  if (nowMs < opensMs) return "upcoming";
+  if (nowMs < meetingEndMs(startTime, endTime)) return "live";
+  return "ended";
+}
+
+/** ms until the current join state changes, or null once ended. */
+export function msUntilNextJoinTransition(
+  now: Date,
+  startTime: string,
+  endTime: string | null,
+  leadMinutes: number
+): number | null {
+  const nowMs = now.getTime();
+  const opensMs = new Date(startTime).getTime() - leadMinutes * 60 * 1000;
+  if (nowMs < opensMs) return opensMs - nowMs;
+  const endMs = meetingEndMs(startTime, endTime);
+  if (nowMs < endMs) return endMs - nowMs;
+  return null;
+}
+
+/** Provider-aware button label derived from the meeting URL host. */
+export function joinButtonLabel(meetingUrl: string): string {
+  try {
+    const host = new URL(meetingUrl).hostname;
+    if (host.includes("zoom.us")) return "Join on Zoom";
+    if (host.includes("meet.google.com")) return "Join on Meet";
+    if (host.includes("teams.microsoft.com") || host.includes("teams.live.com"))
+      return "Join on Teams";
+  } catch {
+    // fall through to the generic label
+  }
+  return "Join meeting";
+}
+
+/**
+ * The meeting fields for an occurrence. Exception rows (series_id set) don't
+ * carry their own meeting — they inherit from the series anchor, which the
+ * caller fetches and passes as `anchor`.
+ */
+export type MeetingFields = Pick<
+  Event,
+  | "meeting_url"
+  | "meeting_id"
+  | "meeting_passcode"
+  | "meeting_show_on_dashboard"
+  | "meeting_lead_minutes"
+>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -157,6 +157,12 @@ export interface Event {
   // Per-occurrence exception support
   series_id: string | null;           // set on exception events; points to the anchor series
   series_occurrence_date: string | null; // the original occurrence ISO date this row replaces
+  // Meeting / video call (set on the series anchor; exceptions inherit)
+  meeting_url: string | null;
+  meeting_id: string | null;
+  meeting_passcode: string | null;
+  meeting_show_on_dashboard: boolean;
+  meeting_lead_minutes: number;
 }
 
 export interface Rsvp {

--- a/supabase/migrations/20260709000000_event_meeting.sql
+++ b/supabase/migrations/20260709000000_event_meeting.sql
@@ -1,0 +1,14 @@
+-- Meeting / video-call link on events.
+-- Lives on the event row itself: a recurring series is a single anchor row
+-- (expanded at render time), so setting the link once covers every occurrence.
+-- Events are members-only via RLS (see 20260421000000_remove_is_private), and
+-- ICS export builds its attributes explicitly, so the link and passcode are
+-- never exposed to the public calendar, .ics export, or email.
+
+alter table public.events
+  add column meeting_url text,
+  add column meeting_id text,
+  add column meeting_passcode text,
+  add column meeting_show_on_dashboard boolean not null default true,
+  add column meeting_lead_minutes integer not null default 15
+    check (meeting_lead_minutes between 0 and 1440);


### PR DESCRIPTION
## Summary

Wires the Zoom join system end to end, from the InCouragers brand sketch (zoom-join.jsx + Meeting admin section):

- **Meeting fields on the event row** (`meeting_url`, `meeting_id`, `meeting_passcode`, `meeting_show_on_dashboard`, `meeting_lead_minutes`, migration `20260709000000_event_meeting.sql`). A recurring series is one anchor row, so the leader sets the link once and it covers every occurrence; exception rows inherit the anchor's meeting.
- **`JoinMeetingBlock`** — one time-aware client component with three states: upcoming (outline button + "opens at" note), live (marigold one-tap button, pulsing dot, from lead-time before start until end), ended (recording pointer to Lectures when lectures exist). Meeting ID + passcode are copyable. Re-renders itself exactly at each state transition; button label adapts to the provider from the URL host (Zoom/Meet/Teams/generic).
- **Surfaces**: dashboard next-event hero (gated by the dashboard toggle) and the event detail RSVP card; events with RSVP disabled get the block in a standalone card.
- **Admin**: shared Meeting section on the create and edit event forms (link, ID, passcode, dashboard toggle, 5/15/30/60-min lead time). Hidden when saving "this event only" since single occurrences inherit the series meeting.

## Notes

- The design's locked/signed-out state and "members only" toggle were dropped: events are fully members-only via RLS since `20260421000000_remove_is_private`, and ICS attributes are built explicitly, so the link and passcode can't reach the public calendar or exports.
- Fixes a dashboard bug the feature depends on: the next-event query was a raw `start_time >= now` filter that never matched a recurring series anchored in the past. It now uses the same `expandUpcomingEvents` expansion as the events page, with a 24h look-back so the live state works and a 3h post-event grace window for the ended/recording state.

## Testing

- `tsc --noEmit`, eslint on changed files, and `next build` all pass.
- Migration applied to the local DB via `supabase migration up --db-url` and columns verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added meeting details to event creation and editing, including join links, IDs, passcodes, dashboard visibility, and early-access timing.
  * Added a new “Join the call” experience on event and dashboard pages, with live, upcoming, and ended states.
  * Event pages can now surface recordings when available.

* **Bug Fixes**
  * Improved handling of recurring events so meeting details carry over correctly to the displayed occurrence.
  * Added validation to prevent incomplete or invalid meeting links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->