### PR TITLE
feat(about): About Our Class page with GUI-editable summary and teachers

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,110 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { siteConfig } from "@/lib/config";
+import { displayName, initials } from "@/lib/names";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Card, CardContent } from "@/components/ui/card";
+import { PageRenderer } from "@/app/pages/[slug]/PageRenderer";
+import type { AboutPage, ClassTeacherWithProfile } from "@/lib/types";
+
+export const metadata = { title: `About Our Class | ${siteConfig.name}` };
+
+export default async function AboutClassPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+  if (!profile || profile.role === "pending") redirect("/dashboard");
+
+  const [{ data: about }, { data: teachers }] = await Promise.all([
+    supabase.from("about_page").select("*").maybeSingle(),
+    supabase
+      .from("class_teachers")
+      .select(
+        "*, profiles(id, first_name, last_name, preferred_name, avatar_url)",
+      )
+      .order("sort_order")
+      .order("created_at"),
+  ]);
+
+  const summary = (about as AboutPage | null)?.body ?? "";
+  const hasSummary = (() => {
+    try {
+      const parsed = JSON.parse(summary);
+      return Array.isArray(parsed) && parsed.length > 0;
+    } catch {
+      return false;
+    }
+  })();
+  const teacherList = (teachers ?? []) as ClassTeacherWithProfile[];
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-4xl">
+      <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-8">
+        About Our Class
+      </h1>
+
+      {hasSummary ? (
+        <PageRenderer body={summary} />
+      ) : (
+        <p className="text-lg text-muted-foreground">
+          The class summary hasn&apos;t been written yet.
+        </p>
+      )}
+
+      <div className="mt-12">
+        <h2 className="text-2xl md:text-3xl font-bold text-brand-primary mb-6">
+          Our Teachers
+        </h2>
+
+        {teacherList.length === 0 ? (
+          <p className="text-lg text-muted-foreground">
+            Teacher info hasn&apos;t been added yet.
+          </p>
+        ) : (
+          <div className="space-y-6">
+            {teacherList.map((teacher) => (
+              <Card key={teacher.id}>
+                <CardContent className="py-6">
+                  <div className="flex flex-col sm:flex-row items-center sm:items-start gap-5">
+                    <Avatar className="h-24 w-24 shrink-0 border-2 border-brand-accent">
+                      {teacher.profiles?.avatar_url && (
+                        <AvatarImage
+                          src={teacher.profiles.avatar_url}
+                          alt={`Photo of ${displayName(teacher.profiles)}`}
+                        />
+                      )}
+                      <AvatarFallback className="bg-brand-primary text-white text-2xl">
+                        {initials(teacher.profiles)}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="min-w-0 text-center sm:text-left">
+                      <h3 className="text-xl font-semibold">
+                        {displayName(teacher.profiles)}
+                      </h3>
+                      <p className="text-sm font-medium uppercase tracking-wider text-brand-primary mb-2">
+                        {teacher.title}
+                      </p>
+                      {teacher.bio ? (
+                        <p className="text-base text-foreground/90 whitespace-pre-line">
+                          {teacher.bio}
+                        </p>
+                      ) : null}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/about/AboutEditor.tsx
+++ b/app/admin/about/AboutEditor.tsx
@@ -1,0 +1,454 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { BlockEditor } from "@/components/editor";
+import { toast } from "sonner";
+import { ArrowDown, ArrowUp, Pencil, Plus, Search, X } from "lucide-react";
+import { displayName, initials } from "@/lib/names";
+import type { Block, PartialBlock } from "@blocknote/core";
+import type { ClassTeacherWithProfile } from "@/lib/types";
+
+type MemberOption = {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  preferred_name: string | null;
+  avatar_url: string | null;
+};
+
+interface AboutEditorProps {
+  initialBody: string;
+  initialTeachers: ClassTeacherWithProfile[];
+}
+
+const TEACHER_SELECT =
+  "*, profiles(id, first_name, last_name, preferred_name, avatar_url)";
+
+export function AboutEditor({ initialBody, initialTeachers }: AboutEditorProps) {
+  const supabase = useMemo(() => createClient(), []);
+
+  // --- Class summary ---
+  const blocksRef = useRef<Block[]>([]);
+  const isDirtyRef = useRef(false);
+  const [savingSummary, setSavingSummary] = useState(false);
+
+  const parsedInitialContent = (): PartialBlock[] | undefined => {
+    if (!initialBody) return undefined;
+    try {
+      const parsed = JSON.parse(initialBody);
+      return Array.isArray(parsed) ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
+  const handleSaveSummary = async () => {
+    setSavingSummary(true);
+    // If the editor was never touched, preserve the existing body instead of
+    // overwriting it with []
+    const body = isDirtyRef.current
+      ? JSON.stringify(blocksRef.current)
+      : initialBody || "[]";
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    const { error } = await supabase.from("about_page").upsert({
+      id: true,
+      body,
+      updated_by: user?.id,
+      updated_at: new Date().toISOString(),
+    });
+
+    setSavingSummary(false);
+    if (error) {
+      toast.error("Failed to save the class summary.");
+      return;
+    }
+    toast.success("Class summary saved.");
+    isDirtyRef.current = false;
+  };
+
+  // --- Teachers ---
+  const [teachers, setTeachers] = useState(initialTeachers);
+  const [addOpen, setAddOpen] = useState(false);
+  const [candidates, setCandidates] = useState<MemberOption[] | null>(null);
+  const [query, setQuery] = useState("");
+  const [editing, setEditing] = useState<ClassTeacherWithProfile | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const openAdd = async () => {
+    setQuery("");
+    setAddOpen(true);
+    if (candidates) return;
+    const { data, error } = await supabase
+      .from("profiles")
+      .select("id, first_name, last_name, preferred_name, avatar_url")
+      .in("role", ["member", "content_editor", "admin"])
+      .order("last_name")
+      .order("first_name");
+    if (error) {
+      toast.error("Failed to load members.");
+      setAddOpen(false);
+      return;
+    }
+    setCandidates((data ?? []) as MemberOption[]);
+  };
+
+  const visibleCandidates = useMemo(() => {
+    if (!candidates) return [];
+    const taken = new Set(teachers.map((t) => t.profile_id));
+    const available = candidates.filter((c) => !taken.has(c.id));
+    if (!query.trim()) return available;
+    const q = query.trim().toLowerCase();
+    return available.filter((c) =>
+      [c.first_name, c.last_name, c.preferred_name]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase()
+        .includes(q),
+    );
+  }, [candidates, teachers, query]);
+
+  const handleAdd = async (member: MemberOption) => {
+    setBusy(true);
+    const nextOrder =
+      teachers.reduce((max, t) => Math.max(max, t.sort_order), -1) + 1;
+    const { data, error } = await supabase
+      .from("class_teachers")
+      .insert({ profile_id: member.id, sort_order: nextOrder })
+      .select(TEACHER_SELECT)
+      .single();
+    setBusy(false);
+    if (error || !data) {
+      toast.error("Failed to add teacher.");
+      return;
+    }
+    const added = data as ClassTeacherWithProfile;
+    setTeachers((prev) => [...prev, added]);
+    setAddOpen(false);
+    // Go straight to the bio form so the new entry doesn't sit empty
+    setEditing(added);
+  };
+
+  const handleRemove = async (teacher: ClassTeacherWithProfile) => {
+    if (
+      !confirm(
+        `Remove ${displayName(teacher.profiles)} from the About page?`,
+      )
+    )
+      return;
+    const { error } = await supabase
+      .from("class_teachers")
+      .delete()
+      .eq("id", teacher.id);
+    if (error) {
+      toast.error("Failed to remove teacher.");
+      return;
+    }
+    setTeachers((prev) => prev.filter((t) => t.id !== teacher.id));
+    toast.success("Teacher removed.");
+  };
+
+  const handleMove = async (index: number, direction: -1 | 1) => {
+    const target = index + direction;
+    if (target < 0 || target >= teachers.length) return;
+    setBusy(true);
+    const a = teachers[index];
+    const b = teachers[target];
+    // Swap sort_order values; fall back to indexes if they were equal
+    const aOrder = a.sort_order === b.sort_order ? target : b.sort_order;
+    const bOrder = a.sort_order === b.sort_order ? index : a.sort_order;
+    const [{ error: e1 }, { error: e2 }] = await Promise.all([
+      supabase.from("class_teachers").update({ sort_order: aOrder }).eq("id", a.id),
+      supabase.from("class_teachers").update({ sort_order: bOrder }).eq("id", b.id),
+    ]);
+    setBusy(false);
+    if (e1 || e2) {
+      toast.error("Failed to reorder teachers.");
+      return;
+    }
+    setTeachers((prev) => {
+      const next = [...prev];
+      next[index] = { ...b, sort_order: bOrder };
+      next[target] = { ...a, sort_order: aOrder };
+      return next;
+    });
+  };
+
+  const handleSaveTeacher = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!editing) return;
+    setBusy(true);
+    const formData = new FormData(e.currentTarget);
+    const title = (formData.get("title") as string).trim() || "Teacher";
+    const bio = (formData.get("bio") as string).trim();
+    const { error } = await supabase
+      .from("class_teachers")
+      .update({ title, bio })
+      .eq("id", editing.id);
+    setBusy(false);
+    if (error) {
+      toast.error("Failed to save teacher.");
+      return;
+    }
+    setTeachers((prev) =>
+      prev.map((t) => (t.id === editing.id ? { ...t, title, bio } : t)),
+    );
+    setEditing(null);
+    toast.success("Teacher saved.");
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-4xl space-y-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold text-brand-primary">About Page</h1>
+        <Button variant="outline" nativeButton={false} render={<Link href="/about" />}>
+          View page
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl text-brand-primary">
+            Class Summary
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-lg overflow-hidden border border-border">
+            <BlockEditor
+              initialContent={parsedInitialContent()}
+              onChange={(blocks) => {
+                blocksRef.current = blocks;
+                isDirtyRef.current = true;
+              }}
+            />
+          </div>
+          <Button
+            onClick={handleSaveSummary}
+            disabled={savingSummary}
+            className="bg-brand-primary hover:bg-brand-primary/90 text-white"
+          >
+            {savingSummary ? "Saving..." : "Save Summary"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-2xl text-brand-primary">
+              Teachers
+            </CardTitle>
+            <Button
+              size="sm"
+              onClick={openAdd}
+              className="bg-brand-primary hover:bg-brand-primary/90 text-white"
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              Add teacher
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {teachers.length === 0 ? (
+            <p className="text-muted-foreground py-4 text-center">
+              No teachers yet. Use &ldquo;Add teacher&rdquo; to pick a member.
+            </p>
+          ) : (
+            <div className="divide-y">
+              {teachers.map((teacher, index) => (
+                <div key={teacher.id} className="flex items-center gap-3 py-3">
+                  <Avatar className="h-10 w-10 shrink-0">
+                    {teacher.profiles?.avatar_url && (
+                      <AvatarImage
+                        src={teacher.profiles.avatar_url}
+                        alt={displayName(teacher.profiles)}
+                      />
+                    )}
+                    <AvatarFallback className="bg-brand-primary text-white text-sm">
+                      {initials(teacher.profiles)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium truncate">
+                      {displayName(teacher.profiles)}
+                      <span className="ml-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                        {teacher.title}
+                      </span>
+                    </p>
+                    <p className="text-sm text-muted-foreground truncate">
+                      {teacher.bio || "No bio yet."}
+                    </p>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    disabled={busy || index === 0}
+                    onClick={() => handleMove(index, -1)}
+                    aria-label={`Move ${displayName(teacher.profiles)} up`}
+                  >
+                    <ArrowUp className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    disabled={busy || index === teachers.length - 1}
+                    onClick={() => handleMove(index, 1)}
+                    aria-label={`Move ${displayName(teacher.profiles)} down`}
+                  >
+                    <ArrowDown className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    disabled={busy}
+                    onClick={() => setEditing(teacher)}
+                    aria-label={`Edit ${displayName(teacher.profiles)}`}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    disabled={busy}
+                    onClick={() => handleRemove(teacher)}
+                    aria-label={`Remove ${displayName(teacher.profiles)}`}
+                    className="text-muted-foreground hover:text-destructive"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={addOpen} onOpenChange={(o) => !o && setAddOpen(false)}>
+        <DialogContent className="max-w-md max-h-[85vh] flex flex-col">
+          <DialogHeader>
+            <DialogTitle>Add teacher</DialogTitle>
+          </DialogHeader>
+          <div className="relative shrink-0">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              type="search"
+              placeholder="Search members..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="pl-10"
+            />
+          </div>
+          <div className="overflow-y-auto flex-1 -mx-1 px-1">
+            {!candidates ? (
+              <p className="text-sm text-muted-foreground py-4 text-center">
+                Loading members...
+              </p>
+            ) : visibleCandidates.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-6 text-center">
+                {query.trim()
+                  ? "No one matches your search."
+                  : "Everyone is already listed as a teacher."}
+              </p>
+            ) : (
+              <div className="divide-y">
+                {visibleCandidates.map((member) => (
+                  <div key={member.id} className="flex items-center gap-3 py-2.5">
+                    <Avatar className="h-8 w-8 shrink-0">
+                      {member.avatar_url && (
+                        <AvatarImage
+                          src={member.avatar_url}
+                          alt={displayName(member)}
+                        />
+                      )}
+                      <AvatarFallback className="bg-brand-primary text-white text-xs">
+                        {initials(member)}
+                      </AvatarFallback>
+                    </Avatar>
+                    <span className="flex-1 min-w-0 text-sm font-medium truncate">
+                      {displayName(member)}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={busy}
+                      onClick={() => handleAdd(member)}
+                    >
+                      <Plus className="mr-1 h-3.5 w-3.5" />
+                      Add
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!editing} onOpenChange={(o) => !o && setEditing(null)}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {editing ? displayName(editing.profiles) : ""}
+            </DialogTitle>
+          </DialogHeader>
+          {editing && (
+            <form onSubmit={handleSaveTeacher} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="teacher-title">Title</Label>
+                <Input
+                  id="teacher-title"
+                  name="title"
+                  defaultValue={editing.title}
+                  placeholder="Teacher"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="teacher-bio">Bio</Label>
+                <Textarea
+                  id="teacher-bio"
+                  name="bio"
+                  rows={6}
+                  defaultValue={editing.bio}
+                  placeholder="A few sentences about this teacher."
+                />
+              </div>
+              <div className="flex gap-3 justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setEditing(null)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={busy}
+                  className="bg-brand-primary hover:bg-brand-primary/90 text-white"
+                >
+                  {busy ? "Saving..." : "Save"}
+                </Button>
+              </div>
+            </form>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/app/admin/about/page.tsx
+++ b/app/admin/about/page.tsx
@@ -1,0 +1,44 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { siteConfig } from "@/lib/config";
+import { AboutEditor } from "./AboutEditor";
+import type { AboutPage, ClassTeacherWithProfile } from "@/lib/types";
+
+export const metadata = { title: `Edit About Page | ${siteConfig.name}` };
+
+export default async function AdminAboutPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile || !["admin", "content_editor"].includes(profile.role)) {
+    redirect("/dashboard");
+  }
+
+  const [{ data: about }, { data: teachers }] = await Promise.all([
+    supabase.from("about_page").select("*").maybeSingle(),
+    supabase
+      .from("class_teachers")
+      .select(
+        "*, profiles(id, first_name, last_name, preferred_name, avatar_url)",
+      )
+      .order("sort_order")
+      .order("created_at"),
+  ]);
+
+  return (
+    <AboutEditor
+      initialBody={(about as AboutPage | null)?.body ?? ""}
+      initialTeachers={(teachers ?? []) as ClassTeacherWithProfile[]}
+    />
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Users, Calendar, Megaphone, BookOpen, Settings, Clock, FileText, Home } from "lucide-react";
+import { Users, Calendar, Megaphone, BookOpen, Settings, Clock, FileText, Home, Info } from "lucide-react";
 import { siteConfig } from "@/lib/config";
 
 export const metadata = { title: `Admin | ${siteConfig.name}` };
@@ -88,6 +88,12 @@ export default async function AdminPage() {
       label: "Pages",
       description: "Edit content pages",
       icon: FileText,
+    },
+    {
+      href: "/admin/about",
+      label: "About Page",
+      description: "Edit the class summary and teachers",
+      icon: Info,
     },
     {
       href: "/admin/settings",

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -18,6 +18,7 @@ import {
   HandCoins,
   HeartHandshake,
   BarChart2,
+  Info,
 } from "lucide-react";
 import { useState, useEffect, type ComponentType } from "react";
 import type { PageContent, Profile } from "@/lib/types";
@@ -41,6 +42,7 @@ const memberNav = [
   { href: "/serving", label: "Serving", icon: HandHelping },
   { href: "/prayer", label: "Prayer", icon: HeartHandshake },
   { href: "/give", label: "Give", icon: HandCoins },
+  { href: "/about", label: "About", icon: Info },
   { href: "/profile", label: "My Profile", icon: UserCircle },
 ];
 
@@ -54,6 +56,7 @@ const adminNav = [
   { href: "/admin/serving", label: "Serving Stats", icon: BarChart2 },
   { href: "/admin/giving", label: "Giving", icon: HandCoins },
   { href: "/admin/pages", label: "Manage Pages", icon: FileText },
+  { href: "/admin/about", label: "About Page", icon: Info },
 ];
 
 export function SidebarNav({
@@ -154,7 +157,12 @@ export function SidebarNav({
           )}
           {collapsed && <div className="border-t border-border my-2" role="separator" />}
           {adminNav
-            .filter((item) => isAdmin || item.href === "/admin/pages")
+            .filter(
+              (item) =>
+                isAdmin ||
+                item.href === "/admin/pages" ||
+                item.href === "/admin/about",
+            )
             .map(renderLink)}
         </>
       )}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -471,3 +471,40 @@ export interface PageContent {
   updated_by: string | null;
   updated_at: string;
 }
+
+/**
+ * Singleton row (id = true) holding the About Our Class summary. Body is
+ * BlockNote JSON, same format as PageContent.body. Members-only via RLS —
+ * unlike page_content, which is publicly readable.
+ */
+export interface AboutPage {
+  id: boolean;
+  body: string;
+  updated_by: string | null;
+  updated_at: string;
+}
+
+/**
+ * A teacher listed on the About Our Class page. Points at a member profile
+ * (name and photo come from the profile) with a teacher-specific title and
+ * bio on top.
+ */
+export interface ClassTeacher {
+  id: string;
+  profile_id: string;
+  title: string;
+  bio: string;
+  sort_order: number;
+  created_at: string;
+}
+
+/** ClassTeacher with the joined profile fields used for display. */
+export interface ClassTeacherWithProfile extends ClassTeacher {
+  profiles: {
+    id: string;
+    first_name: string | null;
+    last_name: string | null;
+    preferred_name: string | null;
+    avatar_url: string | null;
+  } | null;
+}

--- a/supabase/migrations/20260710000000_about_page.sql
+++ b/supabase/migrations/20260710000000_about_page.sql
@@ -1,0 +1,55 @@
+-- About Our Class page: a members-only class summary plus a roster of
+-- teachers. Content lives here (not in page_content) because page_content
+-- is publicly readable and teacher bios should stay behind login.
+
+-- Singleton row holding the class summary (BlockNote JSON, same format as
+-- page_content.body).
+create table public.about_page (
+  id boolean primary key default true check (id),
+  body text not null default '',
+  updated_by uuid references auth.users,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.about_page enable row level security;
+
+create policy "Members can read about page"
+  on public.about_page for select
+  using (public.is_member());
+
+create policy "Editors can insert about page"
+  on public.about_page for insert
+  with check (public.is_content_editor());
+
+create policy "Editors can update about page"
+  on public.about_page for update
+  using (public.is_content_editor());
+
+-- Teachers are members: each entry points at a profile and adds a
+-- teacher-specific title and bio. Photo comes from the profile's avatar.
+create table public.class_teachers (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null unique references public.profiles(id) on delete cascade,
+  title text not null default 'Teacher',
+  bio text not null default '',
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now()
+);
+
+alter table public.class_teachers enable row level security;
+
+create policy "Members can read class teachers"
+  on public.class_teachers for select
+  using (public.is_member());
+
+create policy "Editors can insert class teachers"
+  on public.class_teachers for insert
+  with check (public.is_content_editor());
+
+create policy "Editors can update class teachers"
+  on public.class_teachers for update
+  using (public.is_content_editor());
+
+create policy "Editors can delete class teachers"
+  on public.class_teachers for delete
+  using (public.is_content_editor());


### PR DESCRIPTION
## Summary

Adds a members-only **/about** page with a class summary and an "Our Teachers" section. All content lives in the database and is edited in the app, so no teacher info is ever hardcoded in the repo or a config file.

- **/about** (members only): class summary rendered from BlockNote content, plus a card per teacher with their directory photo, name, title, and bio
- **/admin/about** (admins + content editors): rich-text summary editor and an Okta-style teacher manager — current teachers listed with edit/reorder/remove, explicit "Add teacher" dialog that searches the member directory
- Teachers link to member profiles, so photos come from existing directory avatars; each entry adds a teacher-specific title and bio
- Sidebar link for members, admin nav + dashboard tile for editing (content editors see it like Manage Pages)

## Database

New migration `20260710000000_about_page.sql`:

- `about_page` — singleton row holding the summary (BlockNote JSON). Kept separate from `page_content` because that table is publicly readable via RLS; this one is member-read only
- `class_teachers` — `profile_id` (unique FK), `title`, `bio`, `sort_order`; writes gated by `is_content_editor()`

## Testing

- Migration applied to local DB via `migration up --db-url`
- `next build` passes with both new routes; eslint clean on changed files

## Notes

If a teacher marks themselves unlisted in the directory, RLS hides their profile from members and the card falls back to "(unnamed)" — assumed fine since teachers will be listed.