### PR TITLE
feat: My Profile + Settings pages from InCouragers redesign

### DIFF
--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -76,9 +76,11 @@ export async function POST(request: Request) {
 
   // Email a copy to the admins — best effort, the row above is the record.
   // Runs after the response so a slow email provider never delays the user.
+  // Uses the service client: the user client's request-scoped cookie store
+  // isn't reliable once the response has been sent.
   after(async () => {
     try {
-      const { data: admins } = await supabase
+      const { data: admins } = await service
         .from("profiles")
         .select("email")
         .eq("role", "admin")

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,0 +1,77 @@
+import { createClient } from "@/lib/supabase/server";
+import { sendFeedbackEmail } from "@/lib/email/resend";
+import { displayName } from "@/lib/names";
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role, first_name, last_name, preferred_name")
+    .eq("id", user.id)
+    .single();
+
+  if (
+    !profile ||
+    !["member", "content_editor", "admin"].includes(profile.role)
+  ) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const type = body?.type;
+  const message = typeof body?.message === "string" ? body.message.trim() : "";
+
+  if (
+    (type !== "idea" && type !== "problem") ||
+    !message ||
+    message.length > 2000
+  ) {
+    return NextResponse.json({ error: "Invalid feedback" }, { status: 400 });
+  }
+
+  const { error: insertError } = await supabase
+    .from("feedback")
+    .insert({ profile_id: user.id, type, message });
+
+  if (insertError) {
+    console.error("Failed to store feedback:", insertError);
+    return NextResponse.json(
+      { error: "Failed to save feedback" },
+      { status: 500 },
+    );
+  }
+
+  // Email a copy to the admins — best effort, the row above is the record.
+  try {
+    const { data: admins } = await supabase
+      .from("profiles")
+      .select("email")
+      .eq("role", "admin")
+      .not("email", "is", null);
+    const emails = (admins ?? [])
+      .map((a) => a.email)
+      .filter((e): e is string => Boolean(e));
+    if (emails.length > 0) {
+      await sendFeedbackEmail(
+        emails,
+        displayName(profile),
+        user.email ?? null,
+        type,
+        message,
+      );
+    }
+  } catch (error) {
+    console.error("Failed to email feedback to admins:", error);
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,7 +1,12 @@
-import { createClient } from "@/lib/supabase/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { sendFeedbackEmail } from "@/lib/email/resend";
 import { displayName } from "@/lib/names";
-import { NextResponse } from "next/server";
+import { NextResponse, after } from "next/server";
+
+// Per-user submission cap. Feedback is a low-volume form; this keeps a
+// stuck client or a hostile script from flooding the table and admin inboxes.
+const RATE_LIMIT = 5;
+const RATE_WINDOW_MS = 60 * 60 * 1000;
 
 export async function POST(request: Request) {
   const supabase = await createClient();
@@ -38,6 +43,25 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid feedback" }, { status: 400 });
   }
 
+  // Throttle per user. RLS only lets admins read feedback rows, so the
+  // count runs on the service client. Fails open — a broken count
+  // shouldn't block feedback.
+  const service = await createServiceClient();
+  const windowStart = new Date(Date.now() - RATE_WINDOW_MS).toISOString();
+  const { count, error: countError } = await service
+    .from("feedback")
+    .select("id", { count: "exact", head: true })
+    .eq("profile_id", user.id)
+    .gte("created_at", windowStart);
+  if (countError) {
+    console.error("Failed to check feedback rate limit:", countError);
+  } else if ((count ?? 0) >= RATE_LIMIT) {
+    return NextResponse.json(
+      { error: "Too many submissions — please try again later" },
+      { status: 429 },
+    );
+  }
+
   const { error: insertError } = await supabase
     .from("feedback")
     .insert({ profile_id: user.id, type, message });
@@ -51,27 +75,30 @@ export async function POST(request: Request) {
   }
 
   // Email a copy to the admins — best effort, the row above is the record.
-  try {
-    const { data: admins } = await supabase
-      .from("profiles")
-      .select("email")
-      .eq("role", "admin")
-      .not("email", "is", null);
-    const emails = (admins ?? [])
-      .map((a) => a.email)
-      .filter((e): e is string => Boolean(e));
-    if (emails.length > 0) {
-      await sendFeedbackEmail(
-        emails,
-        displayName(profile),
-        user.email ?? null,
-        type,
-        message,
-      );
+  // Runs after the response so a slow email provider never delays the user.
+  after(async () => {
+    try {
+      const { data: admins } = await supabase
+        .from("profiles")
+        .select("email")
+        .eq("role", "admin")
+        .not("email", "is", null);
+      const emails = (admins ?? [])
+        .map((a) => a.email)
+        .filter((e): e is string => Boolean(e));
+      if (emails.length > 0) {
+        await sendFeedbackEmail(
+          emails,
+          displayName(profile),
+          user.email ?? null,
+          type,
+          message,
+        );
+      }
+    } catch (error) {
+      console.error("Failed to email feedback to admins:", error);
     }
-  } catch (error) {
-    console.error("Failed to email feedback to admins:", error);
-  }
+  });
 
   return NextResponse.json({ ok: true });
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -63,12 +63,14 @@
   --secondary: #E2ECF7;
   --secondary-foreground: #2F6BA8;
   --muted: #E5E0D4;
-  --muted-foreground: #6E7E94;
+  /* Locked design tokens: secondary text passes 4.5:1, borders deepened
+     for visible edges (senior-legibility corrections from the redesign) */
+  --muted-foreground: #435066;
   --accent: #E8A93C;
   --accent-foreground: #15243A;
   --destructive: #EF4444;
-  --border: #E5E0D4;
-  --input: #E5E0D4;
+  --border: #D8D2C4;
+  --input: #D8D2C4;
   --ring: #2F6BA8;
   --radius: 0.5rem;
   --sidebar: #FBFAF5;
@@ -77,16 +79,16 @@
   --sidebar-primary-foreground: #FFFFFF;
   --sidebar-accent: #E8A93C;
   --sidebar-accent-foreground: #15243A;
-  --sidebar-border: #E5E0D4;
+  --sidebar-border: #D8D2C4;
   --sidebar-ring: #2F6BA8;
 
 }
 
 /* ============================================================
    Display preferences (Settings → Display)
-   data-textsize / data-contrast are set on <html> by the inline
-   script in app/layout.tsx (from localStorage) and by the
-   Settings page controls.
+   data-textsize is set on <html> by the inline script in
+   app/layout.tsx (from localStorage) and by the Settings page
+   text-size control.
    ============================================================ */
 
 /* Text size: scale the Tailwind font-size variables so every
@@ -112,16 +114,6 @@ html[data-textsize="large"] {
 
 html[data-textsize="larger"] {
   --text-scale: 1.22;
-}
-
-/* Higher contrast: darker secondary text and stronger edges. */
-html[data-contrast="high"] {
-  --muted-foreground: #435066;
-  --border: #C9C2B0;
-  --input: #C9C2B0;
-  --color-slate-400: #64748B;
-  --color-slate-500: #435066;
-  --color-slate-600: #334155;
 }
 
 @keyframes float {

--- a/app/globals.css
+++ b/app/globals.css
@@ -82,6 +82,48 @@
 
 }
 
+/* ============================================================
+   Display preferences (Settings → Display)
+   data-textsize / data-contrast are set on <html> by the inline
+   script in app/layout.tsx (from localStorage) and by the
+   Settings page controls.
+   ============================================================ */
+
+/* Text size: scale the Tailwind font-size variables so every
+   text-* utility follows the chosen comfort level. Unlayered
+   :root wins over the @layer theme defaults. Line heights are
+   ratios in Tailwind v4, so they scale along automatically. */
+:root {
+  --text-scale: 1;
+  --text-xs: calc(0.75rem * var(--text-scale));
+  --text-sm: calc(0.875rem * var(--text-scale));
+  --text-base: calc(1rem * var(--text-scale));
+  --text-lg: calc(1.125rem * var(--text-scale));
+  --text-xl: calc(1.25rem * var(--text-scale));
+  --text-2xl: calc(1.5rem * var(--text-scale));
+  --text-3xl: calc(1.875rem * var(--text-scale));
+  --text-4xl: calc(2.25rem * var(--text-scale));
+  --text-5xl: calc(3rem * var(--text-scale));
+}
+
+html[data-textsize="large"] {
+  --text-scale: 1.11;
+}
+
+html[data-textsize="larger"] {
+  --text-scale: 1.22;
+}
+
+/* Higher contrast: darker secondary text and stronger edges. */
+html[data-contrast="high"] {
+  --muted-foreground: #435066;
+  --border: #C9C2B0;
+  --input: #C9C2B0;
+  --color-slate-400: #64748B;
+  --color-slate-500: #435066;
+  --color-slate-600: #334155;
+}
+
 @keyframes float {
   0%, 100% { transform: translateY(0px) scale(1); }
   50% { transform: translateY(-24px) scale(1.04); }
@@ -139,7 +181,7 @@
   body {
     @apply bg-background text-foreground;
     font-family: var(--font-sans);
-    font-size: 18px;
+    font-size: calc(18px * var(--text-scale));
     line-height: 1.55;
   }
   html {
@@ -151,13 +193,13 @@
     font-weight: 500;
   }
   h1 {
-    font-size: 2.5rem;
+    font-size: calc(2.5rem * var(--text-scale));
   }
   h2 {
-    font-size: 1.75rem;
+    font-size: calc(1.75rem * var(--text-scale));
   }
   h3 {
-    font-size: 1.25rem;
+    font-size: calc(1.25rem * var(--text-scale));
   }
   h4, h5, h6 {
     line-height: 1.35;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -76,9 +76,9 @@ export default async function RootLayout({
   }
 
   return (
-    // suppressHydrationWarning: the head script sets data-textsize/-contrast
-    // on <html> before React hydrates, and browsers mask script nonces so the
-    // client always reads them as "" — both are expected mismatches.
+    // suppressHydrationWarning: the head script sets data-textsize on <html>
+    // before React hydrates, and browsers mask script nonces so the client
+    // always reads them as "" — both are expected mismatches.
     <html lang="en" data-scroll-behavior="smooth" suppressHydrationWarning>
       <head>
         {/* Apply saved display preferences before first paint */}
@@ -86,7 +86,7 @@ export default async function RootLayout({
           nonce={nonce}
           suppressHydrationWarning
           dangerouslySetInnerHTML={{
-            __html: `try{var d=document.documentElement,t=localStorage.getItem("pref-textsize");if(t==="large"||t==="larger")d.dataset.textsize=t;if(localStorage.getItem("pref-contrast")==="high")d.dataset.contrast="high"}catch(e){}`,
+            __html: `try{var t=localStorage.getItem("pref-textsize");if(t==="large"||t==="larger")document.documentElement.dataset.textsize=t}catch(e){}`,
           }}
         />
         <style

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,7 @@ import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { AppShell } from "@/components/layout/AppShell";
 import { SidebarProvider } from "@/components/layout/SidebarContext";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { siteConfig } from "@/lib/config";
 import "./globals.css";
@@ -46,6 +46,8 @@ export default async function RootLayout({
   // Skip the getUser() call entirely when there are no auth cookies.
   // This avoids noisy "Invalid Refresh Token" errors for unauthenticated visitors.
   const cookieStore = await cookies();
+  // CSP allows inline scripts only with the per-request nonce
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
   const hasAuthCookie = cookieStore.getAll().some((c) => c.name.includes("auth-token"));
 
   let profile = null;
@@ -74,8 +76,19 @@ export default async function RootLayout({
   }
 
   return (
-    <html lang="en" data-scroll-behavior="smooth">
+    // suppressHydrationWarning: the head script sets data-textsize/-contrast
+    // on <html> before React hydrates, and browsers mask script nonces so the
+    // client always reads them as "" — both are expected mismatches.
+    <html lang="en" data-scroll-behavior="smooth" suppressHydrationWarning>
       <head>
+        {/* Apply saved display preferences before first paint */}
+        <script
+          nonce={nonce}
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{
+            __html: `try{var d=document.documentElement,t=localStorage.getItem("pref-textsize");if(t==="large"||t==="larger")d.dataset.textsize=t;if(localStorage.getItem("pref-contrast")==="high")d.dataset.contrast="high"}catch(e){}`,
+          }}
+        />
         <style
           dangerouslySetInnerHTML={{
             __html: `

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,12 +1,8 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
-import Link from "next/link";
-import { ProfileForm } from "@/components/profile/ProfileForm";
-import { DirectoryPreview } from "@/components/profile/DirectoryPreview";
-import { Button } from "@/components/ui/button";
+import { MyProfileView, type HouseholdEntry } from "@/components/profile/MyProfileView";
 import { siteConfig } from "@/lib/config";
-import { Home } from "lucide-react";
-import type { Profile, FamilyUnit } from "@/lib/types";
+import type { Profile, FamilyUnit, FamilyMember } from "@/lib/types";
 
 export const metadata = { title: `My Profile | ${siteConfig.name}` };
 
@@ -34,42 +30,54 @@ export default async function ProfilePage() {
     redirect("/profile/setup");
   }
 
-  // Members don't reassign their own family — but we still need the form
-  // component to render the family tab disabled, so pass an empty list.
-  const families: FamilyUnit[] = [];
+  let family: FamilyUnit | null = null;
+  let householdProfiles: HouseholdEntry[] = [];
+  let familyMembers: FamilyMember[] = [];
+
+  if (profile.family_id) {
+    const [{ data: f }, { data: others }, { data: fms }] = await Promise.all([
+      supabase
+        .from("family_units")
+        .select("*")
+        .eq("id", profile.family_id)
+        .maybeSingle<FamilyUnit>(),
+      // Other enrolled household members, with privacy masking applied so
+      // the tiles show what the directory shows.
+      supabase
+        .from("profiles_directory")
+        .select(
+          "id, first_name, last_name, preferred_name, avatar_url, relationship, email, phone_mobile",
+        )
+        .eq("family_id", profile.family_id)
+        .neq("id", user.id)
+        .order("first_name")
+        .returns<HouseholdEntry[]>(),
+      // Family members without accounts (children etc.)
+      supabase
+        .from("family_members")
+        .select("*")
+        .eq("family_id", profile.family_id)
+        .is("claimed_profile_id", null)
+        .order("relationship")
+        .returns<FamilyMember[]>(),
+    ]);
+    family = f ?? null;
+    householdProfiles = others ?? [];
+    familyMembers = fms ?? [];
+  }
 
   return (
-    <div className="container mx-auto px-4 py-12 max-w-3xl">
-      <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-2">
+    <div className="container mx-auto max-w-3xl px-4 py-12">
+      <h1 className="mb-6 text-3xl font-bold text-brand-primary md:text-4xl">
         My Profile
       </h1>
-      <p className="text-base text-muted-foreground mb-4">
-        Your contact info for the member directory. Privacy controls let you
-        hide specific fields from other members.
-      </p>
 
-      <div className="mb-8">
-        <DirectoryPreview />
-      </div>
-
-      <ProfileForm profile={profile} families={families} isAdmin={false} />
-
-      {profile.family_id && (
-        <div className="mt-8 pt-6 border-t">
-          <Button
-            variant="outline"
-            nativeButton={false}
-            render={<Link href="/household" />}
-            className="w-full sm:w-auto"
-          >
-            <Home className="mr-2 h-4 w-4" />
-            Manage Household
-          </Button>
-          <p className="text-sm text-muted-foreground mt-2">
-            Update your household&apos;s address, home phone, and family members.
-          </p>
-        </div>
-      )}
+      <MyProfileView
+        profile={profile}
+        family={family}
+        householdProfiles={householdProfiles}
+        familyMembers={familyMembers}
+      />
     </div>
   );
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -35,7 +35,7 @@ export default async function ProfilePage() {
   let familyMembers: FamilyMember[] = [];
 
   if (profile.family_id) {
-    const [{ data: f }, { data: others }, { data: fms }] = await Promise.all([
+    const [familyRes, othersRes, fmsRes] = await Promise.all([
       supabase
         .from("family_units")
         .select("*")
@@ -61,9 +61,15 @@ export default async function ProfilePage() {
         .order("relationship")
         .returns<FamilyMember[]>(),
     ]);
-    family = f ?? null;
-    householdProfiles = others ?? [];
-    familyMembers = fms ?? [];
+    // Fail loudly rather than rendering an empty household over a query error.
+    const queryError = familyRes.error ?? othersRes.error ?? fmsRes.error;
+    if (queryError) {
+      console.error("Failed to load household data:", queryError);
+      throw new Error("Failed to load your household information.");
+    }
+    family = familyRes.data ?? null;
+    householdProfiles = othersRes.data ?? [];
+    familyMembers = fmsRes.data ?? [];
   }
 
   return (

--- a/app/settings/DisplayCard.tsx
+++ b/app/settings/DisplayCard.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Segmented } from "./Segmented";
+
+type TextSize = "normal" | "large" | "larger";
+
+const TEXT_SIZE_OPTIONS: { value: TextSize; label: string }[] = [
+  { value: "normal", label: "Normal" },
+  { value: "large", label: "Large" },
+  { value: "larger", label: "Larger" },
+];
+
+function persist(key: string, value: string | null) {
+  try {
+    if (value === null) localStorage.removeItem(key);
+    else localStorage.setItem(key, value);
+  } catch {
+    // Private browsing can block storage; the choice still applies this visit.
+  }
+}
+
+export function DisplayCard() {
+  const [textSize, setTextSize] = useState<TextSize>("normal");
+  const [highContrast, setHighContrast] = useState(false);
+
+  // The <head> script applied saved prefs before paint; sync state to it.
+  useEffect(() => {
+    const root = document.documentElement;
+    const saved = root.dataset.textsize;
+    if (saved === "large" || saved === "larger") setTextSize(saved);
+    setHighContrast(root.dataset.contrast === "high");
+  }, []);
+
+  const applyTextSize = (size: TextSize) => {
+    setTextSize(size);
+    const root = document.documentElement;
+    if (size === "normal") {
+      delete root.dataset.textsize;
+      persist("pref-textsize", null);
+    } else {
+      root.dataset.textsize = size;
+      persist("pref-textsize", size);
+    }
+  };
+
+  const applyContrast = (on: boolean) => {
+    setHighContrast(on);
+    const root = document.documentElement;
+    if (on) {
+      root.dataset.contrast = "high";
+      persist("pref-contrast", "high");
+    } else {
+      delete root.dataset.contrast;
+      persist("pref-contrast", null);
+    }
+  };
+
+  return (
+    <Card>
+      <CardContent className="space-y-5 pt-6">
+        <h3>Display</h3>
+
+        <div className="space-y-2">
+          <Label className="text-base">Text size</Label>
+          <div>
+            <Segmented
+              label="Text size"
+              options={TEXT_SIZE_OPTIONS}
+              value={textSize}
+              onChange={applyTextSize}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-4 border-t border-border pt-5">
+          <div>
+            <Label htmlFor="high-contrast" className="text-base font-semibold">
+              Higher contrast
+            </Label>
+            <p className="text-sm text-muted-foreground">
+              Darker text and stronger edges — easier to read.
+            </p>
+          </div>
+          <Switch
+            id="high-contrast"
+            checked={highContrast}
+            onCheckedChange={applyContrast}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/settings/DisplayCard.tsx
+++ b/app/settings/DisplayCard.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import { Segmented } from "./Segmented";
 
 type TextSize = "normal" | "large" | "larger";
@@ -25,14 +24,11 @@ function persist(key: string, value: string | null) {
 
 export function DisplayCard() {
   const [textSize, setTextSize] = useState<TextSize>("normal");
-  const [highContrast, setHighContrast] = useState(false);
 
-  // The <head> script applied saved prefs before paint; sync state to it.
+  // The <head> script applied the saved pref before paint; sync state to it.
   useEffect(() => {
-    const root = document.documentElement;
-    const saved = root.dataset.textsize;
+    const saved = document.documentElement.dataset.textsize;
     if (saved === "large" || saved === "larger") setTextSize(saved);
-    setHighContrast(root.dataset.contrast === "high");
   }, []);
 
   const applyTextSize = (size: TextSize) => {
@@ -44,18 +40,6 @@ export function DisplayCard() {
     } else {
       root.dataset.textsize = size;
       persist("pref-textsize", size);
-    }
-  };
-
-  const applyContrast = (on: boolean) => {
-    setHighContrast(on);
-    const root = document.documentElement;
-    if (on) {
-      root.dataset.contrast = "high";
-      persist("pref-contrast", "high");
-    } else {
-      delete root.dataset.contrast;
-      persist("pref-contrast", null);
     }
   };
 
@@ -74,22 +58,6 @@ export function DisplayCard() {
               onChange={applyTextSize}
             />
           </div>
-        </div>
-
-        <div className="flex items-center justify-between gap-4 border-t border-border pt-5">
-          <div>
-            <Label htmlFor="high-contrast" className="text-base font-semibold">
-              Higher contrast
-            </Label>
-            <p className="text-sm text-muted-foreground">
-              Darker text and stronger edges — easier to read.
-            </p>
-          </div>
-          <Switch
-            id="high-contrast"
-            checked={highContrast}
-            onCheckedChange={applyContrast}
-          />
         </div>
       </CardContent>
     </Card>

--- a/app/settings/FeedbackCard.tsx
+++ b/app/settings/FeedbackCard.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Send } from "lucide-react";
+import { toast } from "sonner";
+import { Segmented } from "./Segmented";
+
+type FeedbackType = "idea" | "problem";
+
+const TYPE_OPTIONS: { value: FeedbackType; label: string }[] = [
+  { value: "idea", label: "An idea" },
+  { value: "problem", label: "Something's broken" },
+];
+
+export function FeedbackCard() {
+  const [type, setType] = useState<FeedbackType>("idea");
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmed = message.trim();
+    if (!trimmed) {
+      toast.error("Please write a short note first.");
+      return;
+    }
+
+    setSending(true);
+    const res = await fetch("/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type, message: trimmed }),
+    });
+    setSending(false);
+
+    if (!res.ok) {
+      toast.error("Failed to send your feedback. Please try again.");
+      return;
+    }
+
+    setMessage("");
+    toast.success("Thank you — your feedback has been sent.");
+  };
+
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <h3 className="mb-2">Feedback</h3>
+        <p className="mb-5 text-muted-foreground">
+          Spotted a problem, or have an idea to make the app better? Tell us
+          here.
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="space-y-2">
+            <Label className="text-base">What kind of feedback is this?</Label>
+            <div>
+              <Segmented
+                label="Feedback type"
+                options={TYPE_OPTIONS}
+                value={type}
+                onChange={setType}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="feedback-message" className="text-base">
+              Tell us what happened, or what you&apos;d like
+            </Label>
+            <Textarea
+              id="feedback-message"
+              rows={3}
+              maxLength={2000}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              className="text-base"
+            />
+          </div>
+
+          <Button type="submit" disabled={sending || !message.trim()}>
+            <Send className="mr-2 h-4 w-4" />
+            {sending ? "Sending..." : "Send my feedback"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/settings/FeedbackCard.tsx
+++ b/app/settings/FeedbackCard.tsx
@@ -30,20 +30,25 @@ export function FeedbackCard() {
     }
 
     setSending(true);
-    const res = await fetch("/api/feedback", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ type, message: trimmed }),
-    });
-    setSending(false);
+    try {
+      const res = await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type, message: trimmed }),
+      });
 
-    if (!res.ok) {
+      if (!res.ok) {
+        toast.error("Failed to send your feedback. Please try again.");
+        return;
+      }
+
+      setMessage("");
+      toast.success("Thank you — your feedback has been sent.");
+    } catch {
       toast.error("Failed to send your feedback. Please try again.");
-      return;
+    } finally {
+      setSending(false);
     }
-
-    setMessage("");
-    toast.success("Thank you — your feedback has been sent.");
   };
 
   return (

--- a/app/settings/NotificationsCard.tsx
+++ b/app/settings/NotificationsCard.tsx
@@ -19,9 +19,13 @@ export function NotificationsCard({
   const [emailAnnouncements, setEmailAnnouncements] = useState(
     initialEmailAnnouncements,
   );
+  const [saving, setSaving] = useState(false);
   const supabase = createClient();
 
+  // The switch is disabled while a save is pending, so updates can't
+  // overlap and a stale response can't clobber a newer selection.
   const handleChange = async (next: boolean) => {
+    setSaving(true);
     setEmailAnnouncements(next);
     const { error } = await supabase
       .from("profiles")
@@ -32,6 +36,7 @@ export function NotificationsCard({
       setEmailAnnouncements(!next);
       toast.error("Couldn't save that. Please try again.");
     }
+    setSaving(false);
   };
 
   return (
@@ -46,6 +51,7 @@ export function NotificationsCard({
             id="email-announcements"
             checked={emailAnnouncements}
             onCheckedChange={handleChange}
+            disabled={saving}
           />
         </div>
       </CardContent>

--- a/app/settings/NotificationsCard.tsx
+++ b/app/settings/NotificationsCard.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { toast } from "sonner";
+
+interface NotificationsCardProps {
+  userId: string;
+  initialEmailAnnouncements: boolean;
+}
+
+export function NotificationsCard({
+  userId,
+  initialEmailAnnouncements,
+}: NotificationsCardProps) {
+  const [emailAnnouncements, setEmailAnnouncements] = useState(
+    initialEmailAnnouncements,
+  );
+  const supabase = createClient();
+
+  const handleChange = async (next: boolean) => {
+    setEmailAnnouncements(next);
+    const { error } = await supabase
+      .from("profiles")
+      .update({ email_announcements: next })
+      .eq("id", userId);
+    if (error) {
+      console.error(error);
+      setEmailAnnouncements(!next);
+      toast.error("Couldn't save that. Please try again.");
+    }
+  };
+
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <h3 className="mb-4">Notifications</h3>
+        <div className="flex items-center justify-between gap-4">
+          <Label htmlFor="email-announcements" className="text-base font-semibold">
+            Email me new announcements
+          </Label>
+          <Switch
+            id="email-announcements"
+            checked={emailAnnouncements}
+            onCheckedChange={handleChange}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/settings/Segmented.tsx
+++ b/app/settings/Segmented.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+interface SegmentedProps<T extends string> {
+  label: string;
+  options: { value: T; label: string }[];
+  value: T;
+  onChange: (value: T) => void;
+}
+
+/** Word-labeled segmented control (design system .seg — never color alone) */
+export function Segmented<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+}: SegmentedProps<T>) {
+  return (
+    <div
+      role="group"
+      aria-label={label}
+      className="inline-flex flex-wrap gap-1 rounded-xl border border-input bg-card p-1"
+    >
+      {options.map((option) => {
+        const active = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(option.value)}
+            className={`min-h-11 rounded-lg px-5 text-base font-semibold transition-colors ${
+              active
+                ? "bg-brand-primary text-white"
+                : "text-foreground hover:bg-brand-warm"
+            }`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/settings/SignInSecurityCard.tsx
+++ b/app/settings/SignInSecurityCard.tsx
@@ -213,9 +213,9 @@ export function SignInSecurityCard({ currentEmail }: SignInSecurityCardProps) {
                 autoComplete="new-password"
               />
               <p className="text-sm text-muted-foreground">
-                At least 8 characters. Tip: a short phrase like{" "}
-                <strong>Coffee-Garden-1968!</strong> is easy to remember and
-                very strong.
+                At least 8 characters. Tip: a short phrase of a few unrelated
+                words with a number or symbol is easy to remember and very
+                strong.
               </p>
             </div>
 

--- a/app/settings/SignInSecurityCard.tsx
+++ b/app/settings/SignInSecurityCard.tsx
@@ -2,24 +2,104 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { normalizeEmail } from "@/lib/sanitize";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Separator } from "@/components/ui/separator";
-import { KeyRound, Mail } from "lucide-react";
+import { Check, KeyRound, LogOut, Mail } from "lucide-react";
 import { toast } from "sonner";
 
 interface SignInSecurityCardProps {
   currentEmail: string;
 }
 
+function PasswordInput({
+  id,
+  value,
+  onChange,
+  autoComplete,
+}: {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+  autoComplete: string;
+}) {
+  const [show, setShow] = useState(false);
+  return (
+    <div className="relative">
+      <Input
+        id={id}
+        type={show ? "text" : "password"}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        autoComplete={autoComplete}
+        className="py-5 pr-20 text-base"
+      />
+      <button
+        type="button"
+        onClick={() => setShow((s) => !s)}
+        className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded-md bg-brand-warm px-3 py-1.5 text-sm font-semibold text-brand-primary"
+      >
+        {show ? "Hide" : "Show"}
+      </button>
+    </div>
+  );
+}
+
 export function SignInSecurityCard({ currentEmail }: SignInSecurityCardProps) {
+  const [panel, setPanel] = useState<"none" | "password" | "email">("none");
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [newEmail, setNewEmail] = useState("");
-  const [sending, setSending] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const router = useRouter();
   const supabase = createClient();
+
+  const togglePanel = (target: "password" | "email") =>
+    setPanel((p) => (p === target ? "none" : target));
+
+  const handlePasswordSave = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (newPassword.length < 8) {
+      toast.error("Your new password needs at least 8 characters.");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      toast.error("The new passwords don't match. Please type them again.");
+      return;
+    }
+
+    setBusy(true);
+    // Confirm it's really them before changing the password
+    const { error: verifyError } = await supabase.auth.signInWithPassword({
+      email: currentEmail,
+      password: currentPassword,
+    });
+    if (verifyError) {
+      setBusy(false);
+      toast.error("That current password doesn't look right.");
+      return;
+    }
+
+    const { error } = await supabase.auth.updateUser({ password: newPassword });
+    setBusy(false);
+
+    if (error) {
+      console.error(error);
+      toast.error("Failed to update your password. Please try again.");
+      return;
+    }
+
+    setCurrentPassword("");
+    setNewPassword("");
+    setConfirmPassword("");
+    setPanel("none");
+    toast.success("Your password has been updated.");
+  };
 
   const handleEmailChange = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -33,9 +113,9 @@ export function SignInSecurityCard({ currentEmail }: SignInSecurityCardProps) {
       return;
     }
 
-    setSending(true);
+    setBusy(true);
     const { error } = await supabase.auth.updateUser({ email });
-    setSending(false);
+    setBusy(false);
 
     if (error) {
       console.error(error);
@@ -44,60 +124,169 @@ export function SignInSecurityCard({ currentEmail }: SignInSecurityCardProps) {
     }
 
     setNewEmail("");
+    setPanel("none");
     toast.success(
       "Confirmation links sent. Check your old and new inboxes to finish the change.",
     );
   };
 
+  const handleSignOut = async () => {
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      toast.error("Sign out failed — please try again.");
+      return;
+    }
+    router.push("/");
+    router.refresh();
+  };
+
   return (
     <Card>
-      <CardContent className="space-y-5 pt-6">
-        <h3>Sign in &amp; security</h3>
+      <CardContent className="pt-6">
+        <h3 className="mb-2">Sign in &amp; security</h3>
+        <p className="mb-5 text-muted-foreground">
+          You&apos;re signed in as{" "}
+          <strong className="text-foreground">{currentEmail}</strong>
+        </p>
 
-        <form onSubmit={handleEmailChange} className="space-y-2">
-          <Label htmlFor="new_email" className="text-base">
-            Email
-          </Label>
-          <p className="text-sm text-muted-foreground">
-            You sign in as <strong>{currentEmail}</strong>. Enter a new email
-            below and we&apos;ll send confirmation links to both addresses.
-          </p>
-          <div className="flex flex-col gap-3 sm:flex-row">
-            <Input
-              id="new_email"
-              type="email"
-              value={newEmail}
-              onChange={(e) => setNewEmail(e.target.value)}
-              placeholder="new.email@example.com"
-              className="py-5 text-base"
-            />
-            <Button
-              type="submit"
-              variant="outline"
-              disabled={sending || !newEmail}
-              className="shrink-0"
-            >
-              <Mail className="mr-2 h-4 w-4" />
-              {sending ? "Sending..." : "Change my email"}
-            </Button>
-          </div>
-        </form>
-
-        <Separator />
-
-        <div className="space-y-2">
-          <Label className="text-base">Password</Label>
-          <div>
-            <Button
-              variant="outline"
-              nativeButton={false}
-              render={<Link href="/update-password" />}
-            >
-              <KeyRound className="mr-2 h-4 w-4" />
-              Change my password
-            </Button>
-          </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            variant="outline"
+            onClick={() => togglePanel("password")}
+            aria-expanded={panel === "password"}
+          >
+            <KeyRound className="mr-2 h-4 w-4" />
+            Change my password
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => togglePanel("email")}
+            aria-expanded={panel === "email"}
+          >
+            <Mail className="mr-2 h-4 w-4" />
+            Change my email
+          </Button>
+          <Button
+            variant="outline"
+            onClick={handleSignOut}
+            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+          >
+            <LogOut className="mr-2 h-4 w-4" />
+            Sign out
+          </Button>
         </div>
+
+        {panel === "password" && (
+          <form
+            onSubmit={handlePasswordSave}
+            className="mt-6 space-y-5 border-t border-border pt-6"
+          >
+            <div className="space-y-2">
+              <Label htmlFor="current-password" className="text-base">
+                Current password
+              </Label>
+              <PasswordInput
+                id="current-password"
+                value={currentPassword}
+                onChange={setCurrentPassword}
+                autoComplete="current-password"
+              />
+              <p className="text-sm text-muted-foreground">
+                Can&apos;t remember it?{" "}
+                <Link
+                  href="/forgot-password"
+                  className="font-semibold text-brand-primary underline underline-offset-2"
+                >
+                  We&apos;ll email you a link to reset it.
+                </Link>
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="new-password" className="text-base">
+                New password
+              </Label>
+              <PasswordInput
+                id="new-password"
+                value={newPassword}
+                onChange={setNewPassword}
+                autoComplete="new-password"
+              />
+              <p className="text-sm text-muted-foreground">
+                At least 8 characters. Tip: a short phrase like{" "}
+                <strong>Coffee-Garden-1968!</strong> is easy to remember and
+                very strong.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="confirm-password" className="text-base">
+                Type your new password again
+              </Label>
+              <PasswordInput
+                id="confirm-password"
+                value={confirmPassword}
+                onChange={setConfirmPassword}
+                autoComplete="new-password"
+              />
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <Button type="submit" disabled={busy || !currentPassword || !newPassword}>
+                <Check className="mr-2 h-4 w-4" />
+                {busy ? "Saving..." : "Save my new password"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setPanel("none")}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        )}
+
+        {panel === "email" && (
+          <form
+            onSubmit={handleEmailChange}
+            className="mt-6 space-y-3 border-t border-border pt-6"
+          >
+            <Label htmlFor="new-email" className="text-base">
+              New email address
+            </Label>
+            <p className="text-sm text-muted-foreground">
+              We&apos;ll send confirmation links to your old and new addresses;
+              the change happens after you click both.
+            </p>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Input
+                id="new-email"
+                type="email"
+                value={newEmail}
+                onChange={(e) => setNewEmail(e.target.value)}
+                placeholder="new.email@example.com"
+                className="py-5 text-base"
+              />
+              <Button
+                type="submit"
+                variant="outline"
+                disabled={busy || !newEmail}
+                className="shrink-0"
+              >
+                <Mail className="mr-2 h-4 w-4" />
+                {busy ? "Sending..." : "Send confirmation links"}
+              </Button>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setPanel("none")}
+            >
+              Cancel
+            </Button>
+          </form>
+        )}
       </CardContent>
     </Card>
   );

--- a/app/settings/SignInSecurityCard.tsx
+++ b/app/settings/SignInSecurityCard.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import { normalizeEmail } from "@/lib/sanitize";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { KeyRound, Mail } from "lucide-react";
+import { toast } from "sonner";
+
+interface SignInSecurityCardProps {
+  currentEmail: string;
+}
+
+export function SignInSecurityCard({ currentEmail }: SignInSecurityCardProps) {
+  const [newEmail, setNewEmail] = useState("");
+  const [sending, setSending] = useState(false);
+  const supabase = createClient();
+
+  const handleEmailChange = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const email = normalizeEmail(newEmail);
+    if (!email) {
+      toast.error("Enter a valid email address.");
+      return;
+    }
+    if (email === currentEmail.toLowerCase()) {
+      toast.error("That's already your email address.");
+      return;
+    }
+
+    setSending(true);
+    const { error } = await supabase.auth.updateUser({ email });
+    setSending(false);
+
+    if (error) {
+      console.error(error);
+      toast.error("Failed to start the email change. Please try again.");
+      return;
+    }
+
+    setNewEmail("");
+    toast.success(
+      "Confirmation links sent. Check your old and new inboxes to finish the change.",
+    );
+  };
+
+  return (
+    <Card>
+      <CardContent className="space-y-5 pt-6">
+        <h3>Sign in &amp; security</h3>
+
+        <form onSubmit={handleEmailChange} className="space-y-2">
+          <Label htmlFor="new_email" className="text-base">
+            Email
+          </Label>
+          <p className="text-sm text-muted-foreground">
+            You sign in as <strong>{currentEmail}</strong>. Enter a new email
+            below and we&apos;ll send confirmation links to both addresses.
+          </p>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Input
+              id="new_email"
+              type="email"
+              value={newEmail}
+              onChange={(e) => setNewEmail(e.target.value)}
+              placeholder="new.email@example.com"
+              className="py-5 text-base"
+            />
+            <Button
+              type="submit"
+              variant="outline"
+              disabled={sending || !newEmail}
+              className="shrink-0"
+            >
+              <Mail className="mr-2 h-4 w-4" />
+              {sending ? "Sending..." : "Change my email"}
+            </Button>
+          </div>
+        </form>
+
+        <Separator />
+
+        <div className="space-y-2">
+          <Label className="text-base">Password</Label>
+          <div>
+            <Button
+              variant="outline"
+              nativeButton={false}
+              render={<Link href="/update-password" />}
+            >
+              <KeyRound className="mr-2 h-4 w-4" />
+              Change my password
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,35 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { siteConfig } from "@/lib/config";
+import { SignInSecurityCard } from "./SignInSecurityCard";
+
+export const metadata = { title: `Settings | ${siteConfig.name}` };
+
+export default async function SettingsPage() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile || !["member", "content_editor", "admin"].includes(profile.role)) {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-12">
+      <h1 className="mb-6 text-3xl font-bold text-brand-primary md:text-4xl">
+        Settings
+      </h1>
+
+      <SignInSecurityCard currentEmail={user.email ?? ""} />
+    </div>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,7 +1,10 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { siteConfig } from "@/lib/config";
+import { DisplayCard } from "./DisplayCard";
 import { SignInSecurityCard } from "./SignInSecurityCard";
+import { NotificationsCard } from "./NotificationsCard";
+import { FeedbackCard } from "./FeedbackCard";
 
 export const metadata = { title: `Settings | ${siteConfig.name}` };
 
@@ -15,7 +18,7 @@ export default async function SettingsPage() {
 
   const { data: profile } = await supabase
     .from("profiles")
-    .select("role")
+    .select("role, email_announcements")
     .eq("id", user.id)
     .single();
 
@@ -25,11 +28,22 @@ export default async function SettingsPage() {
 
   return (
     <div className="container mx-auto max-w-3xl px-4 py-12">
-      <h1 className="mb-6 text-3xl font-bold text-brand-primary md:text-4xl">
+      <h1 className="mb-2 text-3xl font-bold text-brand-primary md:text-4xl">
         Settings
       </h1>
+      <p className="mb-8 text-muted-foreground">
+        Make the app comfortable for you. Your choices are saved automatically.
+      </p>
 
-      <SignInSecurityCard currentEmail={user.email ?? ""} />
+      <div className="space-y-6">
+        <DisplayCard />
+        <SignInSecurityCard currentEmail={user.email ?? ""} />
+        <NotificationsCard
+          userId={user.id}
+          initialEmailAnnouncements={profile.email_announcements ?? true}
+        />
+        <FeedbackCard />
+      </div>
     </div>
   );
 }

--- a/components/directory/PersonCard.tsx
+++ b/components/directory/PersonCard.tsx
@@ -107,11 +107,6 @@ export function PersonCard({ profile, family }: PersonCardProps) {
         </div>
       )}
 
-      {/* Bio */}
-      {profile.bio && (
-        <p className="text-base italic text-muted-foreground">{profile.bio}</p>
-      )}
-
       <div>
         {/* Phones */}
         {profile.phone_mobile && (

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -21,6 +21,7 @@ export const SIDEBAR_ROUTES = [
   "/serving",
   "/prayer",
   "/profile",
+  "/settings",
 ];
 
 export function AppShell({ profile, hasServingAccess, children }: AppShellProps) {

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -45,6 +45,7 @@ const memberNav = [
   { href: "/give", label: "Give", icon: HandCoins },
   { href: "/about", label: "About", icon: Info },
   { href: "/profile", label: "My Profile", icon: UserCircle },
+  { href: "/settings", label: "Settings", icon: Settings },
 ];
 
 const directorySubNav = [

--- a/components/profile/MyProfileView.tsx
+++ b/components/profile/MyProfileView.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { MapPin, Pencil, Phone } from "lucide-react";
+import { ProfileForm } from "@/components/profile/ProfileForm";
+import { DirectoryPreview } from "@/components/profile/DirectoryPreview";
+import { displayName, initials } from "@/lib/names";
+import { formatPhone } from "@/lib/sanitize";
+import type {
+  FamilyMember,
+  FamilyMemberRelationship,
+  FamilyUnit,
+  Profile,
+} from "@/lib/types";
+
+/** Privacy-masked household member row from the profiles_directory view */
+export interface HouseholdEntry {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  preferred_name: string | null;
+  avatar_url: string | null;
+  relationship: FamilyMemberRelationship;
+  email: string | null;
+  phone_mobile: string | null;
+}
+
+interface MyProfileViewProps {
+  profile: Profile;
+  family: FamilyUnit | null;
+  /** Other enrolled members of the household (privacy masking applied) */
+  householdProfiles: HouseholdEntry[];
+  /** Non-enrolled family members (children etc.) without accounts */
+  familyMembers: FamilyMember[];
+}
+
+const eyebrow =
+  "text-sm font-bold uppercase tracking-wider text-muted-foreground";
+
+function MemberTile({
+  name,
+  suffix,
+  detail,
+  avatarUrl,
+  avatarInitials,
+  editHref,
+  onEdit,
+  editLabel = "Edit",
+}: {
+  name: string;
+  suffix?: string;
+  detail: string | null;
+  avatarUrl: string | null;
+  avatarInitials: string;
+  editHref?: string;
+  onEdit?: () => void;
+  editLabel?: string;
+}) {
+  const editLink =
+    "text-base font-semibold text-brand-primary underline underline-offset-4 hover:text-brand-primary/80";
+  return (
+    <div className="flex items-center gap-4 rounded-xl border bg-card p-4">
+      <Avatar className="h-11 w-11 shrink-0">
+        {avatarUrl && <AvatarImage src={avatarUrl} alt={name} />}
+        <AvatarFallback className="bg-brand-primary text-white">
+          {avatarInitials}
+        </AvatarFallback>
+      </Avatar>
+      <div className="min-w-0 flex-1">
+        <p className="font-bold">
+          {name}
+          {suffix && (
+            <span className="font-medium text-muted-foreground"> · {suffix}</span>
+          )}
+        </p>
+        {detail && (
+          <p className="truncate text-base text-muted-foreground">{detail}</p>
+        )}
+      </div>
+      {onEdit ? (
+        <button type="button" onClick={onEdit} className={editLink}>
+          {editLabel}
+        </button>
+      ) : editHref ? (
+        <Link href={editHref} className={editLink}>
+          {editLabel}
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
+export function MyProfileView({
+  profile,
+  family,
+  householdProfiles,
+  familyMembers,
+}: MyProfileViewProps) {
+  const router = useRouter();
+  // Without a family card there is no "Edit" row to open the editor from,
+  // so it starts open.
+  const [editing, setEditing] = useState(!family);
+  const editorRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (editing && family) {
+      editorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [editing, family]);
+
+  const canManageFamily =
+    profile.relationship === "primary" || profile.relationship === "spouse";
+
+  // Summary line mirrors what the directory shows: hidden fields stay hidden.
+  const visiblePhone = profile.hide_phone_mobile ? null : profile.phone_mobile;
+  const visibleCity = !profile.hide_address && profile.city
+    ? `${profile.city}${profile.state ? `, ${profile.state}` : ""}`
+    : family && !family.hide_address && family.city
+      ? `${family.city}${family.state ? `, ${family.state}` : ""}`
+      : null;
+  const summary = [visiblePhone && formatPhone(visiblePhone), visibleCity]
+    .filter(Boolean)
+    .join(" · ");
+
+  const familyAddress =
+    family &&
+    [
+      family.address_line1,
+      family.address_line2,
+      [
+        family.city,
+        [family.state, family.postal_code].filter(Boolean).join(" "),
+      ]
+        .filter(Boolean)
+        .join(", "),
+    ]
+      .filter(Boolean)
+      .join(", ");
+
+  return (
+    <div className="space-y-6">
+      {/* How others see you */}
+      <div className="rounded-xl border border-brand-primary/25 bg-brand-warm p-5 sm:px-6">
+        <p className={`${eyebrow} mb-3`}>How others see you</p>
+        <div className="flex items-center gap-4">
+          <Avatar className="h-13 w-13 shrink-0">
+            {profile.avatar_url && (
+              <AvatarImage src={profile.avatar_url} alt={displayName(profile)} />
+            )}
+            <AvatarFallback className="bg-brand-accent-text text-white text-lg">
+              {initials(profile)}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <p className="font-bold">{displayName(profile)}</p>
+            <p className="text-base text-muted-foreground">
+              {profile.is_unlisted
+                ? "You're hidden from the directory."
+                : summary || "No contact info shared yet."}
+            </p>
+          </div>
+        </div>
+        <div className="mt-4">
+          <DirectoryPreview />
+        </div>
+      </div>
+
+      {/* Family photo */}
+      {family?.photo_url && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={family.photo_url}
+          alt={`${family.family_name} family photo`}
+          className="h-56 w-full rounded-xl object-cover sm:h-64"
+        />
+      )}
+
+      {/* Family info */}
+      {family && (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="mb-1 flex items-center justify-between gap-4">
+              <h3>Family Info</h3>
+              <Button
+                variant="outline"
+                nativeButton={false}
+                render={<Link href="/household" />}
+              >
+                <Pencil className="mr-2 h-4 w-4" />
+                Edit
+              </Button>
+            </div>
+            <p className="mb-4 text-base text-muted-foreground">
+              Shared by your family — any family member can keep this up to
+              date.
+            </p>
+
+            <div className="mb-6">
+              {familyAddress && (
+                <div className="flex items-center gap-3 py-1.5">
+                  <MapPin
+                    className="h-5 w-5 shrink-0 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                  <span className="text-base">{familyAddress}</span>
+                </div>
+              )}
+              {family.phone_home && (
+                <div className="flex items-center gap-3 py-1.5">
+                  <Phone
+                    className="h-5 w-5 shrink-0 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                  <span className="text-base">
+                    {formatPhone(family.phone_home)}
+                  </span>
+                  <span className="text-sm text-muted-foreground">home</span>
+                </div>
+              )}
+            </div>
+
+            <p className={`${eyebrow} mb-3`}>Family members</p>
+            <div className="space-y-3">
+              <MemberTile
+                name={displayName(profile)}
+                suffix="you"
+                detail={
+                  [
+                    profile.phone_mobile && formatPhone(profile.phone_mobile),
+                    profile.email,
+                  ]
+                    .filter(Boolean)
+                    .join(" · ") || null
+                }
+                avatarUrl={profile.avatar_url}
+                avatarInitials={initials(profile)}
+                onEdit={() => setEditing((v) => !v)}
+                editLabel={editing ? "Close" : "Edit"}
+              />
+              {householdProfiles.map((m) => (
+                <MemberTile
+                  key={m.id}
+                  name={displayName(m)}
+                  detail={
+                    [m.phone_mobile && formatPhone(m.phone_mobile), m.email]
+                      .filter(Boolean)
+                      .join(" · ") || null
+                  }
+                  avatarUrl={m.avatar_url}
+                  avatarInitials={initials(m)}
+                  editHref={
+                    canManageFamily ? `/household/member/${m.id}` : undefined
+                  }
+                />
+              ))}
+              {familyMembers.map((fm) => (
+                <MemberTile
+                  key={fm.id}
+                  name={displayName(fm)}
+                  detail={null}
+                  avatarUrl={fm.avatar_url}
+                  avatarInitials={initials(fm)}
+                  editHref={
+                    canManageFamily
+                      ? `/household/member/fm/${fm.id}`
+                      : undefined
+                  }
+                />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Personal details editor */}
+      {editing && (
+        <div ref={editorRef} className="scroll-mt-24">
+          <ProfileForm
+            profile={profile}
+            families={[]}
+            isAdmin={false}
+            onSaved={() => {
+              if (family) setEditing(false);
+              router.refresh();
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/profile/MyProfileView.tsx
+++ b/components/profile/MyProfileView.tsx
@@ -283,6 +283,7 @@ export function MyProfileView({
           <ProfileForm
             profile={profile}
             families={[]}
+            family={family}
             isAdmin={false}
             onSaved={() => {
               if (family) setEditing(false);

--- a/components/profile/ProfileForm.tsx
+++ b/components/profile/ProfileForm.tsx
@@ -29,10 +29,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { toast } from "sonner";
-import { Camera } from "lucide-react";
+import { Camera, Check } from "lucide-react";
 import type { Profile, FamilyUnit } from "@/lib/types";
 
 interface ProfileFormProps {
@@ -134,6 +133,36 @@ const MONTHS = [
   { value: "11", label: "November" },
   { value: "12", label: "December" },
 ];
+
+function Required() {
+  return <span className="font-normal text-muted-foreground">(required)</span>;
+}
+
+function Optional() {
+  return <span className="font-normal text-muted-foreground">(optional)</span>;
+}
+
+/** Inline privacy switch rendered directly under the field it hides */
+function HideRow({
+  id,
+  label,
+  checked,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 pt-2">
+      <Label htmlFor={id} className="cursor-pointer font-medium">
+        {label}
+      </Label>
+      <Switch id={id} checked={checked} onCheckedChange={onChange} />
+    </div>
+  );
+}
 
 export function ProfileForm({
   profile,
@@ -326,542 +355,494 @@ export function ProfileForm({
     "??";
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
-      {/* Avatar — always visible, not in a tab */}
+    <form onSubmit={handleSubmit}>
       <Card>
-        <CardContent className="pt-6">
-          <div className="flex items-center gap-6">
-            <div className="relative">
-              <Avatar className="h-24 w-24">
-                {avatarUrl && <AvatarImage src={avatarUrl} alt="Profile photo" />}
-                <AvatarFallback className="text-2xl bg-brand-primary text-white">
-                  {initials}
-                </AvatarFallback>
-              </Avatar>
-              <button
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={uploadingAvatar}
-                className="absolute -bottom-1 -right-1 bg-brand-primary hover:bg-brand-primary/90 text-white rounded-full p-2 shadow-md transition-colors disabled:opacity-50"
-                aria-label="Upload photo"
-              >
-                <Camera className="h-4 w-4" />
-              </button>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-                onChange={handleAvatarUpload}
-                className="hidden"
+        <CardContent className="space-y-5 pt-6">
+          {!isAdmin && !relaxValidation && (
+            <p className="text-base text-muted-foreground">
+              Anything you fill in here is listed in the group directory. If
+              you&apos;d rather keep something private, leave it blank or turn
+              on its hide switch.
+            </p>
+          )}
+
+          {/* Photo */}
+          <div className="flex items-center gap-5">
+            <Avatar className="h-20 w-20 shrink-0">
+              {avatarUrl && <AvatarImage src={avatarUrl} alt="Profile photo" />}
+              <AvatarFallback className="bg-brand-primary text-2xl text-white">
+                {initials}
+              </AvatarFallback>
+            </Avatar>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={uploadingAvatar}
+            >
+              <Camera className="mr-2 h-4 w-4" />
+              {uploadingAvatar
+                ? "Uploading..."
+                : relaxValidation
+                  ? "Change their photo"
+                  : "Change my photo"}
+            </Button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handleAvatarUpload}
+              className="hidden"
+            />
+          </div>
+
+          {/* Name */}
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="first_name" className="text-base">
+                First name <Required />
+              </Label>
+              <Input
+                id="first_name"
+                value={state.first_name}
+                onChange={(e) => update("first_name", e.target.value)}
+                onBlur={(e) =>
+                  update("first_name", titleCaseName(e.target.value) || "")
+                }
+                required
+                className="py-5 text-base"
               />
             </div>
-            <div className="flex-1">
-              <p className="text-lg font-semibold">
-                {state.preferred_name || state.first_name || "Your profile"}{" "}
-                {state.last_name}
-              </p>
+            <div className="space-y-2">
+              <Label htmlFor="last_name" className="text-base">
+                Last name <Required />
+              </Label>
+              <Input
+                id="last_name"
+                value={state.last_name}
+                onChange={(e) => update("last_name", e.target.value)}
+                onBlur={(e) =>
+                  update("last_name", titleCaseName(e.target.value) || "")
+                }
+                required
+                className="py-5 text-base"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="preferred_name" className="text-base">
+              Nickname <Optional />
+            </Label>
+            <Input
+              id="preferred_name"
+              value={state.preferred_name}
+              onChange={(e) => update("preferred_name", e.target.value)}
+              onBlur={(e) =>
+                update("preferred_name", titleCaseName(e.target.value) || "")
+              }
+              className="py-5 text-base"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="bio" className="text-base">
+              About me <Optional />
+            </Label>
+            <Textarea
+              id="bio"
+              value={state.bio}
+              onChange={(e) => update("bio", e.target.value)}
+              rows={3}
+              className="text-base"
+              placeholder="A sentence or two about yourself"
+            />
+          </div>
+
+          <Separator />
+
+          {/* Email */}
+          <div className="space-y-2">
+            <Label htmlFor="email" className="text-base">
+              Email
+            </Label>
+            <Input
+              id="email"
+              type="email"
+              value={state.email}
+              onChange={(e) => update("email", e.target.value)}
+              disabled={!isAdmin}
+              className="py-5 text-base"
+            />
+            {!isAdmin && (
               <p className="text-sm text-muted-foreground">
-                {uploadingAvatar
-                  ? "Uploading photo..."
-                  : relaxValidation
-                    ? "Click the camera icon to update their photo."
-                    : "Click the camera icon to update your photo."}
+                Contact an admin to change your login email.
+              </p>
+            )}
+            <HideRow
+              id="hide_email"
+              label="Hide my email from the directory"
+              checked={state.hide_email}
+              onChange={(v) => update("hide_email", v)}
+            />
+          </div>
+
+          {/* Phones */}
+          <div className="space-y-2">
+            <Label htmlFor="phone_mobile" className="text-base">
+              Mobile phone
+            </Label>
+            <Input
+              id="phone_mobile"
+              type="tel"
+              inputMode="tel"
+              value={state.phone_mobile}
+              onChange={(e) =>
+                update("phone_mobile", formatPhoneAsYouType(e.target.value))
+              }
+              placeholder="(555) 123-4567"
+              className="py-5 text-base"
+            />
+            <HideRow
+              id="hide_phone_mobile"
+              label="Hide my mobile number"
+              checked={state.hide_phone_mobile}
+              onChange={(v) => update("hide_phone_mobile", v)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="phone_home" className="text-base">
+              Home phone <Optional />
+            </Label>
+            <Input
+              id="phone_home"
+              type="tel"
+              inputMode="tel"
+              value={state.phone_home}
+              onChange={(e) =>
+                update("phone_home", formatPhoneAsYouType(e.target.value))
+              }
+              placeholder="(555) 123-4567"
+              className="py-5 text-base"
+            />
+            {state.phone_home && (
+              <HideRow
+                id="hide_phone_home"
+                label="Hide my home number"
+                checked={state.hide_phone_home}
+                onChange={(v) => update("hide_phone_home", v)}
+              />
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="phone_work" className="text-base">
+              Work phone <Optional />
+            </Label>
+            <Input
+              id="phone_work"
+              type="tel"
+              inputMode="tel"
+              value={state.phone_work}
+              onChange={(e) =>
+                update("phone_work", formatPhoneAsYouType(e.target.value))
+              }
+              placeholder="(555) 123-4567"
+              className="py-5 text-base"
+            />
+            {state.phone_work && (
+              <HideRow
+                id="hide_phone_work"
+                label="Hide my work number"
+                checked={state.hide_phone_work}
+                onChange={(v) => update("hide_phone_work", v)}
+              />
+            )}
+          </div>
+
+          <Separator />
+
+          {/* Birthday */}
+          <div className="space-y-2">
+            <Label className="text-base">
+              Birthday {relaxValidation ? <Optional /> : <Required />}
+            </Label>
+            <div className="grid grid-cols-3 gap-3">
+              <Select
+                items={MONTHS}
+                value={state.birth_month}
+                onValueChange={(v) => update("birth_month", v ?? "")}
+              >
+                <SelectTrigger className="py-5 text-base">
+                  <SelectValue placeholder="Month" />
+                </SelectTrigger>
+                <SelectContent>
+                  {MONTHS.map((m) => (
+                    <SelectItem key={m.value} value={m.value}>
+                      {m.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Input
+                type="number"
+                min="1"
+                max="31"
+                placeholder="Day"
+                value={state.birth_day}
+                onChange={(e) => update("birth_day", e.target.value)}
+                className="py-5 text-base"
+                aria-label="Day"
+              />
+              <Input
+                type="number"
+                min="1900"
+                max="2100"
+                placeholder="Year (optional)"
+                value={state.birth_year}
+                onChange={(e) => update("birth_year", e.target.value)}
+                className="py-5 text-base"
+                aria-label="Year (optional)"
+              />
+            </div>
+            <p className="text-sm text-muted-foreground">
+              The year is optional — the directory only shows the month and
+              day.
+            </p>
+            <HideRow
+              id="hide_birthday"
+              label="Hide my birthday"
+              checked={state.hide_birthday}
+              onChange={(v) => update("hide_birthday", v)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="anniversary" className="text-base">
+              Anniversary <Optional />
+            </Label>
+            <Input
+              id="anniversary"
+              type="date"
+              value={state.anniversary}
+              onChange={(e) => update("anniversary", e.target.value)}
+              className="py-5 text-base"
+            />
+            {state.anniversary && (
+              <HideRow
+                id="hide_anniversary"
+                label="Hide my anniversary"
+                checked={state.hide_anniversary}
+                onChange={(v) => update("hide_anniversary", v)}
+              />
+            )}
+          </div>
+
+          <Separator />
+
+          {/* Address */}
+          <div className="space-y-2">
+            <Label htmlFor="address_line1" className="text-base">
+              Street address <Optional />
+            </Label>
+            <Input
+              id="address_line1"
+              value={state.address_line1}
+              onChange={(e) => update("address_line1", e.target.value)}
+              onBlur={(e) =>
+                update("address_line1", titleCaseStreet(e.target.value) || "")
+              }
+              placeholder="123 Main St"
+              className="py-5 text-base"
+            />
+            {profile.family_id && (
+              <p className="text-sm text-muted-foreground">
+                Leave blank to use your family&apos;s shared address.
+              </p>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="address_line2" className="text-base">
+              Apt / unit <Optional />
+            </Label>
+            <Input
+              id="address_line2"
+              value={state.address_line2}
+              onChange={(e) => update("address_line2", e.target.value)}
+              onBlur={(e) =>
+                update("address_line2", titleCaseStreet(e.target.value) || "")
+              }
+              placeholder="Apt 4B"
+              className="py-5 text-base"
+            />
+          </div>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-6">
+            <div className="space-y-2 sm:col-span-3">
+              <Label htmlFor="city" className="text-base">
+                City
+              </Label>
+              <Input
+                id="city"
+                value={state.city}
+                onChange={(e) => update("city", e.target.value)}
+                onBlur={(e) =>
+                  update("city", titleCaseCity(e.target.value) || "")
+                }
+                className="py-5 text-base"
+              />
+            </div>
+            <div className="space-y-2 sm:col-span-1">
+              <Label htmlFor="state" className="text-base">
+                State
+              </Label>
+              <Input
+                id="state"
+                value={state.state}
+                onChange={(e) => update("state", e.target.value.toUpperCase())}
+                maxLength={2}
+                placeholder="TX"
+                className="py-5 text-base uppercase"
+              />
+            </div>
+            <div className="space-y-2 sm:col-span-2">
+              <Label htmlFor="postal_code" className="text-base">
+                ZIP
+              </Label>
+              <Input
+                id="postal_code"
+                value={state.postal_code}
+                onChange={(e) => update("postal_code", e.target.value)}
+                placeholder="12345"
+                className="py-5 text-base"
+              />
+            </div>
+          </div>
+          <HideRow
+            id="hide_address"
+            label="Hide my address from the directory"
+            checked={state.hide_address}
+            onChange={(v) => update("hide_address", v)}
+          />
+
+          <Separator />
+
+          {/* Occupation */}
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="occupation" className="text-base">
+                Occupation <Optional />
+              </Label>
+              <Input
+                id="occupation"
+                value={state.occupation}
+                onChange={(e) => update("occupation", e.target.value)}
+                placeholder="e.g. Plumber, Teacher"
+                className="py-5 text-base"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="employer" className="text-base">
+                Employer <Optional />
+              </Label>
+              <Input
+                id="employer"
+                value={state.employer}
+                onChange={(e) => update("employer", e.target.value)}
+                placeholder="Company / organization"
+                className="py-5 text-base"
+              />
+            </div>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Sharing what you do helps others in the class find help from
+            someone they know.
+          </p>
+          {(state.occupation || state.employer) && (
+            <HideRow
+              id="hide_occupation"
+              label="Hide my occupation and employer"
+              checked={state.hide_occupation}
+              onChange={(v) => update("hide_occupation", v)}
+            />
+          )}
+
+          {/* Family assignment (admin only) */}
+          {isAdmin && (
+            <>
+              <Separator />
+              <div className="space-y-2">
+                <Label htmlFor="family_id" className="text-base">
+                  Family
+                </Label>
+                <Select
+                  value={state.family_id || "none"}
+                  onValueChange={(v) =>
+                    update("family_id", !v || v === "none" ? "" : v)
+                  }
+                >
+                  <SelectTrigger className="py-5 text-base">
+                    <SelectValue placeholder="No family assigned">
+                      {(v: string | null | undefined) => {
+                        if (!v || v === "none") return "No family assigned";
+                        return families.find((f) => f.id === v)?.family_name ?? "(Unknown family)";
+                      }}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">— No family —</SelectItem>
+                    {families.map((f) => (
+                      <SelectItem key={f.id} value={f.id}>
+                        {f.family_name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-sm text-muted-foreground">
+                  Manage families on the{" "}
+                  <a
+                    href="/admin/families"
+                    className="text-brand-primary underline"
+                  >
+                    Families page
+                  </a>
+                  .
+                </p>
+              </div>
+            </>
+          )}
+
+          <Separator />
+
+          {/* Master directory switch */}
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <Label htmlFor="is_unlisted" className="cursor-pointer text-base">
+                Hide me from the directory completely
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                Your profile will not appear in the member directory at all.
+                Admins can always see all fields.
               </p>
             </div>
+            <Switch
+              id="is_unlisted"
+              checked={state.is_unlisted}
+              onCheckedChange={(v) => update("is_unlisted", v)}
+            />
+          </div>
+
+          <div className="border-t pt-5">
+            <Button
+              type="submit"
+              size="lg"
+              disabled={saving}
+              className="bg-brand-primary text-base text-white hover:bg-brand-primary/90"
+            >
+              <Check className="mr-2 h-4 w-4" />
+              {saving ? "Saving..." : "Save my changes"}
+            </Button>
           </div>
         </CardContent>
       </Card>
-
-      <Tabs defaultValue="personal">
-        <TabsList className={`grid w-full ${isAdmin ? "grid-cols-5" : "grid-cols-4"}`}>
-          <TabsTrigger value="personal">Personal</TabsTrigger>
-          <TabsTrigger value="contact">Contact</TabsTrigger>
-          <TabsTrigger value="address">Address</TabsTrigger>
-          {isAdmin && <TabsTrigger value="family">Family</TabsTrigger>}
-          <TabsTrigger value="privacy">Privacy</TabsTrigger>
-        </TabsList>
-
-        {/* =========================================================
-            PERSONAL
-            ========================================================= */}
-        <TabsContent value="personal">
-          <Card>
-            <CardContent className="pt-6 space-y-5">
-              <div className="grid sm:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="first_name" className="text-base">
-                    First name{" "}
-                    <span className="text-destructive" aria-hidden>*</span>
-                  </Label>
-                  <Input
-                    id="first_name"
-                    value={state.first_name}
-                    onChange={(e) => update("first_name", e.target.value)}
-                    onBlur={(e) =>
-                      update("first_name", titleCaseName(e.target.value) || "")
-                    }
-                    required
-                    className="text-base py-5"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="last_name" className="text-base">
-                    Last name{" "}
-                    <span className="text-destructive" aria-hidden>*</span>
-                  </Label>
-                  <Input
-                    id="last_name"
-                    value={state.last_name}
-                    onChange={(e) => update("last_name", e.target.value)}
-                    onBlur={(e) =>
-                      update("last_name", titleCaseName(e.target.value) || "")
-                    }
-                    required
-                    className="text-base py-5"
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="preferred_name" className="text-base">
-                  Preferred name / nickname{" "}
-                  <span className="text-muted-foreground font-normal">
-                    (optional)
-                  </span>
-                </Label>
-                <Input
-                  id="preferred_name"
-                  value={state.preferred_name}
-                  onChange={(e) => update("preferred_name", e.target.value)}
-                  onBlur={(e) =>
-                    update(
-                      "preferred_name",
-                      titleCaseName(e.target.value) || "",
-                    )
-                  }
-                  className="text-base py-5"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="bio" className="text-base">
-                  About me{" "}
-                  <span className="text-muted-foreground font-normal">
-                    (optional)
-                  </span>
-                </Label>
-                <Textarea
-                  id="bio"
-                  value={state.bio}
-                  onChange={(e) => update("bio", e.target.value)}
-                  rows={3}
-                  className="text-base"
-                  placeholder="A sentence or two about yourself"
-                />
-              </div>
-
-              <Separator />
-
-              <div>
-                <Label className="text-base">
-                  Birthday{" "}
-                  <span className="text-destructive" aria-hidden>*</span>
-                </Label>
-                <p className="text-sm text-muted-foreground mb-2">
-                  Month and day are required. Year is optional.
-                </p>
-                <div className="grid grid-cols-3 gap-3">
-                  <Select
-                    items={MONTHS}
-                    value={state.birth_month}
-                    onValueChange={(v) => update("birth_month", v ?? "")}
-                  >
-                    <SelectTrigger className="text-base py-5">
-                      <SelectValue placeholder="Month" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {MONTHS.map((m) => (
-                        <SelectItem key={m.value} value={m.value}>
-                          {m.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <Input
-                    type="number"
-                    min="1"
-                    max="31"
-                    placeholder="Day"
-                    value={state.birth_day}
-                    onChange={(e) => update("birth_day", e.target.value)}
-                    className="text-base py-5"
-                  />
-                  <Input
-                    type="number"
-                    min="1900"
-                    max="2100"
-                    placeholder="Year (optional)"
-                    value={state.birth_year}
-                    onChange={(e) => update("birth_year", e.target.value)}
-                    className="text-base py-5"
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="anniversary" className="text-base">
-                  Anniversary{" "}
-                  <span className="text-muted-foreground font-normal">
-                    (optional)
-                  </span>
-                </Label>
-                <Input
-                  id="anniversary"
-                  type="date"
-                  value={state.anniversary}
-                  onChange={(e) => update("anniversary", e.target.value)}
-                  className="text-base py-5"
-                />
-              </div>
-
-              <Separator />
-
-              <div className="grid sm:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="occupation" className="text-base">
-                    Occupation{" "}
-                    <span className="text-muted-foreground font-normal">
-                      (optional)
-                    </span>
-                  </Label>
-                  <Input
-                    id="occupation"
-                    value={state.occupation}
-                    onChange={(e) => update("occupation", e.target.value)}
-                    placeholder="e.g. Plumber, Teacher"
-                    className="text-base py-5"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="employer" className="text-base">
-                    Employer{" "}
-                    <span className="text-muted-foreground font-normal">
-                      (optional)
-                    </span>
-                  </Label>
-                  <Input
-                    id="employer"
-                    value={state.employer}
-                    onChange={(e) => update("employer", e.target.value)}
-                    placeholder="Company / organization"
-                    className="text-base py-5"
-                  />
-                </div>
-              </div>
-              <p className="text-sm text-muted-foreground">
-                Sharing what you do helps others in the class find help from
-                someone they know.
-              </p>
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* =========================================================
-            CONTACT
-            ========================================================= */}
-        <TabsContent value="contact">
-          <Card>
-            <CardContent className="pt-6 space-y-5">
-              <div className="space-y-2">
-                <Label htmlFor="email" className="text-base">
-                  Email
-                </Label>
-                <Input
-                  id="email"
-                  type="email"
-                  value={state.email}
-                  onChange={(e) => update("email", e.target.value)}
-                  disabled={!isAdmin}
-                  className="text-base py-5"
-                />
-                {!isAdmin && (
-                  <p className="text-xs text-muted-foreground">
-                    Contact an admin to change your login email.
-                  </p>
-                )}
-              </div>
-
-              <Separator />
-
-              <div className="space-y-2">
-                <Label htmlFor="phone_mobile" className="text-base">
-                  Mobile phone
-                </Label>
-                <Input
-                  id="phone_mobile"
-                  type="tel"
-                  inputMode="tel"
-                  value={state.phone_mobile}
-                  onChange={(e) =>
-                    update("phone_mobile", formatPhoneAsYouType(e.target.value))
-                  }
-                  placeholder="(555) 123-4567"
-                  className="text-base py-5"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="phone_home" className="text-base">
-                  Home phone
-                </Label>
-                <Input
-                  id="phone_home"
-                  type="tel"
-                  inputMode="tel"
-                  value={state.phone_home}
-                  onChange={(e) =>
-                    update("phone_home", formatPhoneAsYouType(e.target.value))
-                  }
-                  placeholder="(555) 123-4567"
-                  className="text-base py-5"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="phone_work" className="text-base">
-                  Work phone{" "}
-                  <span className="text-muted-foreground font-normal">
-                    (optional)
-                  </span>
-                </Label>
-                <Input
-                  id="phone_work"
-                  type="tel"
-                  inputMode="tel"
-                  value={state.phone_work}
-                  onChange={(e) =>
-                    update("phone_work", formatPhoneAsYouType(e.target.value))
-                  }
-                  placeholder="(555) 123-4567"
-                  className="text-base py-5"
-                />
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* =========================================================
-            ADDRESS
-            ========================================================= */}
-        <TabsContent value="address">
-          <Card>
-            <CardContent className="pt-6 space-y-5">
-              <div className="space-y-2">
-                <Label htmlFor="address_line1" className="text-base">
-                  Street address
-                </Label>
-                <Input
-                  id="address_line1"
-                  value={state.address_line1}
-                  onChange={(e) => update("address_line1", e.target.value)}
-                  onBlur={(e) =>
-                    update(
-                      "address_line1",
-                      titleCaseStreet(e.target.value) || "",
-                    )
-                  }
-                  placeholder="123 Main St"
-                  className="text-base py-5"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="address_line2" className="text-base">
-                  Apt / unit{" "}
-                  <span className="text-muted-foreground font-normal">
-                    (optional)
-                  </span>
-                </Label>
-                <Input
-                  id="address_line2"
-                  value={state.address_line2}
-                  onChange={(e) => update("address_line2", e.target.value)}
-                  onBlur={(e) =>
-                    update(
-                      "address_line2",
-                      titleCaseStreet(e.target.value) || "",
-                    )
-                  }
-                  placeholder="Apt 4B"
-                  className="text-base py-5"
-                />
-              </div>
-              <div className="grid grid-cols-1 sm:grid-cols-6 gap-3">
-                <div className="sm:col-span-3 space-y-2">
-                  <Label htmlFor="city" className="text-base">
-                    City
-                  </Label>
-                  <Input
-                    id="city"
-                    value={state.city}
-                    onChange={(e) => update("city", e.target.value)}
-                    onBlur={(e) =>
-                      update("city", titleCaseCity(e.target.value) || "")
-                    }
-                    className="text-base py-5"
-                  />
-                </div>
-                <div className="sm:col-span-1 space-y-2">
-                  <Label htmlFor="state" className="text-base">
-                    State
-                  </Label>
-                  <Input
-                    id="state"
-                    value={state.state}
-                    onChange={(e) =>
-                      update("state", e.target.value.toUpperCase())
-                    }
-                    maxLength={2}
-                    placeholder="TX"
-                    className="text-base py-5 uppercase"
-                  />
-                </div>
-                <div className="sm:col-span-2 space-y-2">
-                  <Label htmlFor="postal_code" className="text-base">
-                    ZIP
-                  </Label>
-                  <Input
-                    id="postal_code"
-                    value={state.postal_code}
-                    onChange={(e) => update("postal_code", e.target.value)}
-                    placeholder="12345"
-                    className="text-base py-5"
-                  />
-                </div>
-              </div>
-              {profile.family_id && (
-                <p className="text-sm text-muted-foreground">
-                  Leave blank to use your family&apos;s shared address.
-                </p>
-              )}
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* =========================================================
-            FAMILY (admin only)
-            ========================================================= */}
-        {isAdmin && (
-          <TabsContent value="family">
-            <Card>
-              <CardContent className="pt-6 space-y-5">
-                <div className="space-y-2">
-                  <Label htmlFor="family_id" className="text-base">
-                    Family
-                  </Label>
-                  <Select
-                    value={state.family_id || "none"}
-                    onValueChange={(v) =>
-                      update("family_id", !v || v === "none" ? "" : v)
-                    }
-                  >
-                    <SelectTrigger className="text-base py-5">
-                      <SelectValue placeholder="No family assigned">
-                        {(v: string | null | undefined) => {
-                          if (!v || v === "none") return "No family assigned";
-                          return families.find((f) => f.id === v)?.family_name ?? "(Unknown family)";
-                        }}
-                      </SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="none">— No family —</SelectItem>
-                      {families.map((f) => (
-                        <SelectItem key={f.id} value={f.id}>
-                          {f.family_name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <p className="text-sm text-muted-foreground">
-                    Manage families on the{" "}
-                    <a
-                      href="/admin/families"
-                      className="text-brand-primary underline"
-                    >
-                      Families page
-                    </a>
-                    .
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
-        )}
-
-        {/* =========================================================
-            PRIVACY
-            ========================================================= */}
-        <TabsContent value="privacy">
-          <Card>
-            <CardContent className="pt-6 space-y-5">
-              <div className="flex items-start justify-between gap-4 pb-4 border-b">
-                <div>
-                  <Label className="text-base">Hide from directory</Label>
-                  <p className="text-sm text-muted-foreground">
-                    Your profile will not appear in the member directory at all.
-                  </p>
-                </div>
-                <Switch
-                  checked={state.is_unlisted}
-                  onCheckedChange={(v) => update("is_unlisted", v)}
-                />
-              </div>
-
-              <p className="text-sm text-muted-foreground">
-                Hide specific fields while still appearing in the directory.
-                Admins can always see all fields.
-              </p>
-
-              {[
-                { key: "hide_email" as const, label: "Hide email" },
-                { key: "hide_phone_mobile" as const, label: "Hide mobile phone" },
-                { key: "hide_phone_home" as const, label: "Hide home phone" },
-                { key: "hide_phone_work" as const, label: "Hide work phone" },
-                { key: "hide_address" as const, label: "Hide address" },
-                { key: "hide_birthday" as const, label: "Hide birthday" },
-                {
-                  key: "hide_birth_year" as const,
-                  label: "Hide birth year (show month/day only)",
-                },
-                { key: "hide_anniversary" as const, label: "Hide anniversary" },
-                { key: "hide_occupation" as const, label: "Hide occupation / employer" },
-              ].map(({ key, label }) => (
-                <div
-                  key={key}
-                  className="flex items-center justify-between gap-4"
-                >
-                  <Label htmlFor={key} className="text-base cursor-pointer">
-                    {label}
-                  </Label>
-                  <Switch
-                    id={key}
-                    checked={state[key]}
-                    onCheckedChange={(v) => update(key, v)}
-                  />
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-        </TabsContent>
-      </Tabs>
-
-      <div className="flex justify-end gap-3">
-        <Button
-          type="submit"
-          size="lg"
-          disabled={saving}
-          className="text-base bg-brand-primary hover:bg-brand-primary/90 text-white"
-        >
-          {saving ? "Saving..." : "Save Profile"}
-        </Button>
-      </div>
     </form>
   );
 }

--- a/components/profile/ProfileForm.tsx
+++ b/components/profile/ProfileForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
+import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { uploadImage } from "@/lib/uploadImage";
 import {
@@ -17,7 +18,6 @@ import {
 } from "@/lib/sanitize";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Card, CardContent } from "@/components/ui/card";
@@ -37,6 +37,12 @@ import type { Profile, FamilyUnit } from "@/lib/types";
 interface ProfileFormProps {
   profile: Profile;
   families: FamilyUnit[];
+  /**
+   * The member's own family. When set, last name and address default to the
+   * family's and only appear as fields behind a "different from my family"
+   * checkbox.
+   */
+  family?: FamilyUnit | null;
   /** Admin mode allows editing family assignment + ignores privacy enforcement on save */
   isAdmin?: boolean;
   /**
@@ -55,7 +61,6 @@ interface FormState {
   first_name: string;
   last_name: string;
   preferred_name: string;
-  bio: string;
   email: string;
   phone_mobile: string;
   phone_home: string;
@@ -72,7 +77,6 @@ interface FormState {
   occupation: string;
   employer: string;
   family_id: string;
-  is_unlisted: boolean;
   hide_phone_mobile: boolean;
   hide_phone_home: boolean;
   hide_phone_work: boolean;
@@ -89,7 +93,6 @@ function initialState(profile: Profile): FormState {
     first_name: profile.first_name || "",
     last_name: profile.last_name || "",
     preferred_name: profile.preferred_name || "",
-    bio: profile.bio || "",
     email: profile.email || "",
     phone_mobile: formatPhone(profile.phone_mobile),
     phone_home: formatPhone(profile.phone_home),
@@ -106,7 +109,6 @@ function initialState(profile: Profile): FormState {
     occupation: profile.occupation || "",
     employer: profile.employer || "",
     family_id: profile.family_id || "",
-    is_unlisted: profile.is_unlisted ?? false,
     hide_phone_mobile: profile.hide_phone_mobile ?? false,
     hide_phone_home: profile.hide_phone_home ?? false,
     hide_phone_work: profile.hide_phone_work ?? false,
@@ -142,6 +144,35 @@ function Optional() {
   return <span className="font-normal text-muted-foreground">(optional)</span>;
 }
 
+/** Checkbox that reveals fields for info that differs from the family's */
+function CheckRow({
+  id,
+  label,
+  checked,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label
+      htmlFor={id}
+      className="flex cursor-pointer items-center gap-3 py-1 text-base font-medium"
+    >
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="size-5 shrink-0 accent-brand-primary"
+      />
+      {label}
+    </label>
+  );
+}
+
 /** Inline privacy switch rendered directly under the field it hides */
 function HideRow({
   id,
@@ -167,12 +198,26 @@ function HideRow({
 export function ProfileForm({
   profile,
   families,
+  family = null,
   isAdmin = false,
   relaxValidation = false,
   onSaved,
 }: ProfileFormProps) {
   const [state, setState] = useState<FormState>(initialState(profile));
   const [avatarUrl, setAvatarUrl] = useState<string | null>(profile.avatar_url);
+
+  // Family defaults: last name falls back to the family surname and address
+  // to the family's home address unless the member marks theirs different.
+  const familySurname =
+    (!isAdmin && family?.family_name?.replace(/\s+family$/i, "").trim()) || "";
+  const [differentLastName, setDifferentLastName] = useState(
+    !familySurname || (profile.last_name || "") !== familySurname,
+  );
+  const familyHasAddress = !!(family?.address_line1 || family?.city);
+  const [differentAddress, setDifferentAddress] = useState(
+    !familyHasAddress ||
+      !!(profile.address_line1 || profile.address_line2 || profile.city),
+  );
   const [saving, setSaving] = useState(false);
   const [uploadingAvatar, setUploadingAvatar] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -217,13 +262,19 @@ export function ProfileForm({
 
     // Sanitize + normalize everything before writing.
     const firstName = titleCaseName(state.first_name);
-    const lastName = titleCaseName(state.last_name);
+    const lastName =
+      familySurname && !differentLastName
+        ? familySurname
+        : titleCaseName(state.last_name);
     const preferredName = titleCaseName(state.preferred_name);
-    const city = titleCaseCity(state.city);
-    const stateCode = normalizeState(state.state);
-    const postal = state.postal_code
-      ? normalizePostalCode(state.postal_code)
-      : null;
+    // Unchecked "different address" means: use the family's address (blank).
+    const ownAddress = !familyHasAddress || differentAddress;
+    const city = ownAddress ? titleCaseCity(state.city) : null;
+    const stateCode = ownAddress ? normalizeState(state.state) : null;
+    const postal =
+      ownAddress && state.postal_code
+        ? normalizePostalCode(state.postal_code)
+        : null;
 
     // Validate required fields.
     if (!firstName) {
@@ -257,12 +308,12 @@ export function ProfileForm({
     }
 
     // Validate required shapes — state/zip return null on malformed input.
-    if (state.state && !stateCode) {
+    if (ownAddress && state.state && !stateCode) {
       toast.error("State must be a valid 2-letter code or full state name.");
       setSaving(false);
       return;
     }
-    if (state.postal_code && !postal) {
+    if (ownAddress && state.postal_code && !postal) {
       toast.error("ZIP code must be 5 digits or ZIP+4 format.");
       setSaving(false);
       return;
@@ -302,13 +353,12 @@ export function ProfileForm({
       first_name: firstName,
       last_name: lastName,
       preferred_name: preferredName,
-      bio: trimText(state.bio),
       email: normalizeEmail(state.email),
       phone_mobile: phoneMobile,
       phone_home: phoneHome,
       phone_work: phoneWork,
-      address_line1: titleCaseStreet(state.address_line1),
-      address_line2: titleCaseStreet(state.address_line2),
+      address_line1: ownAddress ? titleCaseStreet(state.address_line1) : null,
+      address_line2: ownAddress ? titleCaseStreet(state.address_line2) : null,
       city,
       state: stateCode,
       postal_code: postal,
@@ -321,7 +371,6 @@ export function ProfileForm({
       ...(isAdmin
         ? { family_id: state.family_id || null }
         : {}),
-      is_unlisted: state.is_unlisted,
       hide_phone_mobile: state.hide_phone_mobile,
       hide_phone_home: state.hide_phone_home,
       hide_phone_work: state.hide_phone_work,
@@ -397,10 +446,10 @@ export function ProfileForm({
           </div>
 
           {/* Name */}
-          <div className="grid gap-4 sm:grid-cols-2">
+          <div className={familySurname ? "space-y-2" : "grid gap-4 sm:grid-cols-2"}>
             <div className="space-y-2">
               <Label htmlFor="first_name" className="text-base">
-                First name <Required />
+                First name
               </Label>
               <Input
                 id="first_name"
@@ -413,21 +462,31 @@ export function ProfileForm({
                 className="py-5 text-base"
               />
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="last_name" className="text-base">
-                Last name <Required />
-              </Label>
-              <Input
-                id="last_name"
-                value={state.last_name}
-                onChange={(e) => update("last_name", e.target.value)}
-                onBlur={(e) =>
-                  update("last_name", titleCaseName(e.target.value) || "")
-                }
-                required
-                className="py-5 text-base"
+            {familySurname && (
+              <CheckRow
+                id="different_last_name"
+                label={`My last name is different from my family's (${familySurname})`}
+                checked={differentLastName}
+                onChange={setDifferentLastName}
               />
-            </div>
+            )}
+            {(!familySurname || differentLastName) && (
+              <div className="space-y-2">
+                <Label htmlFor="last_name" className="text-base">
+                  Last name
+                </Label>
+                <Input
+                  id="last_name"
+                  value={state.last_name}
+                  onChange={(e) => update("last_name", e.target.value)}
+                  onBlur={(e) =>
+                    update("last_name", titleCaseName(e.target.value) || "")
+                  }
+                  required
+                  className="py-5 text-base"
+                />
+              </div>
+            )}
           </div>
 
           <div className="space-y-2">
@@ -442,20 +501,6 @@ export function ProfileForm({
                 update("preferred_name", titleCaseName(e.target.value) || "")
               }
               className="py-5 text-base"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="bio" className="text-base">
-              About me <Optional />
-            </Label>
-            <Textarea
-              id="bio"
-              value={state.bio}
-              onChange={(e) => update("bio", e.target.value)}
-              rows={3}
-              className="text-base"
-              placeholder="A sentence or two about yourself"
             />
           </div>
 
@@ -476,7 +521,14 @@ export function ProfileForm({
             />
             {!isAdmin && (
               <p className="text-sm text-muted-foreground">
-                Contact an admin to change your login email.
+                To change your email, use the{" "}
+                <Link
+                  href="/settings"
+                  className="text-brand-primary underline underline-offset-4"
+                >
+                  Settings page
+                </Link>
+                .
               </p>
             )}
             <HideRow
@@ -618,7 +670,7 @@ export function ProfileForm({
 
           <div className="space-y-2">
             <Label htmlFor="anniversary" className="text-base">
-              Anniversary <Optional />
+              Anniversary
             </Label>
             <Input
               id="anniversary"
@@ -640,88 +692,103 @@ export function ProfileForm({
           <Separator />
 
           {/* Address */}
-          <div className="space-y-2">
-            <Label htmlFor="address_line1" className="text-base">
-              Street address <Optional />
-            </Label>
-            <Input
-              id="address_line1"
-              value={state.address_line1}
-              onChange={(e) => update("address_line1", e.target.value)}
-              onBlur={(e) =>
-                update("address_line1", titleCaseStreet(e.target.value) || "")
-              }
-              placeholder="123 Main St"
-              className="py-5 text-base"
+          {familyHasAddress && (
+            <CheckRow
+              id="different_address"
+              label="My address is different from my family's home address"
+              checked={differentAddress}
+              onChange={setDifferentAddress}
             />
-            {profile.family_id && (
-              <p className="text-sm text-muted-foreground">
-                Leave blank to use your family&apos;s shared address.
-              </p>
-            )}
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="address_line2" className="text-base">
-              Apt / unit <Optional />
-            </Label>
-            <Input
-              id="address_line2"
-              value={state.address_line2}
-              onChange={(e) => update("address_line2", e.target.value)}
-              onBlur={(e) =>
-                update("address_line2", titleCaseStreet(e.target.value) || "")
-              }
-              placeholder="Apt 4B"
-              className="py-5 text-base"
-            />
-          </div>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-6">
-            <div className="space-y-2 sm:col-span-3">
-              <Label htmlFor="city" className="text-base">
-                City
-              </Label>
-              <Input
-                id="city"
-                value={state.city}
-                onChange={(e) => update("city", e.target.value)}
-                onBlur={(e) =>
-                  update("city", titleCaseCity(e.target.value) || "")
-                }
-                className="py-5 text-base"
+          )}
+          {(!familyHasAddress || differentAddress) && (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="address_line1" className="text-base">
+                  Street address <Optional />
+                </Label>
+                <Input
+                  id="address_line1"
+                  value={state.address_line1}
+                  onChange={(e) => update("address_line1", e.target.value)}
+                  onBlur={(e) =>
+                    update(
+                      "address_line1",
+                      titleCaseStreet(e.target.value) || "",
+                    )
+                  }
+                  placeholder="123 Main St"
+                  className="py-5 text-base"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="address_line2" className="text-base">
+                  Apt / unit <Optional />
+                </Label>
+                <Input
+                  id="address_line2"
+                  value={state.address_line2}
+                  onChange={(e) => update("address_line2", e.target.value)}
+                  onBlur={(e) =>
+                    update(
+                      "address_line2",
+                      titleCaseStreet(e.target.value) || "",
+                    )
+                  }
+                  placeholder="Apt 4B"
+                  className="py-5 text-base"
+                />
+              </div>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-6">
+                <div className="space-y-2 sm:col-span-3">
+                  <Label htmlFor="city" className="text-base">
+                    City
+                  </Label>
+                  <Input
+                    id="city"
+                    value={state.city}
+                    onChange={(e) => update("city", e.target.value)}
+                    onBlur={(e) =>
+                      update("city", titleCaseCity(e.target.value) || "")
+                    }
+                    className="py-5 text-base"
+                  />
+                </div>
+                <div className="space-y-2 sm:col-span-1">
+                  <Label htmlFor="state" className="text-base">
+                    State
+                  </Label>
+                  <Input
+                    id="state"
+                    value={state.state}
+                    onChange={(e) =>
+                      update("state", e.target.value.toUpperCase())
+                    }
+                    maxLength={2}
+                    placeholder="TX"
+                    className="py-5 text-base uppercase"
+                  />
+                </div>
+                <div className="space-y-2 sm:col-span-2">
+                  <Label htmlFor="postal_code" className="text-base">
+                    ZIP
+                  </Label>
+                  <Input
+                    id="postal_code"
+                    value={state.postal_code}
+                    onChange={(e) => update("postal_code", e.target.value)}
+                    placeholder="12345"
+                    className="py-5 text-base"
+                  />
+                </div>
+              </div>
+              <HideRow
+                id="hide_address"
+                label="Hide my address from the directory"
+                checked={state.hide_address}
+                onChange={(v) => update("hide_address", v)}
               />
-            </div>
-            <div className="space-y-2 sm:col-span-1">
-              <Label htmlFor="state" className="text-base">
-                State
-              </Label>
-              <Input
-                id="state"
-                value={state.state}
-                onChange={(e) => update("state", e.target.value.toUpperCase())}
-                maxLength={2}
-                placeholder="TX"
-                className="py-5 text-base uppercase"
-              />
-            </div>
-            <div className="space-y-2 sm:col-span-2">
-              <Label htmlFor="postal_code" className="text-base">
-                ZIP
-              </Label>
-              <Input
-                id="postal_code"
-                value={state.postal_code}
-                onChange={(e) => update("postal_code", e.target.value)}
-                placeholder="12345"
-                className="py-5 text-base"
-              />
-            </div>
-          </div>
-          <HideRow
-            id="hide_address"
-            label="Hide my address from the directory"
-            checked={state.hide_address}
-            onChange={(v) => update("hide_address", v)}
-          />
+            </>
+          )}
 
           <Separator />
 
@@ -809,26 +876,6 @@ export function ProfileForm({
               </div>
             </>
           )}
-
-          <Separator />
-
-          {/* Master directory switch */}
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <Label htmlFor="is_unlisted" className="cursor-pointer text-base">
-                Hide me from the directory completely
-              </Label>
-              <p className="text-sm text-muted-foreground">
-                Your profile will not appear in the member directory at all.
-                Admins can always see all fields.
-              </p>
-            </div>
-            <Switch
-              id="is_unlisted"
-              checked={state.is_unlisted}
-              onCheckedChange={(v) => update("is_unlisted", v)}
-            />
-          </div>
 
           <div className="border-t pt-5">
             <Button

--- a/components/profile/ProfileForm.tsx
+++ b/components/profile/ProfileForm.tsx
@@ -86,6 +86,7 @@ interface FormState {
   hide_birth_year: boolean;
   hide_anniversary: boolean;
   hide_occupation: boolean;
+  is_unlisted: boolean;
 }
 
 function initialState(profile: Profile): FormState {
@@ -118,6 +119,7 @@ function initialState(profile: Profile): FormState {
     hide_birth_year: profile.hide_birth_year ?? false,
     hide_anniversary: profile.hide_anniversary ?? false,
     hide_occupation: profile.hide_occupation ?? false,
+    is_unlisted: profile.is_unlisted ?? false,
   };
 }
 
@@ -309,7 +311,7 @@ export function ProfileForm({
 
     // Validate required shapes — state/zip return null on malformed input.
     if (ownAddress && state.state && !stateCode) {
-      toast.error("State must be a valid 2-letter code or full state name.");
+      toast.error("State must be a 2-letter abbreviation, like TX.");
       setSaving(false);
       return;
     }
@@ -349,11 +351,26 @@ export function ProfileForm({
     const birthDay = state.birth_day ? Number(state.birth_day) : null;
     const birthYear = state.birth_year ? Number(state.birth_year) : null;
 
+    // Calendar-aware birthday check — rejects impossible dates like Feb 31.
+    // Without a year, leap year 2000 is assumed so Feb 29 stays allowed.
+    if (birthDay !== null) {
+      const maxDay = birthMonth
+        ? new Date(birthYear ?? 2000, birthMonth, 0).getDate()
+        : 31;
+      if (!Number.isInteger(birthDay) || birthDay < 1 || birthDay > maxDay) {
+        toast.error("That birthday day doesn't exist in the selected month.");
+        setSaving(false);
+        return;
+      }
+    }
+
     const updates = {
       first_name: firstName,
       last_name: lastName,
       preferred_name: preferredName,
-      email: normalizeEmail(state.email),
+      // The email field is disabled for non-admins (changed via Settings),
+      // and RLS pins profiles.email on non-admin updates — don't send it.
+      ...(isAdmin ? { email: normalizeEmail(state.email) } : {}),
       phone_mobile: phoneMobile,
       phone_home: phoneHome,
       phone_work: phoneWork,
@@ -380,6 +397,7 @@ export function ProfileForm({
       hide_birth_year: state.hide_birth_year,
       hide_anniversary: state.hide_anniversary,
       hide_occupation: state.hide_occupation,
+      is_unlisted: state.is_unlisted,
     };
 
     const { error } = await supabase
@@ -831,6 +849,21 @@ export function ProfileForm({
               onChange={(v) => update("hide_occupation", v)}
             />
           )}
+
+          <Separator />
+
+          {/* Directory listing */}
+          <div className="space-y-1">
+            <HideRow
+              id="is_unlisted"
+              label="Hide me from the directory entirely"
+              checked={state.is_unlisted}
+              onChange={(v) => update("is_unlisted", v)}
+            />
+            <p className="text-sm text-muted-foreground">
+              The profile will not appear in the member directory at all.
+            </p>
+          </div>
 
           {/* Family assignment (admin only) */}
           {isAdmin && (

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -137,9 +137,15 @@ export async function sendFeedbackEmail(
         <div style="background: #F3F7FB; padding: 20px; border-radius: 8px; margin: 20px 0;">
           <p style="font-size: 18px; line-height: 1.6; margin: 0; color: #44403c;">${safeMessage}</p>
         </div>
-        <p style="font-size: 14px; color: #78716c; margin-top: 40px;">
+        ${
+          senderEmail
+            ? `<p style="font-size: 14px; color: #78716c; margin-top: 40px;">
           Reply to this email to answer them directly.
-        </p>
+        </p>`
+            : `<p style="font-size: 14px; color: #78716c; margin-top: 40px;">
+          They don't have an email address on file, so this email can't be replied to directly.
+        </p>`
+        }
       </div>
     `,
   });

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -110,6 +110,46 @@ export async function sendFamilyInviteEmail(
   }
 }
 
+export async function sendFeedbackEmail(
+  to: string[],
+  senderName: string,
+  senderEmail: string | null,
+  type: "idea" | "problem",
+  message: string
+) {
+  const kind = type === "problem" ? "Something's broken" : "An idea";
+  const safeSenderName = escapeHtml(senderName);
+  const safeMessage = escapeHtml(message).replace(/\n/g, "<br />");
+
+  const { error } = await getResend().emails.send({
+    from: siteConfig.email.from,
+    to,
+    ...(senderEmail ? { replyTo: senderEmail } : {}),
+    subject: `${siteConfig.name} feedback from ${senderName}: ${kind}`,
+    html: `
+      <div style="font-family: Georgia, serif; max-width: 600px; margin: 0 auto; padding: 40px 20px;">
+        <h1 style="color: ${siteConfig.colors.primary}; font-size: 28px;">Member feedback</h1>
+        <p style="font-size: 18px; line-height: 1.6; color: #44403c;">
+          <strong>${safeSenderName}</strong>${senderEmail ? ` (${escapeHtml(senderEmail)})` : ""}
+          sent feedback from the Settings page.
+        </p>
+        <p style="font-size: 16px; color: #78716c; margin: 0;">Type: <strong>${kind}</strong></p>
+        <div style="background: #F3F7FB; padding: 20px; border-radius: 8px; margin: 20px 0;">
+          <p style="font-size: 18px; line-height: 1.6; margin: 0; color: #44403c;">${safeMessage}</p>
+        </div>
+        <p style="font-size: 14px; color: #78716c; margin-top: 40px;">
+          Reply to this email to answer them directly.
+        </p>
+      </div>
+    `,
+  });
+
+  if (error) {
+    console.error("Failed to send feedback email:", error);
+    throw error;
+  }
+}
+
 export async function sendEventReminderEmail(
   email: string,
   name: string,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -43,6 +43,7 @@ export interface Profile {
   is_prayer_team: boolean;
   is_greeter_team: boolean;
   is_prayer_warrior: boolean;
+  email_announcements: boolean;
   setup_completed: boolean;
   approved_at: string | null;
   approved_by: string | null;

--- a/supabase/migrations/20260715000000_fix_profiles_update_recursion.sql
+++ b/supabase/migrations/20260715000000_fix_profiles_update_recursion.sql
@@ -20,6 +20,22 @@ as $$
   );
 $$;
 
+-- Own-row lookups for the self-update branch. get_profile_role/email are
+-- household-scoped (family_id = current_family_id()) so they return null
+-- for profiles without a family — e.g. during the setup wizard. These read
+-- the caller's own row unconditionally.
+create or replace function public.get_own_role() returns text
+language sql stable security definer set search_path = ''
+as $$
+  select role from public.profiles where id = auth.uid();
+$$;
+
+create or replace function public.get_own_email() returns text
+language sql stable security definer set search_path = ''
+as $$
+  select email from public.profiles where id = auth.uid();
+$$;
+
 drop policy if exists "Profiles are updatable per access rules" on public.profiles;
 create policy "Profiles are updatable per access rules"
   on public.profiles for update
@@ -34,7 +50,15 @@ create policy "Profiles are updatable per access rules"
     )
   )
   with check (
-    (select auth.uid()) = id
+    (
+      -- Self-updates cannot change role (privilege escalation) or email
+      -- (login identity — kept in sync from auth.users by trigger).
+      -- family_id and relationship stay self-editable: the setup wizard
+      -- sets one's own family and the household picker sets relationship.
+      (select auth.uid()) = id
+      and role = (select public.get_own_role())
+      and (email is not distinct from (select public.get_own_email()))
+    )
     or (select public.is_admin())
     or (
       family_id = (select public.current_family_id())

--- a/supabase/migrations/20260715000000_fix_profiles_update_recursion.sql
+++ b/supabase/migrations/20260715000000_fix_profiles_update_recursion.sql
@@ -1,0 +1,44 @@
+-- ============================================================
+-- Fix: profiles UPDATE policy self-reference recursion
+-- ============================================================
+-- "Profiles are updatable per access rules" referenced public.profiles
+-- directly in an EXISTS subquery. A policy that references its own table
+-- recurses when Postgres applies it, so every non-admin profile UPDATE
+-- failed with:
+--   42P17: infinite recursion detected in policy for relation "profiles"
+-- Move the household-manager check into a SECURITY DEFINER helper (same
+-- pattern as is_admin/is_member) so the policy no longer self-references.
+
+create or replace function public.is_household_manager() returns boolean
+language sql stable security definer set search_path = ''
+as $$
+  select exists (
+    select 1 from public.profiles
+    where id = auth.uid()
+      and relationship in ('primary', 'spouse')
+      and role in ('member', 'content_editor', 'admin')
+  );
+$$;
+
+drop policy if exists "Profiles are updatable per access rules" on public.profiles;
+create policy "Profiles are updatable per access rules"
+  on public.profiles for update
+  using (
+    (select auth.uid()) = id
+    or (select public.is_admin())
+    or (
+      (select auth.uid()) != id
+      and family_id is not null
+      and family_id = (select public.current_family_id())
+      and (select public.is_household_manager())
+    )
+  )
+  with check (
+    (select auth.uid()) = id
+    or (select public.is_admin())
+    or (
+      family_id = (select public.current_family_id())
+      and role = public.get_profile_role(id)
+      and (email is not distinct from public.get_profile_email(id))
+    )
+  );

--- a/supabase/migrations/20260716000000_sync_auth_email_to_profile.sql
+++ b/supabase/migrations/20260716000000_sync_auth_email_to_profile.sql
@@ -1,0 +1,22 @@
+-- ============================================================
+-- Sync login email changes to profiles.email
+-- ============================================================
+-- Members can now change their own login email from the Settings page
+-- (supabase.auth.updateUser). Once the change is confirmed, auth.users
+-- is updated — mirror it onto the profile so the directory and admin
+-- views show the current address.
+
+create or replace function public.handle_auth_user_email_change()
+returns trigger as $$
+begin
+  update public.profiles set email = new.email where id = new.id;
+  return new;
+end;
+$$ language plpgsql security definer set search_path = '';
+
+drop trigger if exists on_auth_user_email_changed on auth.users;
+create trigger on_auth_user_email_changed
+  after update of email on auth.users
+  for each row
+  when (old.email is distinct from new.email)
+  execute procedure public.handle_auth_user_email_change();

--- a/supabase/migrations/20260716000001_settings_notifications_feedback.sql
+++ b/supabase/migrations/20260716000001_settings_notifications_feedback.sql
@@ -1,0 +1,30 @@
+-- Settings page: notification preference + member feedback.
+
+-- Per-member opt-out for announcement emails. Nothing in-app sends these
+-- yet (announcements go out via Resend broadcasts); the audience sync
+-- reads this flag so opted-out members are excluded.
+alter table public.profiles
+  add column email_announcements boolean not null default true;
+
+-- Feedback submitted from Settings. Rows are the durable record; admins
+-- also get an email copy on submit.
+create table public.feedback (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid references public.profiles(id) on delete set null,
+  type text not null check (type in ('idea', 'problem')),
+  message text not null check (char_length(message) between 1 and 2000),
+  created_at timestamptz not null default now()
+);
+
+alter table public.feedback enable row level security;
+
+create policy "Members can submit their own feedback"
+  on public.feedback for insert
+  with check (
+    (select auth.uid()) = profile_id
+    and (select public.is_member())
+  );
+
+create policy "Admins can read feedback"
+  on public.feedback for select
+  using ((select public.is_admin()));


### PR DESCRIPTION
## Summary

Implements screens 4 (My Profile) and 10 (Settings) from the InCouragers redesign, plus a pre-existing RLS bug fix found while verifying.

### My Profile (screen 4)
- "How others see you" summary card with privacy-masked phone/city and a directory preview
- Family Info card: shared address/home phone, family photo, member tiles with contextual Edit links
- ProfileForm flattened from tabs to a single card with inline privacy switches; shared with admin members edit and household member edit
- Last name and address default to the family's behind "different from my family" checkboxes; About me field and unlisted switch removed from the form

### Settings (screen 10)
- **Display**: Normal/Large/Larger text size, applied app-wide by scaling the Tailwind font-size variables under `data-textsize` on `<html>`; saved in localStorage and applied before first paint by a nonce'd head script (CSP nonce read from the `x-nonce` header)
- **Sign in & security**: inline change-password form that verifies the current password first, email change with Supabase double confirmation, sign out
- **Notifications**: `profiles.email_announcements` flag for the future Resend audience sync to respect
- **Feedback**: idea/problem note stored in a new `feedback` table (admins can read) and emailed to admins best-effort via `/api/feedback`
- Settings added to the sidebar nav; the redesign's contrast corrections (muted text #435066, borders #D8D2C4) promoted to app-wide defaults instead of an opt-in toggle

### Fixes
- profiles UPDATE policy self-referenced profiles in an inline EXISTS → 42P17 infinite recursion; all non-admin profile saves have been broken since migration 20260706000003. Fixed with an `is_household_manager()` security-definer helper (migration 20260715000000)

### Migrations
- `20260715000000` — profiles update policy recursion fix
- `20260716000000` — trigger syncing confirmed auth email changes to profiles.email
- `20260716000001` — `profiles.email_announcements` + `feedback` table with RLS

## Test plan
- [x] Verified end-to-end in the browser on the local stack: profile save, family defaults, text-size persistence across reloads, password change (wrong current password rejected, correct one succeeds), notifications toggle persisted to DB, feedback row inserted
- [x] `tsc --noEmit` and `npm run lint` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Settings with text-size preferences, email announcement notifications, sign-in/security controls, and feedback submission.
  * Feedback now supports typed ideas/problems with validation and per-user rate limiting.
  * Updated profile experience with family-aware data, improved editing flow, and consolidated privacy controls.
  * Added “Settings” to the main sidebar navigation.
* **Bug Fixes**
  * Fixed profile update permission/policy recursion and improved auth email-to-profile synchronization.
* **Style**
  * Added scalable typography tokens and refined muted/border/input theme colors.
  * Removed biography text from directory cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->