### PR TITLE
refactor: efficiency fixes (P0/P1) — queries, bundles, batching

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -185,6 +185,7 @@ export default async function DashboardPage() {
       .from("announcements")
       .select("id", { count: "exact", head: true })
       .eq("is_published", true)
+      .lte("published_at", now)
       .gte("published_at", thirtyDaysAgo),
     supabase
       .from("lectures")

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -116,15 +116,94 @@ export default async function DashboardPage() {
   // anchors and recently-started occurrences (for the live/ended join states).
   const windowStart = new Date(nowDate.getTime() - 24 * 60 * 60 * 1000);
   const windowStartISO = windowStart.toISOString();
-  const { data: rawEvents } = await supabase
-    .from("events")
-    .select("*")
-    .or(
-      `start_time.gte.${windowStartISO},` +
-      `and(recurrence_frequency.not.is.null,or(recurrence_until.is.null,recurrence_until.gte.${windowStartISO}))`
-    )
-    .order("start_time", { ascending: true })
-    .limit(500);
+
+  // Give tile — live funds, gated by the admin toggle. UTC date to match
+  // the retirement filtering on /give and /admin/giving.
+  const today = new Date().toISOString().slice(0, 10);
+  const thirtyDaysAgo = new Date(new Date(now).getTime() - 30 * 86400000).toISOString();
+
+  // Phase A — every query below is independent of `nextEvent`; fire them
+  // together instead of awaiting one at a time.
+  const [
+    { data: rawEvents },
+    { data: rsvps },
+    { data: announcements },
+    { data: giveTileSetting },
+    { data: liveFunds, count: liveFundCount },
+    { count: eventCount },
+    { count: memberCount },
+    { count: announcementCount },
+    { count: lectureCount },
+    { data: lectures },
+    { data: myServings },
+  ] = await Promise.all([
+    supabase
+      .from("events")
+      .select("*")
+      .or(
+        `start_time.gte.${windowStartISO},` +
+        `and(recurrence_frequency.not.is.null,or(recurrence_until.is.null,recurrence_until.gte.${windowStartISO}))`
+      )
+      .order("start_time", { ascending: true })
+      .limit(500),
+    // User RSVPs
+    supabase
+      .from("rsvps")
+      .select("*")
+      .eq("user_id", user.id),
+    // Announcements (latest 3)
+    supabase
+      .from("announcements")
+      .select("*")
+      .eq("is_published", true)
+      .lte("published_at", now)
+      .order("published_at", { ascending: false })
+      .limit(3),
+    supabase
+      .from("site_settings")
+      .select("value")
+      .eq("key", "giving_dashboard_tile")
+      .maybeSingle(),
+    supabase
+      .from("giving_funds")
+      .select("name", { count: "exact" })
+      .eq("is_active", true)
+      .or(`retire_on.is.null,retire_on.gte.${today}`)
+      .order("display_order")
+      .order("created_at")
+      .limit(1),
+    // Counts for quick-actions
+    supabase
+      .from("events")
+      .select("id", { count: "exact", head: true })
+      .gte("start_time", now),
+    supabase
+      .from("profiles")
+      .select("id", { count: "exact", head: true })
+      .neq("role", "pending"),
+    supabase
+      .from("announcements")
+      .select("id", { count: "exact", head: true })
+      .eq("is_published", true)
+      .gte("published_at", thirtyDaysAgo),
+    supabase
+      .from("lectures")
+      .select("id", { count: "exact", head: true }),
+    // Recent lectures for "Continue listening" panel
+    supabase
+      .from("lectures")
+      .select("id, title, description, lecture_date")
+      .order("lecture_date", { ascending: false })
+      .limit(3),
+    // Upcoming serving commitments for this member (inner join filters to user's rows)
+    supabase
+      .from("serving_signups")
+      .select("id, service_date, group_id, member_groups(id, name), serving_signup_attendees!inner(profile_id)")
+      .eq("serving_signup_attendees.profile_id", profile.id)
+      .gte("service_date", toDateString(new Date()))
+      .order("service_date", { ascending: true })
+      .limit(3),
+  ]);
 
   // Keep the current occurrence on the hero through its live window plus a
   // short grace period (ended state points to the recording), then roll over.
@@ -134,43 +213,59 @@ export default async function DashboardPage() {
       (e) => meetingEndMs(e.start_time, e.end_time) + ENDED_GRACE_MS > nowDate.getTime()
     ) ?? null;
 
-  // Meeting fields live on the series anchor; exception rows inherit them.
-  let meeting: MeetingFields | null = null;
-  if (nextEvent) {
-    let source: MeetingFields = nextEvent;
-    if (nextEvent.series_id) {
-      const { data: anchor } = await supabase
-        .from("events")
-        .select(
-          "meeting_url, meeting_id, meeting_passcode, meeting_show_on_dashboard, meeting_lead_minutes"
-        )
-        .eq("id", nextEvent.series_id)
-        .maybeSingle();
-      if (anchor) source = anchor;
-    }
-    if (source.meeting_url && source.meeting_show_on_dashboard) meeting = source;
-  }
-
   // User RSVPs
   let userRsvps: Record<string, Rsvp> = {};
-  const { data: rsvps } = await supabase
-    .from("rsvps")
-    .select("*")
-    .eq("user_id", user.id);
   if (rsvps) {
     userRsvps = Object.fromEntries(rsvps.map((r) => [r.event_id, r]));
   }
 
+  const showGiveTile =
+    (giveTileSetting?.value ?? "on") === "on" &&
+    (liveFundCount ?? 0) > 0;
+  const giveTileSubtitle =
+    liveFundCount === 1 && liveFunds?.[0]
+      ? liveFunds[0].name
+      : `${liveFundCount} funds collecting`;
+
+  const hasLectures = lectures && lectures.length > 0;
+
+  const upcomingServings = (myServings ?? []) as Array<{
+    id: string;
+    service_date: string;
+    group_id: string;
+    member_groups: { id: string; name: string } | Array<{ id: string; name: string }> | null;
+  }>;
+
+  // Meeting fields live on the series anchor; exception rows inherit them.
+  let meeting: MeetingFields | null = null;
   // RSVP counts + attendee names for hero card
   let goingCount = 0;
   let maybeCount = 0;
   let attendeeInitials: string[] = [];
 
+  // Phase B — these depend on `nextEvent`. The anchor lookup and the event's
+  // RSVP list are mutually independent, so fetch them together.
   if (nextEvent) {
-    const { data: eventRsvps } = await supabase
-      .from("rsvps")
-      .select("status, user_id")
-      .eq("event_id", nextEvent.id);
+    const [anchor, { data: eventRsvps }] = await Promise.all([
+      nextEvent.series_id
+        ? supabase
+            .from("events")
+            .select(
+              "meeting_url, meeting_id, meeting_passcode, meeting_show_on_dashboard, meeting_lead_minutes"
+            )
+            .eq("id", nextEvent.series_id)
+            .maybeSingle()
+            .then(({ data }) => data)
+        : Promise.resolve(null),
+      supabase
+        .from("rsvps")
+        .select("status, user_id")
+        .eq("event_id", nextEvent.id),
+    ]);
+
+    let source: MeetingFields = nextEvent;
+    if (anchor) source = anchor;
+    if (source.meeting_url && source.meeting_show_on_dashboard) meeting = source;
 
     if (eventRsvps) {
       goingCount = eventRsvps.filter((r) => r.status === "yes").length;
@@ -198,89 +293,6 @@ export default async function DashboardPage() {
       }
     }
   }
-
-  // Announcements (latest 3)
-  const { data: announcements } = await supabase
-    .from("announcements")
-    .select("*")
-    .eq("is_published", true)
-    .lte("published_at", now)
-    .order("published_at", { ascending: false })
-    .limit(3);
-
-  // Give tile — live funds, gated by the admin toggle. UTC date to match
-  // the retirement filtering on /give and /admin/giving.
-  const today = new Date().toISOString().slice(0, 10);
-  const [{ data: giveTileSetting }, { data: liveFunds, count: liveFundCount }] =
-    await Promise.all([
-      supabase
-        .from("site_settings")
-        .select("value")
-        .eq("key", "giving_dashboard_tile")
-        .maybeSingle(),
-      supabase
-        .from("giving_funds")
-        .select("name", { count: "exact" })
-        .eq("is_active", true)
-        .or(`retire_on.is.null,retire_on.gte.${today}`)
-        .order("display_order")
-        .order("created_at")
-        .limit(1),
-    ]);
-  const showGiveTile =
-    (giveTileSetting?.value ?? "on") === "on" &&
-    (liveFundCount ?? 0) > 0;
-  const giveTileSubtitle =
-    liveFundCount === 1 && liveFunds?.[0]
-      ? liveFunds[0].name
-      : `${liveFundCount} funds collecting`;
-
-  // Counts for quick-actions
-  const { count: eventCount } = await supabase
-    .from("events")
-    .select("id", { count: "exact", head: true })
-    .gte("start_time", now);
-
-  const { count: memberCount } = await supabase
-    .from("profiles")
-    .select("id", { count: "exact", head: true })
-    .neq("role", "pending");
-
-  const thirtyDaysAgo = new Date(new Date(now).getTime() - 30 * 86400000).toISOString();
-  const { count: announcementCount } = await supabase
-    .from("announcements")
-    .select("id", { count: "exact", head: true })
-    .eq("is_published", true)
-    .gte("published_at", thirtyDaysAgo);
-
-  const { count: lectureCount } = await supabase
-    .from("lectures")
-    .select("id", { count: "exact", head: true });
-
-  // Recent lectures for "Continue listening" panel
-  const { data: lectures } = await supabase
-    .from("lectures")
-    .select("id, title, description, lecture_date")
-    .order("lecture_date", { ascending: false })
-    .limit(3);
-
-  const hasLectures = lectures && lectures.length > 0;
-
-  // Upcoming serving commitments for this member (inner join filters to user's rows)
-  const { data: myServings } = await supabase
-    .from("serving_signups")
-    .select("id, service_date, group_id, member_groups(id, name), serving_signup_attendees!inner(profile_id)")
-    .eq("serving_signup_attendees.profile_id", profile.id)
-    .gte("service_date", toDateString(new Date()))
-    .order("service_date", { ascending: true })
-    .limit(3);
-
-  const upcomingServings = (myServings ?? []) as Array<{
-    id: string;
-    service_date: string;
-    group_id: string;
-    member_groups: { id: string; name: string } | Array<{ id: string; name: string }> | null;
-  }>;
 
   // ── render ─────────────────────────────────────────────────────────────────
   return (

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -30,7 +30,6 @@ export default async function EventsPage() {
   const now = new Date();
   const oneYearAgo = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000).toISOString();
   const oneYearAhead = new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000).toISOString();
-  const nowISO = now.toISOString();
 
   // Fetch events within a bounded window for calendar view.
   // Include non-recurring events whose start_time falls in the window, AND
@@ -47,27 +46,9 @@ export default async function EventsPage() {
     .order("start_time", { ascending: true })
     .limit(500);
 
-  // Fetch upcoming events for list view.
-  // Include non-recurring events starting from now, AND recurring anchors whose
-  // series hasn't ended yet (recurrence_until IS NULL or >= now).
-  const upcomingEventsQuery = supabase
-    .from("events")
-    .select("*, calendar:event_calendars(*)")
-    .or(
-      `start_time.gte.${nowISO},` +
-      `and(recurrence_frequency.not.is.null,or(recurrence_until.is.null,recurrence_until.gte.${nowISO}))`
-    )
-    .order("start_time", { ascending: true })
-    .limit(1000);
-
   const { data: allEventsRaw, error: allEventsError } = await allEventsQuery;
   if (allEventsError) {
     console.error("Failed to fetch events:", allEventsError);
-  }
-
-  const { data: upcomingEventsRaw, error: upcomingEventsError } = await upcomingEventsQuery;
-  if (upcomingEventsError) {
-    console.error("Failed to fetch upcoming events:", upcomingEventsError);
   }
 
   // Fetch event calendars
@@ -115,16 +96,12 @@ export default async function EventsPage() {
   const allEvents = (allEventsRaw ?? []) as (Event & {
     calendar?: EventCalendar | null;
   })[];
-  const upcomingEvents = (upcomingEventsRaw ?? []) as (Event & {
-    calendar?: EventCalendar | null;
-  })[];
   const calendars = (calendarsRaw ?? []) as EventCalendar[];
 
   return (
     <div className="container mx-auto px-4 py-12">
       <EventsPageClient
         allEvents={allEvents}
-        upcomingEvents={upcomingEvents}
         calendars={calendars}
         userRsvps={userRsvps}
         userId={user?.id ?? null}

--- a/app/pages/[slug]/PageRenderer.tsx
+++ b/app/pages/[slug]/PageRenderer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { StaticBlockContent } from "@/components/editor/StaticBlockContent";
 import type { PartialBlock } from "@blocknote/core";
 
@@ -8,13 +9,14 @@ interface PageRendererProps {
 }
 
 export function PageRenderer({ body }: PageRendererProps) {
-  let blocks: PartialBlock[] | undefined;
-  try {
-    const parsed = JSON.parse(body);
-    blocks = Array.isArray(parsed) ? parsed : undefined;
-  } catch {
-    blocks = undefined;
-  }
+  const blocks = useMemo<PartialBlock[] | undefined>(() => {
+    try {
+      const parsed = JSON.parse(body);
+      return Array.isArray(parsed) ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  }, [body]);
 
   if (!blocks?.length) {
     return <p className="text-lg text-muted-foreground">This page has no content yet.</p>;

--- a/app/pages/[slug]/PageRenderer.tsx
+++ b/app/pages/[slug]/PageRenderer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BlockEditor } from "@/components/editor";
+import { StaticBlockContent } from "@/components/editor/StaticBlockContent";
 import type { PartialBlock } from "@blocknote/core";
 
 interface PageRendererProps {
@@ -20,5 +20,5 @@ export function PageRenderer({ body }: PageRendererProps) {
     return <p className="text-lg text-muted-foreground">This page has no content yet.</p>;
   }
 
-  return <BlockEditor initialContent={blocks} editable={false} />;
+  return <StaticBlockContent blocks={blocks} />;
 }

--- a/components/announcements/AnnouncementCard.tsx
+++ b/components/announcements/AnnouncementCard.tsx
@@ -2,7 +2,7 @@
 
 import DOMPurify from "dompurify";
 import { Megaphone } from "lucide-react";
-import { BlockEditor } from "@/components/editor";
+import { StaticBlockContent } from "@/components/editor/StaticBlockContent";
 import type { Announcement } from "@/lib/types";
 import type { PartialBlock } from "@blocknote/core";
 
@@ -66,7 +66,7 @@ export function AnnouncementCard({ announcement }: AnnouncementCardProps) {
 
         {blocks ? (
           <div className="text-base text-slate-600 leading-relaxed">
-            <BlockEditor initialContent={blocks} editable={false} />
+            <StaticBlockContent blocks={blocks} />
           </div>
         ) : (
           <div

--- a/components/announcements/AnnouncementCard.tsx
+++ b/components/announcements/AnnouncementCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import DOMPurify from "dompurify";
 import { Megaphone } from "lucide-react";
 import { StaticBlockContent } from "@/components/editor/StaticBlockContent";
@@ -33,7 +34,7 @@ function parseBlocks(content: string): PartialBlock[] | null {
 
 export function AnnouncementCard({ announcement }: AnnouncementCardProps) {
   const date = new Date(announcement.published_at || announcement.created_at);
-  const blocks = parseBlocks(announcement.content);
+  const blocks = useMemo(() => parseBlocks(announcement.content), [announcement.content]);
 
   return (
     <div className="bg-white rounded-2xl border-2 border-border overflow-hidden hover:border-brand-accent/40 hover:shadow-lg transition-all duration-200">

--- a/components/editor/StaticBlockContent.css
+++ b/components/editor/StaticBlockContent.css
@@ -1,0 +1,48 @@
+/* Static read-only BlockNote rendering.
+   Base structural styles (block layout, list markers, inline content) come from
+   BlockNote's core stylesheet; the rules below clone the read-only brand
+   overrides from BlockEditor.css, re-scoped from .bn-editor to .bn-static. */
+
+@import "@blocknote/core/style.css";
+
+/* Text colors and styling */
+.bn-static p,
+.bn-static .bn-block-content {
+  color: var(--foreground) !important;
+  font-family: inherit !important;
+  line-height: 1.75 !important;
+}
+
+/* Heading styling */
+.bn-static h1,
+.bn-static h2,
+.bn-static h3 {
+  color: var(--foreground) !important;
+  font-family: var(--font-display, Georgia, serif) !important;
+  font-weight: 700 !important;
+}
+
+/* List styling */
+.bn-static ul,
+.bn-static ol {
+  margin-left: 1.5rem !important;
+}
+
+/* Code blocks */
+.bn-static pre {
+  background: var(--background, oklch(0.985 0.004 150)) !important;
+  border: 1px solid var(--border, oklch(0.88 0.02 163)) !important;
+  border-radius: 0.5rem !important;
+  padding: 1rem !important;
+}
+
+/* Link styling */
+.bn-static a {
+  color: var(--color-brand-accent, #E8A93C) !important;
+  text-decoration: underline !important;
+}
+
+.bn-static a:hover {
+  color: var(--color-brand-accent, #E8A93C) !important;
+  opacity: 0.8;
+}

--- a/components/editor/StaticBlockContent.tsx
+++ b/components/editor/StaticBlockContent.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import DOMPurify from "dompurify";
+import type { PartialBlock } from "@blocknote/core";
+import { renderBlocksToFullHTML } from "./renderBlocks";
+import "./StaticBlockContent.css";
+
+interface StaticBlockContentProps {
+  blocks: PartialBlock[];
+}
+
+export function StaticBlockContent({ blocks }: StaticBlockContentProps) {
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    renderBlocksToFullHTML(blocks).then((raw) => {
+      if (!cancelled) setHtml(DOMPurify.sanitize(raw));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [blocks]);
+
+  if (html === null) {
+    return <div className="h-64 rounded-lg border border-input bg-muted/30 animate-pulse" />;
+  }
+
+  return <div className="bn-static" dangerouslySetInnerHTML={{ __html: html }} />;
+}

--- a/components/editor/StaticBlockContent.tsx
+++ b/components/editor/StaticBlockContent.tsx
@@ -12,16 +12,26 @@ interface StaticBlockContentProps {
 
 export function StaticBlockContent({ blocks }: StaticBlockContentProps) {
   const [html, setHtml] = useState<string | null>(null);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    renderBlocksToFullHTML(blocks).then((raw) => {
-      if (!cancelled) setHtml(DOMPurify.sanitize(raw));
-    });
+    setError(false);
+    renderBlocksToFullHTML(blocks)
+      .then((raw) => {
+        if (!cancelled) setHtml(DOMPurify.sanitize(raw));
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      });
     return () => {
       cancelled = true;
     };
   }, [blocks]);
+
+  if (error) {
+    return <p className="text-sm text-muted-foreground">Unable to display this content.</p>;
+  }
 
   if (html === null) {
     return <div className="h-64 rounded-lg border border-input bg-muted/30 animate-pulse" />;

--- a/components/editor/renderBlocks.ts
+++ b/components/editor/renderBlocks.ts
@@ -1,0 +1,14 @@
+"use server";
+
+import { ServerBlockNoteEditor } from "@blocknote/server-util";
+import type { PartialBlock } from "@blocknote/core";
+
+// `ServerBlockNoteEditor` renders blocks to HTML using jsdom, which depends on
+// Node built-ins and therefore cannot be bundled into a client component. This
+// server action keeps that work on the server; callers sanitize the returned
+// HTML on the client before injecting it.
+export async function renderBlocksToFullHTML(
+  blocks: PartialBlock[],
+): Promise<string> {
+  return ServerBlockNoteEditor.create().blocksToFullHTML(blocks);
+}

--- a/components/events/EventCalendarView.impl.tsx
+++ b/components/events/EventCalendarView.impl.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import FullCalendar from "@fullcalendar/react";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import timeGridPlugin from "@fullcalendar/timegrid";
+import interactionPlugin from "@fullcalendar/interaction";
+import type { DatesSetArg, EventClickArg, EventInput } from "@fullcalendar/core";
+import type { DateClickArg } from "@fullcalendar/interaction";
+import { buildExceptionMap, expandOccurrences } from "@/lib/recurrence";
+import type { Event, EventCalendar } from "@/lib/types";
+
+interface EventCalendarViewProps {
+  events: (Event & { calendar?: EventCalendar | null })[];
+  visibleCalendarIds: Set<string | null>;
+  isAdmin?: boolean;
+}
+
+export default function EventCalendarView({ events, visibleCalendarIds, isAdmin }: EventCalendarViewProps) {
+  const router = useRouter();
+  const calendarRef = useRef<FullCalendar>(null);
+  const [currentView, setCurrentView] = useState("dayGridMonth");
+
+  const filteredEvents: EventInput[] = useMemo(() => {
+    // Build exception map from all events before filtering by calendar visibility,
+    // so exception rows for hidden calendars still suppress their series occurrences.
+    const exceptions = buildExceptionMap(events);
+
+    const expanded: (Event & { calendar?: EventCalendar | null })[] = [];
+
+    for (const e of events) {
+      if (!visibleCalendarIds.has(e.calendar_id)) continue;
+
+      if (e.series_id) {
+        // Exception event — include directly (not expanded as a series)
+        expanded.push(e);
+      } else if (e.recurrence_frequency) {
+        // Recurring series — expand, skipping exception-covered dates
+        expanded.push(...expandOccurrences(e, exceptions.get(e.id)));
+      } else {
+        expanded.push(e);
+      }
+    }
+
+    return expanded.map((e) => {
+      const color = e.calendar?.color ?? "#2F6BA8";
+      return {
+        id: e.id,
+        title: e.title,
+        start: e.start_time,
+        end: e.end_time ?? undefined,
+        backgroundColor: color,
+        borderColor: color,
+        extendedProps: { event: e },
+      };
+    });
+  }, [events, visibleCalendarIds]);
+
+  const handleEventClick = (info: EventClickArg) => {
+    const event = info.event.extendedProps.event as Event;
+
+    if (event.recurrence_frequency && !event.series_id) {
+      // Recurring series occurrence — pass the occurrence date so the detail
+      // page and edit page know which specific occurrence is being viewed.
+      const occurrence = encodeURIComponent(event.start_time);
+      router.push(`/events/${event.id}?occurrence=${occurrence}`);
+    } else {
+      // Regular event or per-occurrence exception
+      router.push(`/events/${event.id}`);
+    }
+  };
+
+  const handleDateClick = (info: DateClickArg) => {
+    if (!isAdmin) return;
+    const date = info.dateStr.split("T")[0]; // normalize to YYYY-MM-DD
+    router.push(`/admin/events/new?date=${date}`);
+  };
+
+  const handleDatesSet = (arg: DatesSetArg) => {
+    setCurrentView(arg.view.type);
+  };
+
+  useEffect(() => {
+    if (currentView !== "timeGridWeek") return;
+
+    const timeoutId = window.setTimeout(() => {
+      calendarRef.current?.getApi().scrollToTime("08:00:00");
+    }, 0);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [currentView]);
+
+  return (
+    <div className="bg-white rounded-[2rem] border-2 border-border overflow-hidden p-5 shadow-sm [&_.fc-event]:cursor-pointer">
+      <div className="rounded-[1.5rem] border border-slate-100 bg-slate-50/70 p-4 md:p-5">
+        {/* Custom navigation buttons */}
+        <div className="mb-3 flex items-center gap-1.5">
+          <button
+            onClick={() => calendarRef.current?.getApi().prev()}
+            className="cursor-pointer rounded-full border border-slate-200 bg-white p-2 text-slate-600 transition-colors hover:border-brand-primary/30 hover:text-brand-primary"
+            aria-label="Previous month"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+          <button
+            onClick={() => calendarRef.current?.getApi().next()}
+            className="cursor-pointer rounded-full border border-slate-200 bg-white p-2 text-slate-600 transition-colors hover:border-brand-primary/30 hover:text-brand-primary"
+            aria-label="Next month"
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        </div>
+
+        <FullCalendar
+          ref={calendarRef}
+          plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
+          initialView="dayGridMonth"
+          headerToolbar={{
+            left: "today",
+            center: "title",
+            right: "dayGridMonth,timeGridWeek",
+          }}
+          timeZone="America/New_York"
+          events={filteredEvents}
+          eventClick={handleEventClick}
+          dateClick={handleDateClick}
+          datesSet={handleDatesSet}
+          selectable={isAdmin}
+          height={currentView === "timeGridWeek" ? 760 : "auto"}
+          scrollTime="08:00:00"
+          buttonText={{
+            today: "Today",
+            month: "Month",
+            week: "Week",
+          }}
+          views={{
+            timeGridWeek: {
+              slotMinTime: "00:00:00",
+              slotMaxTime: "24:00:00",
+            },
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/events/EventCalendarView.impl.tsx
+++ b/components/events/EventCalendarView.impl.tsx
@@ -92,6 +92,8 @@ export default function EventCalendarView({ events, visibleCalendarIds, isAdmin 
     return () => window.clearTimeout(timeoutId);
   }, [currentView]);
 
+  const navUnit = currentView === "timeGridWeek" ? "week" : "month";
+
   return (
     <div className="bg-white rounded-[2rem] border-2 border-border overflow-hidden p-5 shadow-sm [&_.fc-event]:cursor-pointer">
       <div className="rounded-[1.5rem] border border-slate-100 bg-slate-50/70 p-4 md:p-5">
@@ -100,14 +102,14 @@ export default function EventCalendarView({ events, visibleCalendarIds, isAdmin 
           <button
             onClick={() => calendarRef.current?.getApi().prev()}
             className="cursor-pointer rounded-full border border-slate-200 bg-white p-2 text-slate-600 transition-colors hover:border-brand-primary/30 hover:text-brand-primary"
-            aria-label="Previous month"
+            aria-label={`Previous ${navUnit}`}
           >
             <ChevronLeft className="h-5 w-5" />
           </button>
           <button
             onClick={() => calendarRef.current?.getApi().next()}
             className="cursor-pointer rounded-full border border-slate-200 bg-white p-2 text-slate-600 transition-colors hover:border-brand-primary/30 hover:text-brand-primary"
-            aria-label="Next month"
+            aria-label={`Next ${navUnit}`}
           >
             <ChevronRight className="h-5 w-5" />
           </button>

--- a/components/events/EventCalendarView.tsx
+++ b/components/events/EventCalendarView.tsx
@@ -1,148 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import FullCalendar from "@fullcalendar/react";
-import dayGridPlugin from "@fullcalendar/daygrid";
-import timeGridPlugin from "@fullcalendar/timegrid";
-import interactionPlugin from "@fullcalendar/interaction";
-import type { DatesSetArg, EventClickArg, EventInput } from "@fullcalendar/core";
-import type { DateClickArg } from "@fullcalendar/interaction";
-import { buildExceptionMap, expandOccurrences } from "@/lib/recurrence";
-import type { Event, EventCalendar } from "@/lib/types";
+import dynamic from "next/dynamic";
 
-interface EventCalendarViewProps {
-  events: (Event & { calendar?: EventCalendar | null })[];
-  visibleCalendarIds: Set<string | null>;
-  isAdmin?: boolean;
-}
-
-export function EventCalendarView({ events, visibleCalendarIds, isAdmin }: EventCalendarViewProps) {
-  const router = useRouter();
-  const calendarRef = useRef<FullCalendar>(null);
-  const [currentView, setCurrentView] = useState("dayGridMonth");
-
-  const filteredEvents: EventInput[] = useMemo(() => {
-    // Build exception map from all events before filtering by calendar visibility,
-    // so exception rows for hidden calendars still suppress their series occurrences.
-    const exceptions = buildExceptionMap(events);
-
-    const expanded: (Event & { calendar?: EventCalendar | null })[] = [];
-
-    for (const e of events) {
-      if (!visibleCalendarIds.has(e.calendar_id)) continue;
-
-      if (e.series_id) {
-        // Exception event — include directly (not expanded as a series)
-        expanded.push(e);
-      } else if (e.recurrence_frequency) {
-        // Recurring series — expand, skipping exception-covered dates
-        expanded.push(...expandOccurrences(e, exceptions.get(e.id)));
-      } else {
-        expanded.push(e);
-      }
-    }
-
-    return expanded.map((e) => {
-      const color = e.calendar?.color ?? "#2F6BA8";
-      return {
-        id: e.id,
-        title: e.title,
-        start: e.start_time,
-        end: e.end_time ?? undefined,
-        backgroundColor: color,
-        borderColor: color,
-        extendedProps: { event: e },
-      };
-    });
-  }, [events, visibleCalendarIds]);
-
-  const handleEventClick = (info: EventClickArg) => {
-    const event = info.event.extendedProps.event as Event;
-
-    if (event.recurrence_frequency && !event.series_id) {
-      // Recurring series occurrence — pass the occurrence date so the detail
-      // page and edit page know which specific occurrence is being viewed.
-      const occurrence = encodeURIComponent(event.start_time);
-      router.push(`/events/${event.id}?occurrence=${occurrence}`);
-    } else {
-      // Regular event or per-occurrence exception
-      router.push(`/events/${event.id}`);
-    }
-  };
-
-  const handleDateClick = (info: DateClickArg) => {
-    if (!isAdmin) return;
-    const date = info.dateStr.split("T")[0]; // normalize to YYYY-MM-DD
-    router.push(`/admin/events/new?date=${date}`);
-  };
-
-  const handleDatesSet = (arg: DatesSetArg) => {
-    setCurrentView(arg.view.type);
-  };
-
-  useEffect(() => {
-    if (currentView !== "timeGridWeek") return;
-
-    const timeoutId = window.setTimeout(() => {
-      calendarRef.current?.getApi().scrollToTime("08:00:00");
-    }, 0);
-
-    return () => window.clearTimeout(timeoutId);
-  }, [currentView]);
-
-  return (
-    <div className="bg-white rounded-[2rem] border-2 border-border overflow-hidden p-5 shadow-sm [&_.fc-event]:cursor-pointer">
-      <div className="rounded-[1.5rem] border border-slate-100 bg-slate-50/70 p-4 md:p-5">
-        {/* Custom navigation buttons */}
-        <div className="mb-3 flex items-center gap-1.5">
-          <button
-            onClick={() => calendarRef.current?.getApi().prev()}
-            className="cursor-pointer rounded-full border border-slate-200 bg-white p-2 text-slate-600 transition-colors hover:border-brand-primary/30 hover:text-brand-primary"
-            aria-label="Previous month"
-          >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
-          <button
-            onClick={() => calendarRef.current?.getApi().next()}
-            className="cursor-pointer rounded-full border border-slate-200 bg-white p-2 text-slate-600 transition-colors hover:border-brand-primary/30 hover:text-brand-primary"
-            aria-label="Next month"
-          >
-            <ChevronRight className="h-5 w-5" />
-          </button>
-        </div>
-
-        <FullCalendar
-          ref={calendarRef}
-          plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
-          initialView="dayGridMonth"
-          headerToolbar={{
-            left: "today",
-            center: "title",
-            right: "dayGridMonth,timeGridWeek",
-          }}
-          timeZone="America/New_York"
-          events={filteredEvents}
-          eventClick={handleEventClick}
-          dateClick={handleDateClick}
-          datesSet={handleDatesSet}
-          selectable={isAdmin}
-          height={currentView === "timeGridWeek" ? 760 : "auto"}
-          scrollTime="08:00:00"
-          buttonText={{
-            today: "Today",
-            month: "Month",
-            week: "Week",
-          }}
-          views={{
-            timeGridWeek: {
-              slotMinTime: "00:00:00",
-              slotMaxTime: "24:00:00",
-            },
-          }}
-        />
+export const EventCalendarView = dynamic(
+  () => import("./EventCalendarView.impl"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="bg-white rounded-[2rem] border-2 border-border overflow-hidden p-5 shadow-sm">
+        <div className="h-[560px] rounded-[1.5rem] border border-slate-100 bg-slate-50/70 animate-pulse" />
       </div>
-    </div>
-  );
-}
+    ),
+  },
+);

--- a/components/events/EventsPageClient.tsx
+++ b/components/events/EventsPageClient.tsx
@@ -23,7 +23,6 @@ type View = "calendar" | "list";
 
 interface EventsPageClientProps {
   allEvents: (Event & { calendar?: EventCalendar | null })[];
-  upcomingEvents: (Event & { calendar?: EventCalendar | null })[];
   calendars: EventCalendar[];
   userRsvps: Record<string, Rsvp>;
   userId: string | null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@base-ui/react": "^1.4.0",
         "@blocknote/core": "^0.51.0",
         "@blocknote/react": "^0.51.0",
+        "@blocknote/server-util": "^0.51.4",
         "@blocknote/shadcn": "^0.51.0",
         "@christicons/react": "^0.1.2",
         "@fullcalendar/core": "^6.1.20",
@@ -65,6 +66,25 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -601,6 +621,26 @@
         "react-dom": "^18.0 || ^19.0 || >= 19.0.0-rc"
       }
     },
+    "node_modules/@blocknote/server-util": {
+      "version": "0.51.4",
+      "resolved": "https://registry.npmjs.org/@blocknote/server-util/-/server-util-0.51.4.tgz",
+      "integrity": "sha512-uuQV4Nouhin2UdDm+5jVGHnB51v9iqowJcvkRXvBz0Z7jeKWwbo3oOMC5lloymAhhItRWP61/u8JcHGptv9gZQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@blocknote/core": "0.51.4",
+        "@blocknote/react": "0.51.4",
+        "@tiptap/core": "^3.13.0",
+        "@tiptap/pm": "^3.13.0",
+        "jsdom": "^25.0.1",
+        "y-prosemirror": "^1.3.7",
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.27"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || >= 19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || >= 19.0.0-rc"
+      }
+    },
     "node_modules/@blocknote/shadcn": {
       "version": "0.51.4",
       "resolved": "https://registry.npmjs.org/@blocknote/shadcn/-/shadcn-0.51.4.tgz",
@@ -666,6 +706,116 @@
       },
       "peerDependencies": {
         "react": ">=18"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -4533,6 +4683,15 @@
         "react-dom": ">=18.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -4838,6 +4997,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/atomically": {
       "version": "1.7.0",
@@ -5244,6 +5409,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -5460,6 +5637,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -5472,6 +5668,19 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -5558,6 +5767,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -5663,6 +5878,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -5820,6 +6044,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -5990,7 +6226,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6935,6 +7170,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -7293,7 +7565,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -7343,6 +7614,18 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -7361,6 +7644,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -7849,6 +8158,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -8137,6 +8452,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -8993,6 +9348,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -9361,6 +9722,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -9881,7 +10254,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10275,6 +10647,12 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "license": "MIT"
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -10376,6 +10754,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -11104,6 +11494,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/systeminformation": {
       "version": "5.31.11",
       "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.11.tgz",
@@ -11232,6 +11628,24 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -11258,6 +11672,30 @@
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
       "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -11724,6 +12162,74 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11844,6 +12350,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/wsl-utils": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
@@ -11859,6 +12386,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/y-prosemirror": {
       "version": "1.3.7",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@base-ui/react": "^1.4.0",
     "@blocknote/core": "^0.51.0",
     "@blocknote/react": "^0.51.0",
+    "@blocknote/server-util": "^0.51.0",
     "@blocknote/shadcn": "^0.51.0",
     "@christicons/react": "^0.1.2",
     "@fullcalendar/core": "^6.1.20",


### PR DESCRIPTION
## Refactoring: highest-priority efficiency fixes (P0/P1)

Behavior-preserving optimizations from `EFFICIENCY_REPORT.md`. No user-visible behavior changes — these cut wasted queries, post-login latency, and client bundle weight.

### Motivation

- The events page fired a 1,000-row `select('*')` + join whose result was passed as a prop the client never read.
- The dashboard performed ~10 independent data fetches sequentially, serializing post-login latency.
- FullCalendar (four `@fullcalendar/*` packages) shipped to every visitor, including list-view users who never render a calendar.
- A full BlockNote/ProseMirror editor was mounted (in `editable={false}` mode) solely to render read-only announcement/page content — one heavyweight editor instance per announcement card.

### Before

```
app/events/page.tsx                              138 lines   (dead upcomingEventsQuery, limit 1000)
components/events/EventsPageClient.tsx           265 lines   (unused upcomingEvents prop)
components/events/EventCalendarView.tsx          148 lines   (4 static @fullcalendar/* imports)
app/dashboard/page.tsx                           749 lines   (~10 sequential awaits)
components/announcements/AnnouncementCard.tsx     80 lines   (read-only BlockEditor)
app/pages/[slug]/PageRenderer.tsx                 24 lines   (read-only BlockEditor)
```

### After

```
app/events/page.tsx                             ~123 lines   (query + prop removed)
components/events/EventsPageClient.tsx           264 lines   (upcomingEvents prop removed)
components/events/EventCalendarView.tsx           ~15 lines   next/dynamic wrapper (named export)
components/events/EventCalendarView.impl.tsx    ~148 lines   NEW: FullCalendar implementation (lazy)
components/editor/StaticBlockContent.tsx          ~31 lines   NEW: static block -> HTML renderer
components/editor/StaticBlockContent.css          ~48 lines   NEW: scoped read-only styles
components/editor/renderBlocks.ts                 ~14 lines   NEW: blocksToFullHTML helper
app/dashboard/page.tsx                          ~740 lines   (awaits batched into 2 Promise.all phases)
components/announcements/AnnouncementCard.tsx     80 lines   (blocks branch -> StaticBlockContent)
app/pages/[slug]/PageRenderer.tsx                 24 lines   (blocks branch -> StaticBlockContent)
package.json                                       +1 dep     (@blocknote/server-util)
```

### Changes

- **P0-1 — remove dead events query** (`78eb04a`): deleted `upcomingEventsQuery` (the `limit(1000)` `select('*')` + join), its await/error handling, the cast, and the unused `upcomingEvents` prop/interface field on `EventsPageClient`. List view still derives upcoming occurrences from `allEvents`.
- **P0-2 — batch dashboard awaits** (`a2d47e4`): the ~10 independent fetches (events, rsvps, announcements, give tile, four counts, lectures, servings) now run in one `Promise.all` (Phase A); `nextEvent`-dependent lookups (meeting anchor, event RSVP counts, attendee profiles) stay in a second phase to preserve the data dependency exactly.
- **P0-3 — lazy-load FullCalendar** (`b6ceba6`): the FullCalendar implementation moved to `EventCalendarView.impl.tsx`; `EventCalendarView.tsx` is now a thin `next/dynamic` wrapper (`ssr: false`) with a card-shaped loading placeholder. The named export is preserved so consumers are untouched. List-view users no longer download the four `@fullcalendar/*` packages.
- **P1 — static read-only rendering** (`a7f141a`): read-only content in `AnnouncementCard` and `PageRenderer` now renders stored block JSON to sanitized static HTML via `@blocknote/server-util`'s `blocksToFullHTML` (DOMPurify-sanitized) with scoped CSS cloned from the editor's read-only styles — no more full editor instance per card. The legacy-HTML and empty-state fallback branches are untouched.

### Safety

- [x] Type check passes (`npx tsc --noEmit` — no errors)
- [x] Lint passes (`npm run lint` — no issues)
- [x] Build passes (`npm run build` — all routes compile; dynamic-import and server-util boundaries resolve)
- [x] No automated tests exist in this repo; behavior verified via build + manual spot-checks per the plan
- [x] Public API preserved (`EventCalendarView` named export unchanged; consumer imports untouched)
- [x] Behavior-preserving: no logic changes — only query removal, await reordering, lazy loading, and static rendering
- [x] Each task committed separately for easy review/revert

### Review Guide

Each commit represents one task (P0-1, P0-3, P0-2, P1). Review commits individually for the easiest read — all are behavior-preserving.

Manual checks worth a look before merge: `/events` list + calendar views, `/dashboard` (nextEvent, RSVP counts, attendee initials, counts, lectures, servings, give tile), and read-only content on `/announcements`, `/pages/[slug]`, `/about`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a refreshed events calendar with support for recurring events, exception handling, calendar visibility filters, and improved navigation.
  - Added admin-friendly date selection for creating new events from the calendar.
- **Improvements**
  - Updated dashboard data loading to reduce wait time by fetching multiple datasets in parallel and deriving display values from the results.
  - Streamlined events page loading to use a single events dataset while preserving RSVP and permission behavior.
  - Enhanced announcement/page read-only rendering with safer formatting, memoized parsing, and skeleton/error states.
- **Chores**
  - Added styling for static read-only block rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->