### PR TITLE
docs: add agent guardrails (CLAUDE.md) and Archon worktree env copy

### DIFF
--- a/.archon/config.yaml
+++ b/.archon/config.yaml
@@ -8,3 +8,9 @@
 #       model: sonnet
 #   docs:
 #     path: docs
+
+# Copy gitignored local config into each Archon worktree so dev servers
+# and Supabase clients work out of the box.
+worktree:
+  copyFiles:
+    - .env.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,6 @@ Next.js + Supabase app for a church small group, deployed on Vercel. Open source
 ## UI conventions
 
 - Plain, functional copy: verb+noun labels, no salesy subtitles or cute metaphors.
-- The audience is 50–85 years old: large type, high contrast, generous touch targets.
+- The audience spans adults 18+ through members in their late 80s. Design for the oldest members — large type, high contrast, generous touch targets — without making the UI feel dated to younger ones.
 - Assignment/roster UIs show current members by default with an explicit "add" mode — never render full toggle lists of every person.
 - Base UI `Select` components must receive the `items` prop, or the trigger renders raw values.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md
+
+Guidance for AI agents working in this repo — interactive Claude Code sessions and autonomous Archon workflow runs alike. See `AGENTS.md` for additional agent notes.
+
+## Project
+
+Next.js + Supabase app for a church small group, deployed on Vercel. Open source. Releases are automated with semantic-release on conventional commits.
+
+## Database — hard rules
+
+- **Never touch the remote Supabase project.** No `supabase db push`, no `supabase migration repair` without `--db-url` pointing at local, no direct remote connections. The CI/CD pipeline is the sole owner of remote schema state.
+- **Never run `supabase db reset`.** It wipes local test data. To apply pending migrations locally:
+
+  ```bash
+  supabase migration up --db-url postgresql://postgres:postgres@127.0.0.1:54322/postgres
+  ```
+
+- The local Supabase stack (API `:54321`, Postgres `:54322`, Studio `:54323`) is a **single shared instance** used by every worktree and parallel agent session. Never stop, restart, or reset it.
+- Migrations are timestamped SQL files in `supabase/migrations/`. Keep them additive. Only one in-flight branch should introduce migrations at a time; if your task needs a schema change and another open PR already adds migrations, flag it instead of racing.
+
+## Git & PRs
+
+- Conventional commits. Only `fix`, `feat`, `perf`, and breaking changes trigger a release. Use `ci:` / `ci(scope):` commits on `ci/` branches for CI/infra changes; `docs:` / `chore:` for other non-release changes.
+- **Never merge a PR** — not even when CI is green or you're told to "merge it in". Open the PR (draft is fine) and stop; Cody reviews and merges personally.
+- Do not include Claude/AI session links in PR titles or bodies.
+
+## Local dev
+
+- Multiple dev servers run in parallel worktrees. Pick a free port (`npm run dev -- -p <port>`) instead of assuming `:3000`.
+- `npm install` may need real network access; sandboxed installs often fail DNS resolution in this repo (see `AGENTS.md`).
+
+## UI conventions
+
+- Plain, functional copy: verb+noun labels, no salesy subtitles or cute metaphors.
+- The audience is 50–85 years old: large type, high contrast, generous touch targets.
+- Assignment/roster UIs show current members by default with an explicit "add" mode — never render full toggle lists of every person.
+- Base UI `Select` components must receive the `items` prop, or the trigger renders raw values.


### PR DESCRIPTION
## Summary

- Add a repo-root `CLAUDE.md` so every AI agent session (interactive Claude Code and autonomous Archon workflow runs) inherits the project's working rules:
  - **Database**: local-only migrations via `supabase migration up --db-url`, never `db reset`, never touch the remote project; the local Supabase stack is a single shared instance across worktrees
  - **Git/PRs**: release-safe conventional-commit usage, agents never merge PRs, no AI session links in PR bodies
  - **Local dev**: per-worktree dev server ports, `npm install` network note
  - **UI conventions**: plain functional copy, senior-friendly type/contrast/touch targets, roster add-mode pattern, Base UI `Select` `items` prop
- Configure `.archon/config.yaml` with `worktree.copyFiles: [.env.local]` so Archon-created worktrees get local env and work out of the box

## Why

Scaling up to multiple parallel agent sessions (Archon detached runs on GitHub issues): these rules previously lived only in session memory, which autonomous worktree runs don't inherit. Committing them makes every worker session follow the same guardrails.

Docs/config only — no app code changes, no release triggered.