### PR TITLE
fix(ui): consistent button hover + click-off dismissal

### DIFF
--- a/app/admin/groups/IconPicker.tsx
+++ b/app/admin/groups/IconPicker.tsx
@@ -61,6 +61,7 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   // Dismiss on outside press or Escape, matching the app's menus/dialogs so the
   // picker doesn't linger when the admin clicks away from it.
@@ -73,7 +74,11 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
       }
     }
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") setOpen(false);
+      if (event.key === "Escape") {
+        setOpen(false);
+        // Return focus to the trigger so keyboard users don't land on <body>.
+        triggerRef.current?.focus();
+      }
     }
 
     document.addEventListener("pointerdown", handlePointerDown);
@@ -100,6 +105,7 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
   return (
     <div className="space-y-2" ref={containerRef}>
       <Button
+        ref={triggerRef}
         type="button"
         variant="outline"
         onClick={() => setOpen(!open)}

--- a/app/admin/groups/IconPicker.tsx
+++ b/app/admin/groups/IconPicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { DynamicIcon, iconNames, type IconName } from "lucide-react/dynamic";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -60,6 +60,29 @@ interface IconPickerProps {
 export function IconPicker({ value, onChange }: IconPickerProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Dismiss on outside press or Escape, matching the app's menus/dialogs so the
+  // picker doesn't linger when the admin clicks away from it.
+  useEffect(() => {
+    if (!open) return;
+
+    function handlePointerDown(event: PointerEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
 
   const { results, total } = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -75,7 +98,7 @@ export function IconPicker({ value, onChange }: IconPickerProps) {
   }
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2" ref={containerRef}>
       <Button
         type="button"
         variant="outline"

--- a/components/events/EventsPageClient.tsx
+++ b/components/events/EventsPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { Rss, ChevronDown, SlidersHorizontal } from "lucide-react";
 import { EventCalendarView } from "@/components/events/EventCalendarView";
@@ -42,6 +42,15 @@ export function EventsPageClient({
   subscriptionToken,
 }: EventsPageClientProps) {
   const [view, setView] = useState<View>("calendar");
+
+  // webcal:// feed links need an absolute host, but this component still SSRs,
+  // where `window` is undefined. Resolve the host on the client after mount.
+  const [host, setHost] = useState("");
+  useEffect(() => setHost(window.location.host), []);
+  const feedBase =
+    host && subscriptionToken
+      ? `webcal://${host}/api/calendar/feed.ics?token=${subscriptionToken}`
+      : undefined;
 
   // For the list view, expand recurring events from the ±1-year window and
   // filter to upcoming occurrences (so "never-ending" series show future dates).
@@ -117,42 +126,42 @@ export function EventsPageClient({
               </>
             )}
 
-            <DropdownMenu>
-              <DropdownMenuTrigger render={
-                <Button
-                  variant="outline"
-                  className="h-11 gap-2 rounded-xl border-slate-200 bg-white px-5 text-sm font-medium text-slate-600 shadow-sm hover:border-brand-primary/30 hover:bg-white hover:text-brand-primary"
-                >
-                  <Rss className="h-4 w-4" />
-                  Subscribe to Calendar
-                  <ChevronDown className="h-4 w-4" />
-                </Button>
-              } />
-              <DropdownMenuContent align="end" className="w-56 rounded-2xl">
-                <DropdownMenuItem
-                  onClick={() => {
-                    window.location.href = `webcal://${window.location.host}/api/calendar/feed.ics?token=${subscriptionToken}`;
-                  }}
-                >
-                  All Calendars
-                </DropdownMenuItem>
-                {calendars.map((cal) => (
-                  <DropdownMenuItem
-                    key={cal.id}
-                    className="gap-2"
-                    onClick={() => {
-                      window.location.href = `webcal://${window.location.host}/api/calendar/feed.ics?token=${subscriptionToken}&calendar=${cal.id}`;
-                    }}
+            {subscriptionToken && (
+              <DropdownMenu>
+                <DropdownMenuTrigger render={
+                  <Button
+                    variant="outline"
+                    className="h-11 gap-2 rounded-xl border-slate-200 bg-white px-5 text-sm font-medium text-slate-600 shadow-sm hover:border-brand-primary/30 hover:bg-white hover:text-brand-primary"
                   >
-                    <span
-                      className="inline-block h-2 w-2 shrink-0 rounded-full"
-                      style={{ backgroundColor: cal.color ?? "#2F6BA8" }}
-                    />
-                    {cal.name}
+                    <Rss className="h-4 w-4" />
+                    Subscribe to Calendar
+                    <ChevronDown className="h-4 w-4" />
+                  </Button>
+                } />
+                <DropdownMenuContent align="end" className="w-56 rounded-2xl">
+                  <DropdownMenuItem render={<a href={feedBase} />}>
+                    All Calendars
                   </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+                  {calendars.map((cal) => (
+                    <DropdownMenuItem
+                      key={cal.id}
+                      className="gap-2"
+                      render={
+                        <a
+                          href={feedBase ? `${feedBase}&calendar=${cal.id}` : undefined}
+                        />
+                      }
+                    >
+                      <span
+                        className="inline-block h-2 w-2 shrink-0 rounded-full"
+                        style={{ backgroundColor: cal.color ?? "#2F6BA8" }}
+                      />
+                      {cal.name}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
           </div>
         </div>
 

--- a/components/events/EventsPageClient.tsx
+++ b/components/events/EventsPageClient.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -41,7 +42,6 @@ export function EventsPageClient({
   subscriptionToken,
 }: EventsPageClientProps) {
   const [view, setView] = useState<View>("calendar");
-  const [showSubscribeMenu, setShowSubscribeMenu] = useState(false);
 
   // For the list view, expand recurring events from the ±1-year window and
   // filter to upcoming occurrences (so "never-ending" series show future dates).
@@ -117,47 +117,42 @@ export function EventsPageClient({
               </>
             )}
 
-            <div className="relative">
-              <Button
-                onClick={() => setShowSubscribeMenu(!showSubscribeMenu)}
-                variant="outline"
-                className="h-11 gap-2 rounded-xl border-slate-200 bg-white px-5 text-sm font-medium text-slate-600 shadow-sm hover:border-brand-primary/30 hover:bg-white hover:text-brand-primary"
-              >
-                <Rss className="h-4 w-4" />
-                Subscribe to Calendar
-                <ChevronDown className="h-4 w-4" />
-              </Button>
-
-              {showSubscribeMenu && (
-                <div className="absolute right-0 z-20 mt-2 w-56 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-lg">
-                  <button
+            <DropdownMenu>
+              <DropdownMenuTrigger render={
+                <Button
+                  variant="outline"
+                  className="h-11 gap-2 rounded-xl border-slate-200 bg-white px-5 text-sm font-medium text-slate-600 shadow-sm hover:border-brand-primary/30 hover:bg-white hover:text-brand-primary"
+                >
+                  <Rss className="h-4 w-4" />
+                  Subscribe to Calendar
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+              } />
+              <DropdownMenuContent align="end" className="w-56 rounded-2xl">
+                <DropdownMenuItem
+                  onClick={() => {
+                    window.location.href = `webcal://${window.location.host}/api/calendar/feed.ics?token=${subscriptionToken}`;
+                  }}
+                >
+                  All Calendars
+                </DropdownMenuItem>
+                {calendars.map((cal) => (
+                  <DropdownMenuItem
+                    key={cal.id}
+                    className="gap-2"
                     onClick={() => {
-                      window.location.href = `webcal://${window.location.host}/api/calendar/feed.ics?token=${subscriptionToken}`;
-                      setShowSubscribeMenu(false);
+                      window.location.href = `webcal://${window.location.host}/api/calendar/feed.ics?token=${subscriptionToken}&calendar=${cal.id}`;
                     }}
-                    className="w-full cursor-pointer border-b border-slate-100 px-4 py-2.5 text-left text-sm text-slate-700 hover:bg-slate-50"
                   >
-                    All Calendars
-                  </button>
-                  {calendars.map((cal) => (
-                    <button
-                      key={cal.id}
-                      onClick={() => {
-                        window.location.href = `webcal://${window.location.host}/api/calendar/feed.ics?token=${subscriptionToken}&calendar=${cal.id}`;
-                        setShowSubscribeMenu(false);
-                      }}
-                      className="flex w-full cursor-pointer items-center gap-2 border-b border-slate-100 px-4 py-2.5 text-left text-sm text-slate-700 hover:bg-slate-50 last:border-b-0"
-                    >
-                      <span
-                        className="inline-block h-2 w-2 shrink-0 rounded-full"
-                        style={{ backgroundColor: cal.color ?? "#2F6BA8" }}
-                      />
-                      {cal.name}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+                    <span
+                      className="inline-block h-2 w-2 shrink-0 rounded-full"
+                      style={{ backgroundColor: cal.color ?? "#2F6BA8" }}
+                    />
+                    {cal.name}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
 

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:


### PR DESCRIPTION
## Summary

Two UX gaps around clickable elements: some buttons had no hover feedback, and a couple of menus/pickers could only be closed via their explicit control (X / trigger) rather than by clicking away.

## Changes

- **Restore hover on primary buttons.** The default `Button` variant used `[a]:hover:bg-primary/80`, which only applies when the button renders as an `<a>` — so ordinary primary `<button>`s had no hover state. Changed to `hover:bg-primary/90` (the `transition-all` was already there). Fixes hover feedback on every primary button app-wide in one line.
- **Subscribe-to-Calendar menu dismisses on click-off.** Replaced the hand-rolled absolute-positioned menu in `EventsPageClient` with the shared Base UI `DropdownMenu` primitive, so it closes on outside press and restores focus to its trigger, matching every other menu/dialog/sheet.
- **Group IconPicker dismisses on click-off.** The icon picker is an inline disclosure panel (not a Base UI overlay), so it wasn't covered by the framework's outside-press handling. Added a scoped `pointerdown`/`Escape` listener so clicking away or pressing Escape collapses it.

## Notes

Every other overlay (Dialog, Sheet, DropdownMenu, Select, Combobox) already dismisses on outside-click by default via Base UI, and all other button variants + hand-styled buttons already had hover states — so no broader changes were needed.

## Verification

- `tsc --noEmit` — clean
- `eslint` on changed files — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the calendar subscription menu with a cleaner dropdown layout, including an “All Calendars” option and direct links to per-calendar feeds.
  * Enhanced the icon picker so it closes when clicking outside the picker or pressing Escape.
* **Bug Fixes**
  * Refined the default button hover styling for a slightly more consistent visual response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->