### PR TITLE
feat: make group roles deployment-configurable

### DIFF
--- a/app/admin/groups/GroupRosterDialog.tsx
+++ b/app/admin/groups/GroupRosterDialog.tsx
@@ -32,8 +32,8 @@ interface GroupRosterDialogProps {
 /**
  * Group roster management, Okta-style: the default view shows only who is
  * currently in the group (with remove), and an explicit "Add members" mode
- * searches the rest of the class. Functional-role booleans stay in sync via
- * setGroupMembership.
+ * searches the rest of the class. Denormalized role flags on profiles stay
+ * in sync via database triggers.
  */
 export function GroupRosterDialog({
   group,

--- a/app/admin/groups/page.tsx
+++ b/app/admin/groups/page.tsx
@@ -26,6 +26,7 @@ import {
   Users,
   Filter,
   HandHeart,
+  Shield,
 } from "lucide-react";
 import type { MemberGroup } from "@/lib/types";
 import { GroupRosterDialog } from "./GroupRosterDialog";
@@ -38,6 +39,7 @@ interface GroupFormState {
   icon: string;
   show_in_directory_filter: boolean;
   is_serving_role: boolean;
+  grants_prayer_access: boolean;
 }
 
 const EMPTY_FORM: GroupFormState = {
@@ -47,6 +49,7 @@ const EMPTY_FORM: GroupFormState = {
   icon: "users",
   show_in_directory_filter: true,
   is_serving_role: false,
+  grants_prayer_access: false,
 };
 
 function fromGroup(g: MemberGroup): GroupFormState {
@@ -57,6 +60,7 @@ function fromGroup(g: MemberGroup): GroupFormState {
     icon: g.icon || "users",
     show_in_directory_filter: g.show_in_directory_filter ?? true,
     is_serving_role: g.is_serving_role ?? false,
+    grants_prayer_access: g.grants_prayer_access ?? false,
   };
 }
 
@@ -124,8 +128,6 @@ export default function GroupsPage() {
       return;
     }
 
-    // functional_role is intentionally omitted: the hidden scheduling link on
-    // the seeded groups is preserved as-is until a feature actually uses it.
     const payload = {
       name: form.name.trim(),
       description: form.description.trim() || null,
@@ -133,6 +135,7 @@ export default function GroupsPage() {
       icon: form.icon || null,
       show_in_directory_filter: form.show_in_directory_filter,
       is_serving_role: form.is_serving_role,
+      grants_prayer_access: form.grants_prayer_access,
     };
 
     setSaving(true);
@@ -284,6 +287,12 @@ export default function GroupsPage() {
                         <Badge variant="secondary" className="text-xs gap-1">
                           <HandHeart className="h-3 w-3" />
                           Serving role
+                        </Badge>
+                      )}
+                      {group.grants_prayer_access && (
+                        <Badge variant="secondary" className="text-xs gap-1">
+                          <Shield className="h-3 w-3" />
+                          Prayer access
                         </Badge>
                       )}
                     </div>
@@ -446,6 +455,23 @@ export default function GroupsPage() {
                 checked={form.is_serving_role}
                 onCheckedChange={(v) =>
                   setForm({ ...form, is_serving_role: v })
+                }
+              />
+            </div>
+
+            <div className="flex items-center justify-between rounded-lg border p-3">
+              <div className="space-y-0.5">
+                <Label htmlFor="g_prayer">Prayer wall access</Label>
+                <p className="text-xs text-muted-foreground">
+                  Members of this group can see prayer requests marked for
+                  prayer warriors.
+                </p>
+              </div>
+              <Switch
+                id="g_prayer"
+                checked={form.grants_prayer_access}
+                onCheckedChange={(v) =>
+                  setForm({ ...form, grants_prayer_access: v })
                 }
               />
             </div>

--- a/app/prayer/page.tsx
+++ b/app/prayer/page.tsx
@@ -40,8 +40,9 @@ export default async function PrayerPage() {
       .order("display_order")
       .order("created_at"),
     loadFundFormData(supabase),
-    // Roster of the Prayer Warriors group so posters can see who a
-    // warrior-restricted request will reach. RLS trims this to listed profiles.
+    // Roster of everyone with prayer-wall access (members of any group that
+    // grants it) so posters can see who a warrior-restricted request will
+    // reach. RLS trims this to listed profiles.
     supabase
       .from("profiles")
       .select("id, first_name, last_name, preferred_name, avatar_url")

--- a/components/profile/MemberGroupsSection.tsx
+++ b/components/profile/MemberGroupsSection.tsx
@@ -16,9 +16,8 @@ interface MemberGroupsSectionProps {
 /**
  * Admin-only section within the member edit page.
  * Displays all member groups as checkboxes — toggling a group
- * assigns or removes the member from that group.
- * When a group has a functional_role, the corresponding boolean on
- * profiles (is_prayer_team / is_greeter_team) is also synced.
+ * assigns or removes the member from that group. Denormalized role
+ * flags on profiles are kept in sync by database triggers.
  */
 export function MemberGroupsSection({ profileId }: MemberGroupsSectionProps) {
   const [groups, setGroups] = useState<MemberGroup[]>([]);

--- a/lib/memberGroups.ts
+++ b/lib/memberGroups.ts
@@ -1,19 +1,9 @@
 import { createClient } from "@/lib/supabase/client";
 import type { MemberGroup } from "@/lib/types";
 
-/** Map a functional role to its denormalized boolean column on profiles */
-const ROLE_COLUMNS: Record<
-  NonNullable<MemberGroup["functional_role"]>,
-  "is_prayer_team" | "is_greeter_team" | "is_prayer_warrior"
-> = {
-  prayer_team: "is_prayer_team",
-  greeter_team: "is_greeter_team",
-  prayer_warriors: "is_prayer_warrior",
-};
-
 /**
- * Add or remove a member from a group, keeping the functional-role boolean
- * on profiles in sync when the group has one.
+ * Add or remove a member from a group. Denormalized role flags on profiles
+ * (is_prayer_warrior) are kept in sync by database triggers.
  *
  * @returns an error message to show the user, or null on success
  */
@@ -37,32 +27,6 @@ export async function setGroupMembership(
       .eq("profile_id", profileId)
       .eq("group_id", group.id);
     if (error) return `Failed to remove from ${group.name}.`;
-  }
-
-  if (group.functional_role) {
-    const column = ROLE_COLUMNS[group.functional_role];
-    const { error } = await supabase
-      .from("profiles")
-      .update({ [column]: member })
-      .eq("id", profileId);
-    if (error) {
-      // Roll back the membership change so the roster and the denormalized
-      // role flag never disagree.
-      if (member) {
-        await supabase
-          .from("profile_groups")
-          .delete()
-          .eq("profile_id", profileId)
-          .eq("group_id", group.id);
-      } else {
-        await supabase
-          .from("profile_groups")
-          .insert({ profile_id: profileId, group_id: group.id });
-      }
-      return member
-        ? `Failed to add to ${group.name}.`
-        : `Failed to remove from ${group.name}.`;
-    }
   }
 
   return null;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -40,8 +40,7 @@ export interface Profile {
   hide_occupation: boolean;
   hide_birth_year: boolean;
   relationship: FamilyMemberRelationship;
-  is_prayer_team: boolean;
-  is_greeter_team: boolean;
+  /** Denormalized from prayer-access group membership; DB triggers own it */
   is_prayer_warrior: boolean;
   email_announcements: boolean;
   setup_completed: boolean;
@@ -221,7 +220,7 @@ export interface FamilyMember {
   updated_at: string;
 }
 
-/** A member group (prayer team, greeter team, custom groups, etc.) */
+/** An admin-defined member group; names and roles vary per deployment */
 export interface MemberGroup {
   id: string;
   name: string;
@@ -229,7 +228,8 @@ export interface MemberGroup {
   color: string | null;
   icon: string | null;
   display_order: number;
-  functional_role: "prayer_team" | "greeter_team" | "prayer_warriors" | null;
+  /** Members can see prayer requests restricted to prayer warriors */
+  grants_prayer_access: boolean;
   show_in_directory_filter: boolean;
   /** Listed on the Serve page as a standing role/team (vs. a directory-only tag) */
   is_serving_role: boolean;

--- a/supabase/migrations/20260422000002_member_groups.sql
+++ b/supabase/migrations/20260422000002_member_groups.sql
@@ -79,14 +79,10 @@ create policy "Admins can delete profile groups"
   on public.profile_groups for delete
   using (public.is_admin());
 
--- ==================
--- SEED: Default groups (Prayer Team, Greeter Team)
--- ==================
-insert into public.member_groups (name, description, color, icon, display_order, functional_role)
-values
-  ('Prayer Team', 'Available for Sunday prayer assignment', '#059669', 'heart', 0, 'prayer_team'),
-  ('Greeter Team', 'Available to greet on Sundays', '#f59e0b', 'hand-helping', 1, 'greeter_team')
-on conflict do nothing;
+-- No seed rows: groups are deployment-specific and created by admins at
+-- /admin/groups. (Historical note: this migration originally seeded Prayer
+-- Team and Greeter Team; the inserts were removed after this version was
+-- applied to existing databases, so only fresh deployments see the change.)
 
 -- ==================
 -- BACKFILL: Create group assignments from existing is_prayer_team / is_greeter_team flags

--- a/supabase/migrations/20260708000000_prayer.sql
+++ b/supabase/migrations/20260708000000_prayer.sql
@@ -11,7 +11,7 @@
 -- with. Prayer call leaders (leader_id on a session) get no special read access.
 
 -- ==================
--- ROLE: prayer warriors (profile flag + seeded member group)
+-- ROLE: prayer warriors (profile flag)
 -- ==================
 alter table public.profiles
   add column is_prayer_warrior boolean not null default false;
@@ -22,17 +22,10 @@ alter table public.member_groups
   add constraint member_groups_functional_role_check
   check (functional_role in ('prayer_team', 'greeter_team', 'prayer_warriors'));
 
-insert into public.member_groups (name, description, color, icon, display_order, functional_role)
-select
-  'Prayer Warriors',
-  'Sees prayer requests shared with prayer warriors',
-  '#8A6BB5',
-  'shield',
-  coalesce((select max(display_order) + 1 from public.member_groups), 0),
-  'prayer_warriors'
-where not exists (
-  select 1 from public.member_groups where functional_role = 'prayer_warriors'
-);
+-- No seed row: each deployment designates its own prayer-access group at
+-- /admin/groups. (Historical note: this migration originally seeded a
+-- "Prayer Warriors" group; the insert was removed after this version was
+-- applied to existing databases, so only fresh deployments see the change.)
 
 -- ==================
 -- PRAYER_CALL_SESSIONS: the weekly prayer call card (supports multiple sessions)

--- a/supabase/migrations/20260716000002_configurable_group_roles.sql
+++ b/supabase/migrations/20260716000002_configurable_group_roles.sql
@@ -45,6 +45,13 @@ returns trigger as $$
 declare
   _profile_id uuid := coalesce(new.profile_id, old.profile_id);
 begin
+  -- Lock the profile row before recomputing so concurrent membership changes
+  -- for the same profile serialize here: under read committed, the statement
+  -- after the lock is granted runs with a fresh snapshot that includes the
+  -- other transaction's committed writes, so the last recompute can't clobber
+  -- the flag with a stale membership view.
+  perform 1 from public.profiles where id = _profile_id for update;
+
   update public.profiles
   set is_prayer_warrior = exists (
     select 1
@@ -68,6 +75,16 @@ create trigger profile_groups_sync_prayer_access
 create or replace function public.sync_prayer_access_for_group()
 returns trigger as $$
 begin
+  -- Same locking discipline as the per-profile sync, and in deterministic
+  -- (id) order so two concurrent group-wide recomputes can't deadlock.
+  perform 1
+  from public.profiles
+  where id in (
+    select profile_id from public.profile_groups where group_id = new.id
+  )
+  order by id
+  for update;
+
   update public.profiles p
   set is_prayer_warrior = exists (
     select 1

--- a/supabase/migrations/20260716000002_configurable_group_roles.sql
+++ b/supabase/migrations/20260716000002_configurable_group_roles.sql
@@ -1,0 +1,109 @@
+-- Deployment-configurable group roles.
+--
+-- member_groups.functional_role hardwired specific seeded groups
+-- ('prayer_team', 'greeter_team', 'prayer_warriors') to app features. Only
+-- 'prayer_warriors' was ever consumed (the prayer wall RLS reads the
+-- denormalized profiles.is_prayer_warrior flag); the other two booleans were
+-- dead. Replace the enum with a grants_prayer_access capability flag that an
+-- admin can put on any group, so each deployment designates its own prayer
+-- group instead of depending on a seeded name.
+--
+-- profiles.is_prayer_warrior stays as a denormalized flag because the
+-- prayer_requests RLS helper (public.is_prayer_warrior) reads it per request;
+-- triggers below now own keeping it in sync (app code no longer writes it).
+
+-- ==================
+-- CAPABILITY FLAG
+-- ==================
+alter table public.member_groups
+  add column grants_prayer_access boolean not null default false;
+
+update public.member_groups
+  set grants_prayer_access = true
+  where functional_role = 'prayer_warriors';
+
+-- ==================
+-- DROP THE HARDCODED ROLE ENUM + DEAD PROFILE BOOLEANS
+-- ==================
+drop index if exists public.member_groups_functional_role_idx;
+
+alter table public.member_groups
+  drop column functional_role;
+
+alter table public.profiles
+  drop column is_prayer_team,
+  drop column is_greeter_team;
+
+-- ==================
+-- TRIGGERS: keep profiles.is_prayer_warrior in sync with group membership
+-- ==================
+-- Membership changes: recompute the one affected profile. A profile is a
+-- prayer warrior when it belongs to at least one group granting access, so
+-- removal from one granting group doesn't clear the flag if another remains.
+create or replace function public.sync_prayer_access_for_profile()
+returns trigger as $$
+declare
+  _profile_id uuid := coalesce(new.profile_id, old.profile_id);
+begin
+  update public.profiles
+  set is_prayer_warrior = exists (
+    select 1
+    from public.profile_groups pg
+    join public.member_groups g on g.id = pg.group_id
+    where pg.profile_id = _profile_id
+      and g.grants_prayer_access
+  )
+  where id = _profile_id;
+  return null;
+end;
+$$ language plpgsql security definer set search_path = '';
+
+-- Deleting a granting group is covered too: the profile_groups rows go away
+-- via on delete cascade, which fires this row trigger for each member.
+create trigger profile_groups_sync_prayer_access
+  after insert or delete on public.profile_groups
+  for each row execute function public.sync_prayer_access_for_profile();
+
+-- Flag toggled on an existing group: recompute everyone currently in it.
+create or replace function public.sync_prayer_access_for_group()
+returns trigger as $$
+begin
+  update public.profiles p
+  set is_prayer_warrior = exists (
+    select 1
+    from public.profile_groups pg
+    join public.member_groups g on g.id = pg.group_id
+    where pg.profile_id = p.id
+      and g.grants_prayer_access
+  )
+  where p.id in (
+    select profile_id from public.profile_groups where group_id = new.id
+  );
+  return null;
+end;
+$$ language plpgsql security definer set search_path = '';
+
+create trigger member_groups_sync_prayer_access
+  after update of grants_prayer_access on public.member_groups
+  for each row
+  when (old.grants_prayer_access is distinct from new.grants_prayer_access)
+  execute function public.sync_prayer_access_for_group();
+
+-- ==================
+-- BACKFILL: one-time recompute to correct any drift from the manual-sync era
+-- ==================
+update public.profiles p
+set is_prayer_warrior = exists (
+  select 1
+  from public.profile_groups pg
+  join public.member_groups g on g.id = pg.group_id
+  where pg.profile_id = p.id
+    and g.grants_prayer_access
+)
+where p.is_prayer_warrior is distinct from exists (
+  select 1
+  from public.profile_groups pg
+  join public.member_groups g on g.id = pg.group_id
+  where pg.profile_id = p.id
+    and g.grants_prayer_access
+);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -52,6 +52,6 @@ UPDATE public.profiles SET role = 'admin' WHERE id = 'a0000000-0000-0000-0000-00
 -- Dev-only starter group so the prayer wall's restricted-visibility flow is
 -- testable locally. Production deployments create their own groups at
 -- /admin/groups.
-INSERT INTO public.member_groups (name, description, color, icon, display_order, grants_prayer_access, is_serving_role)
-VALUES ('Prayer Warriors', 'Sees prayer requests shared with prayer warriors', '#8A6BB5', 'shield', 0, true, true)
-ON CONFLICT DO NOTHING;
+INSERT INTO public.member_groups (id, name, description, color, icon, display_order, grants_prayer_access, is_serving_role)
+VALUES ('b0000000-0000-0000-0000-000000000001', 'Prayer Warriors', 'Sees prayer requests shared with prayer warriors', '#8A6BB5', 'shield', 0, true, true)
+ON CONFLICT (id) DO NOTHING;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -48,3 +48,10 @@ ON CONFLICT (id) DO NOTHING;
 -- The handle_new_user trigger auto-creates the profile with role 'pending',
 -- so we just update it to admin
 UPDATE public.profiles SET role = 'admin' WHERE id = 'a0000000-0000-0000-0000-000000000001';
+
+-- Dev-only starter group so the prayer wall's restricted-visibility flow is
+-- testable locally. Production deployments create their own groups at
+-- /admin/groups.
+INSERT INTO public.member_groups (name, description, color, icon, display_order, grants_prayer_access, is_serving_role)
+VALUES ('Prayer Warriors', 'Sees prayer requests shared with prayer warriors', '#8A6BB5', 'shield', 0, true, true)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary

Removes the last hardcoded group coupling so every deployment defines its own member groups. The `member_groups.functional_role` enum (`prayer_team` / `greeter_team` / `prayer_warriors`) is replaced by a `grants_prayer_access` flag an admin can put on **any** group.

## Changes

### Migration (`20260716000002_configurable_group_roles.sql`)
- Add `member_groups.grants_prayer_access`, backfilled from `functional_role = 'prayer_warriors'`
- Drop `functional_role` (+ its index) and the never-consumed `profiles.is_prayer_team` / `is_greeter_team` booleans
- `profiles.is_prayer_warrior` stays (the prayer-wall RLS helper reads it per request) but is now **trigger-owned**: membership insert/delete, flag toggles on a group with existing members, and group deletion (via `on delete cascade`) all recompute it. A profile keeps the flag while it belongs to *any* granting group.
- One-time recompute to correct any drift from the manual-sync era

### Seed removal
- The Prayer Team / Greeter Team / Prayer Warriors seed inserts were edited out of the already-applied migrations (`20260422000002`, `20260708000000`). Existing databases skip those versions by number, so this only affects fresh deployments, which now start with zero groups. Comments in both files document the history edit.
- A dev-only starter group moved to `supabase/seed.sql` (runs only on local `db reset`) so the restricted-prayer flow stays testable on a fresh local stack.

### App
- `/admin/groups`: new "Prayer wall access" toggle in the group dialog + Shield badge on the list
- `lib/memberGroups.ts`: `setGroupMembership` no longer mirrors booleans client-side (and loses its rollback dance) — the database owns the denormalized flag
- `lib/types.ts`: `MemberGroup.functional_role` → `grants_prayer_access`; dead Profile booleans removed

## Testing

- Migration applied to local DB via `supabase migration up --db-url ...`; backfill verified (existing Prayer Warriors group flagged, warrior count preserved, dead columns gone)
- All four trigger paths exercised in a rolled-back transaction: add member → `true`, remove → `false`, grant flag to group with existing members → `true`, delete granting group → cascade clears to `false`
- `tsc --noEmit` and `eslint` clean

## Notes for existing deployment

No functional change: current groups keep working, the Prayer Warriors group simply carries the new flag instead of the enum value. Groups are now freely renameable/deletable; prayer-wall access follows whichever group(s) have the toggle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable prayer wall access for groups.
  * Administrators can enable or disable “Prayer wall access” when creating or editing groups.
  * Groups with prayer wall access now display a clear access badge.
  * Prayer wall permissions automatically stay aligned with group membership.
  * Development environments now include a starter Prayer Warriors group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->