### PR TITLE
chore(db): RLS helper perf, index tune-up, FK delete behavior

### DIFF
--- a/supabase/migrations/20260712000000_rls_helper_perf.sql
+++ b/supabase/migrations/20260712000000_rls_helper_perf.sql
@@ -1,0 +1,707 @@
+-- RLS helper performance pass.
+--
+-- 1) The role-check helpers (is_admin, is_member, is_content_editor,
+--    is_group_leader, giving_stewards_can_manage, giving_can_manage_fund)
+--    were created with default VOLATILE volatility, so Postgres must call
+--    them once per row inside RLS filters and can never hoist them into a
+--    one-time filter. They only read data, so declare them STABLE and pin
+--    search_path (clears the function_search_path_mutable linter warning).
+--
+-- 2) Even as STABLE, a bare helper call in a policy is still evaluated per
+--    row (verified with EXPLAIN ANALYZE: RLS security quals are not hoisted
+--    into one-time filters). Wrap every zero-argument helper call in a
+--    scalar subquery so it becomes an InitPlan evaluated once per
+--    statement — same treatment 20260710000001 gave auth.uid().
+--    Helpers that take a column argument (is_group_leader(group_id),
+--    giving_can_manage_fund(fund_id)) are inherently per-row and stay bare.
+
+-- ---------------------------------------------------------------------------
+-- Helper functions: STABLE + pinned search_path (bodies unchanged)
+-- ---------------------------------------------------------------------------
+
+create or replace function public.is_admin() returns boolean
+language sql stable security definer set search_path = ''
+as $$
+  select exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role = 'admin'
+  );
+$$;
+
+create or replace function public.is_member() returns boolean
+language sql stable security definer set search_path = ''
+as $$
+  select exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role in ('member', 'content_editor', 'admin')
+  );
+$$;
+
+create or replace function public.is_content_editor() returns boolean
+language sql stable security definer set search_path = ''
+as $$
+  select exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role in ('content_editor', 'admin')
+  );
+$$;
+
+create or replace function public.is_group_leader(_group_id uuid) returns boolean
+language sql stable security definer set search_path = ''
+as $$
+  select exists (
+    select 1 from public.profile_groups
+    where profile_id = auth.uid()
+      and group_id = _group_id
+      and is_leader = true
+  );
+$$;
+
+create or replace function public.current_family_id() returns uuid
+language sql stable security definer set search_path = ''
+as $$
+  select family_id from public.profiles where id = auth.uid();
+$$;
+
+create or replace function public.giving_stewards_can_manage() returns boolean
+language sql stable security definer set search_path = ''
+as $$
+  select coalesce(
+    (select value from public.site_settings where key = 'giving_manage_mode'),
+    'stewards'
+  ) = 'stewards';
+$$;
+
+create or replace function public.giving_can_manage_fund(_fund_id uuid) returns boolean
+language sql stable security definer set search_path = ''
+as $$
+  select public.is_admin() or (
+    public.giving_stewards_can_manage() and exists (
+      select 1 from public.giving_funds f
+      where f.id = _fund_id and f.steward_id = auth.uid()
+    )
+  );
+$$;
+
+-- Trigger function: stays volatile (it writes), but pin search_path.
+create or replace function public.handle_new_user() returns trigger
+language plpgsql security definer set search_path = ''
+as $$
+declare
+  _role text := 'pending';
+  _full_name text := new.raw_user_meta_data->>'full_name';
+  _first text;
+  _last text;
+begin
+  if exists (
+    select 1 from public.access_requests
+    where email = new.email
+      and status = 'approved'
+  ) then
+    _role := 'member';
+  end if;
+
+  if _full_name is not null and btrim(_full_name) <> '' then
+    if position(' ' in btrim(_full_name)) = 0 then
+      _first := btrim(_full_name);
+      _last := null;
+    else
+      _first := btrim(substring(btrim(_full_name) from 1 for (length(btrim(_full_name)) - position(' ' in reverse(btrim(_full_name))))));
+      _last := btrim(substring(btrim(_full_name) from (length(btrim(_full_name)) - position(' ' in reverse(btrim(_full_name))) + 2)));
+    end if;
+  end if;
+
+  insert into public.profiles (id, first_name, last_name, email, role, relationship)
+  values (new.id, _first, _last, new.email, _role, 'primary');
+  return new;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Policies mixing helpers with column references: wrap helpers in (select ...)
+-- ---------------------------------------------------------------------------
+
+-- profiles
+drop policy if exists "Profiles are visible per access rules" on public.profiles;
+create policy "Profiles are visible per access rules"
+  on public.profiles for select
+  using (
+    (select auth.uid()) = id
+    or (select public.is_admin())
+    or (
+      family_id is not null
+      and family_id = (select public.current_family_id())
+      and (select auth.uid()) != id
+      and (select public.is_member())
+    )
+    or (
+      (select public.is_member())
+      and is_unlisted = false
+      and role in ('member', 'content_editor', 'admin')
+    )
+  );
+
+drop policy if exists "Profiles are updatable per access rules" on public.profiles;
+create policy "Profiles are updatable per access rules"
+  on public.profiles for update
+  using (
+    (select auth.uid()) = id
+    or (select public.is_admin())
+    or (
+      (select auth.uid()) != id
+      and family_id is not null
+      and family_id = (select public.current_family_id())
+      and exists (
+        select 1 from public.profiles self
+        where self.id = (select auth.uid())
+          and self.relationship in ('primary', 'spouse')
+          and self.role in ('member', 'content_editor', 'admin')
+      )
+    )
+  )
+  with check (
+    (select auth.uid()) = id
+    or (select public.is_admin())
+    or (
+      family_id = (select public.current_family_id())
+      and role = public.get_profile_role(id)
+      and (email is not distinct from public.get_profile_email(id))
+    )
+  );
+
+-- family_members
+drop policy if exists "Admins and household leaders can insert family members" on public.family_members;
+create policy "Admins and household leaders can insert family members"
+  on public.family_members for insert
+  with check (
+    (select public.is_admin())
+    or (
+      family_id = (select public.current_family_id())
+      and (select public.is_member())
+      and exists (
+        select 1 from public.profiles self
+        where self.id = (select auth.uid())
+          and self.relationship in ('primary', 'spouse')
+      )
+    )
+  );
+
+drop policy if exists "Admins and household leaders can update family members" on public.family_members;
+create policy "Admins and household leaders can update family members"
+  on public.family_members for update
+  using (
+    (select public.is_admin())
+    or (
+      family_id = (select public.current_family_id())
+      and (select public.is_member())
+      and exists (
+        select 1 from public.profiles self
+        where self.id = (select auth.uid())
+          and self.relationship in ('primary', 'spouse')
+      )
+    )
+  )
+  with check (
+    (select public.is_admin())
+    or (
+      family_id = (select public.current_family_id())
+      and (select public.is_member())
+      and exists (
+        select 1 from public.profiles self
+        where self.id = (select auth.uid())
+          and self.relationship in ('primary', 'spouse')
+      )
+    )
+  );
+
+drop policy if exists "Admins and household leaders can delete family members" on public.family_members;
+create policy "Admins and household leaders can delete family members"
+  on public.family_members for delete
+  using (
+    (select public.is_admin())
+    or (
+      family_id = (select public.current_family_id())
+      and (select public.is_member())
+      and exists (
+        select 1 from public.profiles self
+        where self.id = (select auth.uid())
+          and self.relationship in ('primary', 'spouse')
+      )
+    )
+  );
+
+-- family_invites
+drop policy if exists "Admins and household primary can insert family invites" on public.family_invites;
+create policy "Admins and household primary can insert family invites"
+  on public.family_invites for insert
+  with check (
+    (select public.is_admin())
+    or exists (
+      select 1 from public.profiles self
+      where self.id = (select auth.uid())
+        and self.family_id = family_invites.family_id
+        and self.family_id is not null
+        and self.relationship = 'primary'
+    )
+  );
+
+drop policy if exists "Admins and household primary can update family invites" on public.family_invites;
+create policy "Admins and household primary can update family invites"
+  on public.family_invites for update
+  using (
+    (select public.is_admin())
+    or exists (
+      select 1 from public.profiles self
+      where self.id = (select auth.uid())
+        and self.family_id = family_invites.family_id
+        and self.family_id is not null
+        and self.relationship = 'primary'
+    )
+  )
+  with check (
+    (select public.is_admin())
+    or exists (
+      select 1 from public.profiles self
+      where self.id = (select auth.uid())
+        and self.family_id = family_invites.family_id
+        and self.family_id is not null
+        and self.relationship = 'primary'
+    )
+  );
+
+-- family_units
+drop policy if exists "Admins and members can update family units" on public.family_units;
+create policy "Admins and members can update family units"
+  on public.family_units for update
+  using (
+    (select public.is_admin())
+    or (
+      id = (select public.current_family_id())
+      and (select public.is_member())
+    )
+  )
+  with check (
+    (select public.is_admin())
+    or (
+      id = (select public.current_family_id())
+      and (select public.is_member())
+    )
+  );
+
+-- giving_funds
+drop policy if exists "Admins and self-stewards can create funds" on public.giving_funds;
+create policy "Admins and self-stewards can create funds"
+  on public.giving_funds for insert
+  with check (
+    created_by = (select auth.uid())
+    and (
+      (select public.is_admin())
+      or (
+        (select public.giving_stewards_can_manage())
+        and (select public.is_member())
+        and steward_id = (select auth.uid())
+      )
+    )
+  );
+
+drop policy if exists "Admins and stewards can update funds" on public.giving_funds;
+create policy "Admins and stewards can update funds"
+  on public.giving_funds for update
+  using (
+    (select public.is_admin())
+    or ((select public.giving_stewards_can_manage()) and steward_id = (select auth.uid()))
+  );
+
+drop policy if exists "Admins and stewards can delete funds" on public.giving_funds;
+create policy "Admins and stewards can delete funds"
+  on public.giving_funds for delete
+  using (
+    (select public.is_admin())
+    or ((select public.giving_stewards_can_manage()) and steward_id = (select auth.uid()))
+  );
+
+-- announcements
+drop policy if exists "Members and published announcements are visible" on public.announcements;
+create policy "Members and published announcements are visible"
+  on public.announcements for select
+  using ((select public.is_member()) or is_published = true);
+
+-- rsvps
+drop policy if exists "Members and admins can insert rsvps" on public.rsvps;
+create policy "Members and admins can insert rsvps"
+  on public.rsvps for insert
+  with check (
+    ((select auth.uid()) = user_id and (select public.is_member()))
+    or (select public.is_admin())
+  );
+
+drop policy if exists "Members and admins can update rsvps" on public.rsvps;
+create policy "Members and admins can update rsvps"
+  on public.rsvps for update
+  using (
+    ((select auth.uid()) = user_id and (select public.is_member()))
+    or (select public.is_admin())
+  )
+  with check (
+    ((select auth.uid()) = user_id and (select public.is_member()))
+    or (select public.is_admin())
+  );
+
+drop policy if exists "Members and admins can delete rsvps" on public.rsvps;
+create policy "Members and admins can delete rsvps"
+  on public.rsvps for delete
+  using (
+    ((select auth.uid()) = user_id and (select public.is_member()))
+    or (select public.is_admin())
+  );
+
+-- serving_team_settings
+drop policy if exists "Leaders and admins can insert serving settings" on public.serving_team_settings;
+create policy "Leaders and admins can insert serving settings"
+  on public.serving_team_settings for insert
+  with check ((select public.is_admin()) or public.is_group_leader(group_id));
+
+drop policy if exists "Leaders and admins can update serving settings" on public.serving_team_settings;
+create policy "Leaders and admins can update serving settings"
+  on public.serving_team_settings for update
+  using ((select public.is_admin()) or public.is_group_leader(group_id));
+
+-- serving_broadcasts
+drop policy if exists "Leaders and admins can view serving broadcasts" on public.serving_broadcasts;
+create policy "Leaders and admins can view serving broadcasts"
+  on public.serving_broadcasts for select
+  using ((select public.is_admin()) or public.is_group_leader(group_id));
+
+drop policy if exists "Leaders and admins can log serving broadcasts" on public.serving_broadcasts;
+create policy "Leaders and admins can log serving broadcasts"
+  on public.serving_broadcasts for insert
+  with check (
+    sent_by = (select auth.uid())
+    and ((select public.is_admin()) or public.is_group_leader(group_id))
+  );
+
+-- serving_signups
+drop policy if exists "Members can create serving signups" on public.serving_signups;
+create policy "Members can create serving signups"
+  on public.serving_signups for insert
+  with check (
+    created_by = (select auth.uid())
+    and (
+      (select public.is_admin())
+      or public.is_group_leader(group_id)
+      or exists (
+        select 1 from public.profile_groups pg
+        where pg.profile_id = (select auth.uid()) and pg.group_id = serving_signups.group_id
+      )
+    )
+  );
+
+drop policy if exists "Members can delete own serving signups" on public.serving_signups;
+create policy "Members can delete own serving signups"
+  on public.serving_signups for delete
+  using (
+    created_by = (select auth.uid())
+    or (select public.is_admin())
+    or public.is_group_leader(group_id)
+  );
+
+-- serving_signup_attendees
+drop policy if exists "Signup owners can add attendees" on public.serving_signup_attendees;
+create policy "Signup owners can add attendees"
+  on public.serving_signup_attendees for insert
+  with check (
+    exists (
+      select 1 from public.serving_signups s
+      where s.id = signup_id
+        and (
+          s.created_by = (select auth.uid())
+          or (select public.is_admin())
+          or public.is_group_leader(s.group_id)
+        )
+    )
+  );
+
+drop policy if exists "Signup owners can remove attendees" on public.serving_signup_attendees;
+create policy "Signup owners can remove attendees"
+  on public.serving_signup_attendees for delete
+  using (
+    exists (
+      select 1 from public.serving_signups s
+      where s.id = signup_id
+        and (
+          s.created_by = (select auth.uid())
+          or (select public.is_admin())
+          or public.is_group_leader(s.group_id)
+        )
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- Single-helper policies: same (select ...) wrap
+-- ---------------------------------------------------------------------------
+
+-- about_page
+drop policy if exists "Members can read about page" on public.about_page;
+create policy "Members can read about page"
+  on public.about_page for select
+  using ((select public.is_member()));
+
+drop policy if exists "Editors can insert about page" on public.about_page;
+create policy "Editors can insert about page"
+  on public.about_page for insert
+  with check ((select public.is_content_editor()));
+
+drop policy if exists "Editors can update about page" on public.about_page;
+create policy "Editors can update about page"
+  on public.about_page for update
+  using ((select public.is_content_editor()));
+
+-- access_requests
+drop policy if exists "Admins can view access requests" on public.access_requests;
+create policy "Admins can view access requests"
+  on public.access_requests for select
+  using ((select public.is_admin()));
+
+drop policy if exists "Admins can update access requests" on public.access_requests;
+create policy "Admins can update access requests"
+  on public.access_requests for update
+  using ((select public.is_admin()));
+
+-- announcements
+drop policy if exists "Admins can insert announcements" on public.announcements;
+create policy "Admins can insert announcements"
+  on public.announcements for insert
+  with check ((select public.is_admin()));
+
+drop policy if exists "Admins can update announcements" on public.announcements;
+create policy "Admins can update announcements"
+  on public.announcements for update
+  using ((select public.is_admin()));
+
+drop policy if exists "Admins can delete announcements" on public.announcements;
+create policy "Admins can delete announcements"
+  on public.announcements for delete
+  using ((select public.is_admin()));
+
+-- class_teachers
+drop policy if exists "Members can read class teachers" on public.class_teachers;
+create policy "Members can read class teachers"
+  on public.class_teachers for select
+  using ((select public.is_member()));
+
+drop policy if exists "Editors can insert class teachers" on public.class_teachers;
+create policy "Editors can insert class teachers"
+  on public.class_teachers for insert
+  with check ((select public.is_content_editor()));
+
+drop policy if exists "Editors can update class teachers" on public.class_teachers;
+create policy "Editors can update class teachers"
+  on public.class_teachers for update
+  using ((select public.is_content_editor()));
+
+drop policy if exists "Editors can delete class teachers" on public.class_teachers;
+create policy "Editors can delete class teachers"
+  on public.class_teachers for delete
+  using ((select public.is_content_editor()));
+
+-- event_calendars
+drop policy if exists "Admins can insert event calendars" on public.event_calendars;
+create policy "Admins can insert event calendars"
+  on public.event_calendars for insert
+  with check ((select public.is_admin()));
+
+drop policy if exists "Admins can update event calendars" on public.event_calendars;
+create policy "Admins can update event calendars"
+  on public.event_calendars for update
+  using ((select public.is_admin()));
+
+drop policy if exists "Admins can delete event calendars" on public.event_calendars;
+create policy "Admins can delete event calendars"
+  on public.event_calendars for delete
+  using ((select public.is_admin()));
+
+-- events
+drop policy if exists "Members can view all events" on public.events;
+create policy "Members can view all events"
+  on public.events for select
+  using ((select public.is_member()));
+
+drop policy if exists "Admins can insert events" on public.events;
+create policy "Admins can insert events"
+  on public.events for insert
+  with check ((select public.is_admin()));
+
+drop policy if exists "Admins can update events" on public.events;
+create policy "Admins can update events"
+  on public.events for update
+  using ((select public.is_admin()));
+
+drop policy if exists "Admins can delete events" on public.events;
+create policy "Admins can delete events"
+  on public.events for delete
+  using ((select public.is_admin()));
+
+-- family_invites
+drop policy if exists "Members can view family invites" on public.family_invites;
+create policy "Members can view family invites"
+  on public.family_invites for select
+  using ((select public.is_member()));
+
+-- family_members
+drop policy if exists "Members can view family members" on public.family_members;
+create policy "Members can view family members"
+  on public.family_members for select
+  using ((select public.is_member()));
+
+-- family_units
+drop policy if exists "Members can view family units" on public.family_units;
+create policy "Members can view family units"
+  on public.family_units for select
+  using ((select public.is_member()));
+
+drop policy if exists "Admins can insert family units" on public.family_units;
+create policy "Admins can insert family units"
+  on public.family_units for insert
+  with check ((select public.is_admin()));
+
+drop policy if exists "Admins can delete family units" on public.family_units;
+create policy "Admins can delete family units"
+  on public.family_units for delete
+  using ((select public.is_admin()));
+
+-- giving_fund_methods
+drop policy if exists "Members can view fund methods" on public.giving_fund_methods;
+create policy "Members can view fund methods"
+  on public.giving_fund_methods for select
+  using ((select public.is_member()));
+
+-- giving_funds
+drop policy if exists "Members can view giving funds" on public.giving_funds;
+create policy "Members can view giving funds"
+  on public.giving_funds for select
+  using ((select public.is_member()));
+
+-- lecture_series
+drop policy if exists "Admins can insert series" on public.lecture_series;
+create policy "Admins can insert series"
+  on public.lecture_series for insert
+  with check ((select public.is_admin()));
+
+drop policy if exists "Admins can update series" on public.lecture_series;
+create policy "Admins can update series"
+  on public.lecture_series for update
+  using ((select public.is_admin()));
+
+drop policy if exists "Admins can delete series" on public.lecture_series;
+create policy "Admins can delete series"
+  on public.lecture_series for delete
+  using ((select public.is_admin()));
+
+-- lectures
+drop policy if exists "Admins can insert lectures" on public.lectures;
+create policy "Admins can insert lectures"
+  on public.lectures for insert
+  with check ((select public.is_admin()));
+
+drop policy if exists "Admins can update lectures" on public.lectures;
+create policy "Admins can update lectures"
+  on public.lectures for update
+  using ((select public.is_admin()));
+
+drop policy if exists "Admins can delete lectures" on public.lectures;
+create policy "Admins can delete lectures"
+  on public.lectures for delete
+  using ((select public.is_admin()));
+
+-- member_groups
+drop policy if exists "Members can view member groups" on public.member_groups;
+create policy "Members can view member groups"
+  on public.member_groups for select
+  using ((select public.is_member()));
+
+drop policy if exists "Admins can insert member groups" on public.member_groups;
+create policy "Admins can insert member groups"
+  on public.member_groups for insert
+  with check ((select public.is_admin()));
+
+drop policy if exists "Admins can update member groups" on public.member_groups;
+create policy "Admins can update member groups"
+  on public.member_groups for update
+  using ((select public.is_admin()));
+
+drop policy if exists "Admins can delete member groups" on public.member_groups;
+create policy "Admins can delete member groups"
+  on public.member_groups for delete
+  using ((select public.is_admin()));
+
+-- page_content
+drop policy if exists "Editors can insert page content" on public.page_content;
+create policy "Editors can insert page content"
+  on public.page_content for insert
+  with check ((select public.is_content_editor()));
+
+drop policy if exists "Editors can update page content" on public.page_content;
+create policy "Editors can update page content"
+  on public.page_content for update
+  using ((select public.is_content_editor()));
+
+drop policy if exists "Admins can delete page content" on public.page_content;
+create policy "Admins can delete page content"
+  on public.page_content for delete
+  using ((select public.is_admin()));
+
+-- profile_groups
+drop policy if exists "Members can view profile groups" on public.profile_groups;
+create policy "Members can view profile groups"
+  on public.profile_groups for select
+  using ((select public.is_member()));
+
+drop policy if exists "Admins can insert profile groups" on public.profile_groups;
+create policy "Admins can insert profile groups"
+  on public.profile_groups for insert
+  with check ((select public.is_admin()));
+
+drop policy if exists "Admins can update profile groups" on public.profile_groups;
+create policy "Admins can update profile groups"
+  on public.profile_groups for update
+  using ((select public.is_admin()));
+
+drop policy if exists "Admins can delete profile groups" on public.profile_groups;
+create policy "Admins can delete profile groups"
+  on public.profile_groups for delete
+  using ((select public.is_admin()));
+
+-- rsvps
+drop policy if exists "Members and admins can view rsvps" on public.rsvps;
+create policy "Members and admins can view rsvps"
+  on public.rsvps for select
+  using ((select public.is_member()) or (select public.is_admin()));
+
+-- serving_signup_attendees
+drop policy if exists "Members can view serving attendees" on public.serving_signup_attendees;
+create policy "Members can view serving attendees"
+  on public.serving_signup_attendees for select
+  using ((select public.is_member()));
+
+-- serving_signups
+drop policy if exists "Members can view serving signups" on public.serving_signups;
+create policy "Members can view serving signups"
+  on public.serving_signups for select
+  using ((select public.is_member()));
+
+-- serving_team_settings
+drop policy if exists "Members can view serving settings" on public.serving_team_settings;
+create policy "Members can view serving settings"
+  on public.serving_team_settings for select
+  using ((select public.is_member()));
+
+drop policy if exists "Admins can delete serving settings" on public.serving_team_settings;
+create policy "Admins can delete serving settings"
+  on public.serving_team_settings for delete
+  using ((select public.is_admin()));
+
+-- site_settings
+drop policy if exists "Admins can update settings" on public.site_settings;
+create policy "Admins can update settings"
+  on public.site_settings for update
+  using ((select public.is_admin()));

--- a/supabase/migrations/20260712000001_index_tuneup.sql
+++ b/supabase/migrations/20260712000001_index_tuneup.sql
@@ -1,0 +1,23 @@
+-- Index tune-up.
+--
+-- events is the most-queried table (dashboard, events page, ICS feed,
+-- reminder function all filter/sort on start_time) but only had its
+-- primary key index. The remaining adds cover foreign keys that Postgres
+-- does not index automatically, so cascaded deletes from profiles and
+-- per-user lookups stop requiring sequential scans.
+
+create index events_start_time_idx on public.events(start_time);
+create index events_series_id_idx on public.events(series_id) where series_id is not null;
+create index events_calendar_id_idx on public.events(calendar_id);
+
+create index lectures_series_id_idx on public.lectures(series_id);
+create index rsvps_user_id_idx on public.rsvps(user_id);
+create index prayer_requests_author_id_idx on public.prayer_requests(author_id);
+create index prayer_responses_profile_id_idx on public.prayer_responses(profile_id);
+
+-- family_invites_token_idx duplicates the family_invites_token_key unique
+-- constraint index; the other two are single-digit-cardinality columns on
+-- tiny tables the planner never picks, so they only add write overhead.
+drop index if exists public.family_invites_token_idx;
+drop index if exists public.profiles_relationship_idx;
+drop index if exists public.member_groups_display_order_idx;

--- a/supabase/migrations/20260712000002_fk_delete_behavior.sql
+++ b/supabase/migrations/20260712000002_fk_delete_behavior.sql
@@ -1,0 +1,57 @@
+-- Fix foreign keys that block account deletion.
+--
+-- These constraints had no ON DELETE action, so deleting a member's
+-- auth.users row (which cascades to profiles) fails as soon as they have
+-- an RSVP or authored/reviewed anything. RSVPs are personal responses and
+-- go with the profile; the rest are nullable audit/authorship columns
+-- where the record should outlive the account.
+
+alter table public.rsvps
+  drop constraint rsvps_user_id_fkey,
+  add constraint rsvps_user_id_fkey
+    foreign key (user_id) references public.profiles(id) on delete cascade;
+
+alter table public.announcements
+  drop constraint announcements_author_id_fkey,
+  add constraint announcements_author_id_fkey
+    foreign key (author_id) references public.profiles(id) on delete set null;
+
+alter table public.events
+  drop constraint events_created_by_fkey,
+  add constraint events_created_by_fkey
+    foreign key (created_by) references public.profiles(id) on delete set null;
+
+alter table public.event_calendars
+  drop constraint event_calendars_created_by_fkey,
+  add constraint event_calendars_created_by_fkey
+    foreign key (created_by) references public.profiles(id) on delete set null;
+
+alter table public.lectures
+  drop constraint lectures_created_by_fkey,
+  add constraint lectures_created_by_fkey
+    foreign key (created_by) references public.profiles(id) on delete set null;
+
+alter table public.about_page
+  drop constraint about_page_updated_by_fkey,
+  add constraint about_page_updated_by_fkey
+    foreign key (updated_by) references auth.users(id) on delete set null;
+
+alter table public.access_requests
+  drop constraint access_requests_reviewed_by_fkey,
+  add constraint access_requests_reviewed_by_fkey
+    foreign key (reviewed_by) references auth.users(id) on delete set null;
+
+alter table public.page_content
+  drop constraint page_content_updated_by_fkey,
+  add constraint page_content_updated_by_fkey
+    foreign key (updated_by) references auth.users(id) on delete set null;
+
+alter table public.profiles
+  drop constraint profiles_approved_by_fkey,
+  add constraint profiles_approved_by_fkey
+    foreign key (approved_by) references auth.users(id) on delete set null;
+
+alter table public.site_settings
+  drop constraint site_settings_updated_by_fkey,
+  add constraint site_settings_updated_by_fkey
+    foreign key (updated_by) references auth.users(id) on delete set null;

--- a/supabase/migrations/20260712000003_prayer_wall_lateral.sql
+++ b/supabase/migrations/20260712000003_prayer_wall_lateral.sql
@@ -1,0 +1,43 @@
+-- prayer_wall ran two correlated subqueries per request (a COUNT and an
+-- EXISTS over prayer_responses), so every wall load scanned responses
+-- twice per row — each pass re-evaluating prayer_responses RLS. Merge
+-- them into one lateral aggregate and hoist auth.uid() into InitPlans.
+-- Column list, names and types are unchanged.
+
+create or replace view public.prayer_wall with (security_invoker = true) as
+select
+  r.id,
+  r.body,
+  r.category,
+  r.is_anonymous,
+  r.visible_to_warriors,
+  r.is_answered,
+  r.created_at,
+  (r.author_id = (select auth.uid())) as mine,
+  case
+    when r.is_anonymous and r.author_id <> (select auth.uid()) then null::text
+    else p.first_name
+  end as first_name,
+  case
+    when r.is_anonymous and r.author_id <> (select auth.uid()) then null::text
+    else p.last_name
+  end as last_name,
+  case
+    when r.is_anonymous and r.author_id <> (select auth.uid()) then null::text
+    else p.preferred_name
+  end as preferred_name,
+  case
+    when r.is_anonymous and r.author_id <> (select auth.uid()) then null::text
+    else p.avatar_url
+  end as avatar_url,
+  coalesce(pc.praying_count, 0) as praying_count,
+  coalesce(pc.i_am_praying, false) as i_am_praying
+from public.prayer_requests r
+left join public.profiles p on p.id = r.author_id
+left join lateral (
+  select
+    count(*)::integer as praying_count,
+    bool_or(pr.profile_id = (select auth.uid())) as i_am_praying
+  from public.prayer_responses pr
+  where pr.request_id = r.id
+) pc on true;


### PR DESCRIPTION
## Summary

Database-only branch (4 migrations, no app code). Migrations deploy via the existing supabase workflow on merge; `chore(db):` avoids a release bump. The schema dump is regenerated by CI after push.

### 1. `20260712000000_rls_helper_perf.sql` — stop per-row RLS helper execution
The role-check helpers (`is_admin`, `is_member`, `is_content_editor`, `is_group_leader`, `current_family_id`, `giving_stewards_can_manage`, `giving_can_manage_fund`) were VOLATILE and called bare inside ~60 policies, so Postgres ran their SECURITY DEFINER subqueries once per scanned row on every query. This migration declares them STABLE with pinned `search_path` and wraps every zero-argument call in `(select ...)` so each becomes an InitPlan evaluated once per statement — finishing what 20260710000001 did for `auth.uid()` (the Supabase linter only flags `auth.*()`, not custom helpers). Helpers taking column arguments stay bare since they are inherently per-row.

Measured locally: scanning 5,003 events as a member drops from 25.1 ms to 0.7 ms, with only 3 profiles in the helper lookup table — the gap widens as the roster grows.

Note for future policies: marking a helper STABLE is not enough on its own (verified with EXPLAIN — RLS quals are not hoisted into one-time filters); always write `(select public.is_member())`, never a bare call.

### 2. `20260712000001_index_tuneup.sql` — index adds and drops
`events` is the most-queried table (dashboard, events page, ICS feed, reminder function all filter/sort `start_time`) but only had its primary key. Adds `events(start_time)`, partial `events(series_id)`, `events(calendar_id)`, plus unindexed FKs `lectures(series_id)`, `rsvps(user_id)`, `prayer_requests(author_id)`, `prayer_responses(profile_id)`. Drops `family_invites_token_idx` (exact duplicate of the unique constraint index), `profiles_relationship_idx`, and `member_groups_display_order_idx` (low-cardinality tiny-table indexes the planner never picks).

### 3. `20260712000002_fk_delete_behavior.sql` — unblock account deletion
Ten FKs had no ON DELETE action, so deleting a member's auth user failed once they had an RSVP or authored/reviewed anything. RSVPs now cascade with the profile; the nullable authorship/audit columns switch to SET NULL so the records outlive the account.

### 4. `20260712000003_prayer_wall_lateral.sql` — single-pass prayer_wall
The view ran two correlated subqueries per request (COUNT + EXISTS over `prayer_responses`, each re-evaluating RLS). Merged into one lateral aggregate, `auth.uid()` hoisted into InitPlans. Column list, names, and types unchanged.

## Verification (local stack)

- EXPLAIN ANALYZE before/after: helper calls now appear as InitPlans (`loops=1`) instead of per-row filters; OR short-circuiting even skips `is_admin()` entirely for members
- Row visibility byte-identical for member and anon across profiles, events, announcements, rsvps, directory views
- `prayer_wall` output diffed byte-identical for member and prayer-warrior viewers across anonymous, own-anonymous, and warriors-only cases
- Deleting a member with an RSVP and an authored announcement now succeeds; the announcement survives with `author_id` nulled
- `supabase db lint`: no schema errors; the STABLE + pinned `search_path` changes also clear `function_search_path_mutable` warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved performance for permission checks and row-level security policies.
  * Added database indexes to speed up event, lecture, RSVP, prayer, and related record searches.
  * Optimized prayer wall loading by reducing repeated data processing.

* **Data Management**
  * Updated deletion behavior to preserve related records or remove dependent records appropriately when accounts are deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->