### PR TITLE
feat(ui): redesign foundation — legibility tokens, comfort text scale, app shell

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -23,6 +23,8 @@
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-hover: var(--hover);
   --color-destructive: var(--destructive);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
@@ -49,6 +51,8 @@
   --color-brand-warm: #E2ECF7;
   --color-brand-bg-light: #FAEBC2;
   --color-brand-bg-muted: #E5E0D4;
+  --text-body: var(--fs-body);
+  --text-label: var(--fs-label);
 }
 
 :root {
@@ -63,23 +67,47 @@
   --secondary: #E2ECF7;
   --secondary-foreground: #2F6BA8;
   --muted: #E5E0D4;
-  --muted-foreground: #6E7E94;
+  --muted-foreground: #435066;
   --accent: #E8A93C;
   --accent-foreground: #15243A;
-  --destructive: #EF4444;
-  --border: #E5E0D4;
-  --input: #E5E0D4;
+  --destructive: #B42318;
+  --border: #D8D2C4;
+  --border-strong: #B9C4D4;
+  --hover: #F1EEE4;
+  --input: #D8D2C4;
   --ring: #2F6BA8;
-  --radius: 0.5rem;
+  --radius: 12px;
   --sidebar: #FBFAF5;
   --sidebar-foreground: #15243A;
   --sidebar-primary: #2F6BA8;
   --sidebar-primary-foreground: #FFFFFF;
   --sidebar-accent: #E8A93C;
   --sidebar-accent-foreground: #15243A;
-  --sidebar-border: #E5E0D4;
+  --sidebar-border: #D8D2C4;
   --sidebar-ring: #2F6BA8;
 
+  /* Senior-legibility type scale; scaled up by the data-textsize comfort setting */
+  --fs-body: 19px;
+  --fs-label: 17px;
+  --fs-h1: 40px;
+  --fs-h2: 30px;
+  --fs-h3: 23px;
+}
+
+[data-textsize="large"] {
+  --fs-body: 21px;
+  --fs-label: 18px;
+  --fs-h1: 44px;
+  --fs-h2: 33px;
+  --fs-h3: 25px;
+}
+
+[data-textsize="larger"] {
+  --fs-body: 23px;
+  --fs-label: 19px;
+  --fs-h1: 48px;
+  --fs-h2: 36px;
+  --fs-h3: 27px;
 }
 
 @keyframes float {
@@ -139,7 +167,7 @@
   body {
     @apply bg-background text-foreground;
     font-family: var(--font-sans);
-    font-size: 18px;
+    font-size: var(--fs-body);
     line-height: 1.55;
   }
   html {
@@ -151,13 +179,13 @@
     font-weight: 500;
   }
   h1 {
-    font-size: 2.5rem;
+    font-size: var(--fs-h1);
   }
   h2 {
-    font-size: 1.75rem;
+    font-size: var(--fs-h2);
   }
   h3 {
-    font-size: 1.25rem;
+    font-size: var(--fs-h3);
   }
   h4, h5, h6 {
     line-height: 1.35;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -74,7 +74,7 @@ export default async function RootLayout({
   }
 
   return (
-    <html lang="en" data-scroll-behavior="smooth">
+    <html lang="en" data-scroll-behavior="smooth" suppressHydrationWarning>
       <head>
         <style
           dangerouslySetInnerHTML={{
@@ -88,6 +88,13 @@ export default async function RootLayout({
                 --color-brand-bg-muted: ${siteConfig.colors.backgroundMuted};
               }
             `,
+          }}
+        />
+        {/* Apply the saved comfort text size before first paint to avoid a flash.
+            Must be a raw script (next/script defers past paint). */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var s=localStorage.getItem("textsize");document.documentElement.setAttribute("data-textsize",s==="large"||s==="larger"?s:"normal");}catch(e){document.documentElement.setAttribute("data-textsize","normal");}})();`,
           }}
         />
       </head>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { ProfileForm } from "@/components/profile/ProfileForm";
 import { DirectoryPreview } from "@/components/profile/DirectoryPreview";
+import { TextSizeControl } from "@/components/settings/TextSizeControl";
 import { Button } from "@/components/ui/button";
 import { siteConfig } from "@/lib/config";
 import { Home } from "lucide-react";
@@ -53,6 +54,14 @@ export default async function ProfilePage() {
       </div>
 
       <ProfileForm profile={profile} families={families} isAdmin={false} />
+
+      <div className="mt-8 pt-6 border-t">
+        <h2 className="text-lg font-semibold text-foreground mb-1">Text size</h2>
+        <p className="text-sm text-muted-foreground mb-3">
+          Choose the text size that is easiest for you to read.
+        </p>
+        <TextSizeControl />
+      </div>
 
       {profile.family_id && (
         <div className="mt-8 pt-6 border-t">

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -64,10 +64,7 @@ export function Header({ profile, hasServingAccess }: HeaderProps) {
         scrolled ? "bg-white/95 backdrop-blur shadow-sm" : "bg-white"
       }`}
     >
-      {/* Top accent bar */}
-      <div className="h-1 w-full bg-gradient-to-r from-brand-primary-light via-brand-primary to-brand-accent" />
-
-      <div className="flex h-16 w-full items-center justify-between px-4">
+      <div className="flex h-[72px] w-full items-center justify-between px-4">
         <div className="flex items-center gap-1">
           {/* Desktop: menu button collapses/expands the sidebar pane */}
           {hasDesktopSidebar && (
@@ -109,12 +106,12 @@ export function Header({ profile, hasServingAccess }: HeaderProps) {
                 <SheetTitle className="sr-only">Navigation menu</SheetTitle>
                 <div className="flex flex-col h-full p-4">
                   <div className="flex items-center gap-2 mb-6 mt-1">
-                    <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-brand-primary-light to-brand-primary flex items-center justify-center">
-                      <span className="text-white font-bold text-sm font-display">
+                    <div className="w-11 h-11 rounded-lg bg-gradient-to-br from-brand-primary-light to-brand-primary flex items-center justify-center">
+                      <span className="text-white font-bold text-[24px] font-display">
                         {siteConfig.logoMonogram}
                       </span>
                     </div>
-                    <span className="text-xl font-bold font-display text-brand-primary">
+                    <span className="text-[26px] font-bold font-display text-brand-primary">
                       {siteConfig.name}
                     </span>
                   </div>
@@ -148,12 +145,12 @@ export function Header({ profile, hasServingAccess }: HeaderProps) {
             href={isMember ? "/dashboard" : "/"}
             className="flex items-center gap-2 group"
           >
-            <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-brand-primary-light to-brand-primary flex items-center justify-center shadow-sm group-hover:shadow-md transition-shadow">
-              <span className="text-white font-bold text-sm font-display">
+            <div className="w-11 h-11 rounded-lg bg-gradient-to-br from-brand-primary-light to-brand-primary flex items-center justify-center shadow-sm group-hover:shadow-md transition-shadow">
+              <span className="text-white font-bold text-[24px] font-display">
                 {siteConfig.logoMonogram}
               </span>
             </div>
-            <span className="text-xl font-bold font-display text-brand-primary tracking-tight">
+            <span className="text-[26px] font-bold font-display text-brand-primary tracking-tight">
               {siteConfig.name}
             </span>
           </Link>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -15,7 +15,7 @@ export function Sidebar({ profile, hasServingAccess }: SidebarProps) {
   return (
     <aside
       className={`hidden md:flex flex-col border-r border-border bg-white shrink-0 transition-all duration-200 ${
-        collapsed ? "w-16" : "w-60"
+        collapsed ? "w-16" : "w-[236px]"
       }`}
     >
       <nav

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -105,10 +105,10 @@ export function SidebarNav({
 
   // Soft-blue active state with a primary left bar, per the design system
   const linkClass = (active: boolean) =>
-    `flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm border-l-4 transition-colors ${
+    `flex items-center gap-3 min-h-[52px] px-3 rounded-lg text-label border-l-4 transition-colors ${
       active
         ? "bg-brand-warm text-brand-primary font-bold border-brand-primary"
-        : "border-transparent font-medium text-slate-600 hover:text-brand-primary hover:bg-brand-warm/50"
+        : "border-transparent font-medium text-muted-foreground hover:text-brand-primary hover:bg-hover"
     }`;
 
   const renderLink = (
@@ -124,7 +124,7 @@ export function SidebarNav({
         title={collapsed ? item.label : undefined}
         onClick={onNavigate}
       >
-        <item.icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+        <item.icon className="h-6 w-6 shrink-0" aria-hidden="true" />
         {!collapsed && <span>{item.label}</span>}
       </Link>
     );
@@ -138,20 +138,20 @@ export function SidebarNav({
         className={`flex items-center rounded-lg border-l-4 transition-colors ${
           active
             ? "bg-brand-warm border-brand-primary"
-            : "border-transparent hover:bg-brand-warm/50"
+            : "border-transparent hover:bg-hover"
         }`}
       >
         <Link
           href="/directory"
-          className={`flex flex-1 min-w-0 items-center gap-3 px-3 py-2.5 text-sm transition-colors ${
+          className={`flex flex-1 min-w-0 items-center gap-3 min-h-[52px] px-3 text-label transition-colors ${
             active
               ? "text-brand-primary font-bold"
-              : "font-medium text-slate-600 hover:text-brand-primary"
+              : "font-medium text-muted-foreground hover:text-brand-primary"
           }`}
           aria-current={active ? "page" : undefined}
           onClick={onNavigate}
         >
-          <Users className="h-5 w-5 shrink-0" aria-hidden="true" />
+          <Users className="h-6 w-6 shrink-0" aria-hidden="true" />
           <span>Directory</span>
         </Link>
         <button
@@ -160,7 +160,7 @@ export function SidebarNav({
           aria-label={directoryOpen ? "Collapse directory menu" : "Expand directory menu"}
           aria-expanded={directoryOpen}
           className={`self-stretch px-2.5 transition-colors ${
-            active ? "text-brand-primary" : "text-slate-600 hover:text-brand-primary"
+            active ? "text-brand-primary" : "text-muted-foreground hover:text-brand-primary"
           }`}
         >
           <ChevronDown
@@ -180,10 +180,10 @@ export function SidebarNav({
         <Link
           key={item.href}
           href={item.href}
-          className={`flex items-center pl-11 pr-3 py-2 rounded-lg text-sm border-l-4 transition-colors ${
+          className={`flex items-center min-h-[48px] pl-11 pr-3 rounded-lg text-label border-l-4 transition-colors ${
             active
               ? "bg-brand-warm text-brand-primary font-bold border-brand-primary"
-              : "border-transparent font-medium text-slate-600 hover:text-brand-primary hover:bg-brand-warm/50"
+              : "border-transparent font-medium text-muted-foreground hover:text-brand-primary hover:bg-hover"
           }`}
           aria-current={active ? "page" : undefined}
           onClick={onNavigate}
@@ -208,7 +208,7 @@ export function SidebarNav({
       {pages.length > 0 && (
         <>
           {!collapsed && (
-            <p className="px-3 pt-4 pb-1 text-xs font-semibold uppercase text-slate-400 tracking-wider">
+            <p className="px-3 pt-4 pb-1 text-xs font-semibold uppercase text-muted-foreground tracking-wider">
               Pages
             </p>
           )}
@@ -225,7 +225,7 @@ export function SidebarNav({
                 title={collapsed ? page.title : undefined}
                 onClick={onNavigate}
               >
-                <FileText className="h-5 w-5 shrink-0" aria-hidden="true" />
+                <FileText className="h-6 w-6 shrink-0" aria-hidden="true" />
                 {!collapsed && <span className="truncate">{page.title}</span>}
               </Link>
             );
@@ -236,7 +236,7 @@ export function SidebarNav({
       {isEditor && (
         <>
           {!collapsed && (
-            <p className="px-3 pt-4 pb-1 text-xs font-semibold uppercase text-slate-400 tracking-wider">
+            <p className="px-3 pt-4 pb-1 text-xs font-semibold uppercase text-muted-foreground tracking-wider">
               Admin
             </p>
           )}

--- a/components/settings/TextSizeControl.tsx
+++ b/components/settings/TextSizeControl.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { cn } from "@/lib/utils";
+
+type TextSize = "normal" | "large" | "larger";
+
+const options: { value: TextSize; label: string }[] = [
+  { value: "normal", label: "Normal" },
+  { value: "large", label: "Large" },
+  { value: "larger", label: "Larger" },
+];
+
+export function TextSizeControl() {
+  // Starts null (nothing highlighted) until mounted — the pre-paint script owns
+  // the attribute before hydration, so reading it during render would mismatch.
+  const [active, setActive] = useState<TextSize | null>(null);
+
+  useEffect(() => {
+    const current = document.documentElement.dataset.textsize;
+    setActive(current === "large" || current === "larger" ? current : "normal");
+  }, []);
+
+  const select = (value: TextSize) => {
+    setActive(value);
+    document.documentElement.setAttribute("data-textsize", value);
+    try {
+      localStorage.setItem("textsize", value);
+    } catch {
+      // Storage unavailable — the size still applies for this visit.
+    }
+  };
+
+  return (
+    <div role="group" aria-label="Text size" className="flex flex-wrap gap-2">
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => select(option.value)}
+          aria-pressed={active === option.value}
+          className={cn(
+            "min-h-[48px] px-5 rounded-lg border text-label font-medium transition-colors",
+            active === option.value
+              ? "bg-primary border-primary text-primary-foreground"
+              : "bg-card border-border-strong text-foreground hover:bg-hover",
+          )}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Foundation-only pass of the InCouragers redesign for users aged 50–85. Three concerns, no page rebuilds:

1. **Design tokens** in `app/globals.css` updated to the locked system — darker secondary text for 4.5:1 contrast (`muted-foreground` `#435066`), deepened borders (`#D8D2C4`), new `--border-strong` (`#B9C4D4`), WCAG-safe danger (`#B42318`), 12px radius — plus a **type scale** (`--fs-*`) and a **comfort text-size scale** (`data-textsize` on `<html>`, persisted in `localStorage`, applied before first paint).
2. A small accessible **text-size control** (Normal / Large / Larger) on the profile page.
3. **Restyle** of the existing `Header` and `SidebarNav`/`Sidebar` to the locked design.

Restyle + token update only — all routes, role-based visibility, the collapsible sidebar, and Directory sub-nav behavior are preserved exactly.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `app/globals.css` | UPDATE | Locked token values, `--border-strong`, `--fs-*` type scale + `data-textsize` large/larger overrides, `text-*`/`bg-hover` utilities wired via `@theme` |
| `app/layout.tsx` | UPDATE | Pre-paint inline `<script>` sets `data-textsize` from `localStorage` (no flash); `<html suppressHydrationWarning>` |
| `components/settings/TextSizeControl.tsx` | CREATE | Accessible 3-button comfort control — `role="group"`, `aria-pressed`, ≥48px targets, starts `null` until mounted |
| `app/profile/page.tsx` | UPDATE | Mounts the control in a bordered section mirroring "Manage Household" |
| `components/layout/SidebarNav.tsx` | UPDATE | Row height 52px, 24px icons, 17px labels, `#F1EEE4` hover — class strings only, no logic touched |
| `components/layout/Sidebar.tsx` | UPDATE | Expanded width 236px |
| `components/layout/Header.tsx` | UPDATE | 72px header, serif brand 26px in primary, 44px mark; gradient accent strip removed |

Total: 7 files, +130/-35.

## Tests

None — this repo has **no test runner** (`package.json` has no `test` script). Per the plan, verification = static analysis + build + manual smoke.

Additionally, compiled CSS was inspected to confirm Tailwind v4 generated the new utilities (`.text-label`, `.border-border-strong`, `.hover:bg-hover`, `[data-textsize=large|larger]` overrides).

## Validation

- [x] Type check passes (`npx tsc --noEmit` — exit 0)
- [x] Lint passes (`npm run lint` — no issues)
- [x] Build succeeds (`npm run build` — compiled in 10.1s, all routes)
- [ ] Manual smoke test (Level 3, `npm run dev`) — visual/token/comfort-size behavior; recommended before sign-off

## Implementation Notes

### Plan-sanctioned choices

- **Gradient accent strip removed** from the header — the plan recommended removing it for design fidelity; masthead is now a plain `border-b`.
- **Plain `<button>` elements** used in `TextSizeControl` (plan allowed either these or `@/components/ui/button`) for fully controllable `aria-pressed` styling.

## Suggestions (not implemented)

- Convert page-level `text-slate-400/500/600` literals (~104 files) to `text-muted-foreground`/`text-foreground` tokens.
- Switch form-field borders to `border-strong` (`#B9C4D4`) to match the design's input spec.
- Persist comfort text-size to the member profile (DB) so it follows the user across devices.
- Extract the repeated nav `linkClass` styling into a shared helper once more surfaces adopt it.
- Give the comfort control a permanent home in the later Settings redesign (its profile-page location is temporary).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added text-size controls in Profile settings with Normal, Large, and Larger options.
  * Text-size preferences are remembered between visits.
  * Updated typography to improve readability across body text and headings.

* **Style**
  * Refined header branding, navigation spacing, icons, colors, borders, and sidebar sizing.
  * Improved navigation readability with larger touch targets and clearer visual states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->