### PR TITLE
fix: show labels in Select triggers and use shared Select/Switch controls

### DIFF
--- a/app/admin/lectures/[id]/edit/page.tsx
+++ b/app/admin/lectures/[id]/edit/page.tsx
@@ -9,6 +9,13 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { toast } from "sonner";
 
 type Lecture = {
@@ -32,6 +39,7 @@ export default function EditLecturePage() {
     "loading",
   );
   const [seriesList, setSeriesList] = useState<{ id: string; name: string; teacher: string | null }[]>([]);
+  const [seriesId, setSeriesId] = useState("none");
   const router = useRouter();
   const params = useParams();
   const supabase = useMemo(() => createClient(), []);
@@ -56,6 +64,7 @@ export default function EditLecturePage() {
           return;
         }
         setLecture(lectureData as Lecture);
+        setSeriesId((lectureData as Lecture).series_id ?? "none");
         setLoadState("ready");
       } catch (err) {
         console.error("Failed to load lecture", err);
@@ -79,7 +88,7 @@ export default function EditLecturePage() {
         video_url: formData.get("video_url") as string,
         thumbnail_url: (formData.get("thumbnail_url") as string) || null,
         lecture_date: (formData.get("lecture_date") as string) || null,
-        series_id: (formData.get("series_id") as string) || null,
+        series_id: seriesId === "none" ? null : seriesId,
         summary: (formData.get("summary") as string) || null,
       })
       .eq("id", params.id as string);
@@ -144,19 +153,29 @@ export default function EditLecturePage() {
             {/* Series */}
             <div className="space-y-2">
               <Label htmlFor="series_id" className="text-lg">Series</Label>
-              <select
-                id="series_id"
-                name="series_id"
-                defaultValue={lecture.series_id ?? ""}
-                className="w-full border border-input rounded-md px-3 py-3 text-base bg-background"
+              <Select
+                items={[
+                  { value: "none", label: "No series" },
+                  ...seriesList.map((s) => ({
+                    value: s.id,
+                    label: `${s.name}${s.teacher ? ` — ${s.teacher}` : ""}`,
+                  })),
+                ]}
+                value={seriesId}
+                onValueChange={(v) => setSeriesId(v ?? "none")}
               >
-                <option value="">No series</option>
-                {seriesList.map((s) => (
-                  <option key={s.id} value={s.id}>
-                    {s.name}{s.teacher ? ` — ${s.teacher}` : ""}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger id="series_id" className="w-full text-base py-5">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">No series</SelectItem>
+                  {seriesList.map((s) => (
+                    <SelectItem key={s.id} value={s.id}>
+                      {s.name}{s.teacher ? ` — ${s.teacher}` : ""}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
             {/* Title */}

--- a/app/admin/lectures/new/page.tsx
+++ b/app/admin/lectures/new/page.tsx
@@ -33,6 +33,16 @@ function NewLecturePage() {
   const preselectedSeries = searchParams.get("series") ?? "";
   const [seriesId, setSeriesId] = useState(preselectedSeries || "none");
   const supabase = useMemo(() => createClient(), []);
+  const seriesOptions = useMemo(
+    () => [
+      { value: "none", label: "No series" },
+      ...seriesList.map((s) => ({
+        value: s.id,
+        label: `${s.name}${s.teacher ? ` — ${s.teacher}` : ""}`,
+      })),
+    ],
+    [seriesList]
+  );
 
   useEffect(() => {
     supabase
@@ -91,13 +101,7 @@ function NewLecturePage() {
                 </a>
               </div>
               <Select
-                items={[
-                  { value: "none", label: "No series" },
-                  ...seriesList.map((s) => ({
-                    value: s.id,
-                    label: `${s.name}${s.teacher ? ` — ${s.teacher}` : ""}`,
-                  })),
-                ]}
+                items={seriesOptions}
                 value={seriesId}
                 onValueChange={(v) => setSeriesId(v ?? "none")}
               >
@@ -105,10 +109,9 @@ function NewLecturePage() {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="none">No series</SelectItem>
-                  {seriesList.map((s) => (
-                    <SelectItem key={s.id} value={s.id}>
-                      {s.name}{s.teacher ? ` — ${s.teacher}` : ""}
+                  {seriesOptions.map((s) => (
+                    <SelectItem key={s.value} value={s.value}>
+                      {s.label}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/app/admin/lectures/new/page.tsx
+++ b/app/admin/lectures/new/page.tsx
@@ -8,6 +8,13 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { toast } from "sonner";
 
 export default function NewLecturePageWrapper() {
@@ -24,6 +31,7 @@ function NewLecturePage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const preselectedSeries = searchParams.get("series") ?? "";
+  const [seriesId, setSeriesId] = useState(preselectedSeries || "none");
   const supabase = useMemo(() => createClient(), []);
 
   useEffect(() => {
@@ -48,7 +56,7 @@ function NewLecturePage() {
       thumbnail_url: (formData.get("thumbnail_url") as string) || null,
       lecture_date: (formData.get("lecture_date") as string) || null,
       created_by: user?.id,
-      series_id: (formData.get("series_id") as string) || null,
+      series_id: seriesId === "none" ? null : seriesId,
       summary: (formData.get("summary") as string) || null,
     });
 
@@ -82,19 +90,29 @@ function NewLecturePage() {
                   + Create new series
                 </a>
               </div>
-              <select
-                id="series_id"
-                name="series_id"
-                defaultValue={preselectedSeries}
-                className="w-full border border-input rounded-md px-3 py-3 text-base bg-background"
+              <Select
+                items={[
+                  { value: "none", label: "No series" },
+                  ...seriesList.map((s) => ({
+                    value: s.id,
+                    label: `${s.name}${s.teacher ? ` — ${s.teacher}` : ""}`,
+                  })),
+                ]}
+                value={seriesId}
+                onValueChange={(v) => setSeriesId(v ?? "none")}
               >
-                <option value="">No series</option>
-                {seriesList.map((s) => (
-                  <option key={s.id} value={s.id}>
-                    {s.name}{s.teacher ? ` — ${s.teacher}` : ""}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger id="series_id" className="w-full text-base py-5">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">No series</SelectItem>
+                  {seriesList.map((s) => (
+                    <SelectItem key={s.id} value={s.id}>
+                      {s.name}{s.teacher ? ` — ${s.teacher}` : ""}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
             {/* Title */}

--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -19,6 +19,13 @@ import { Check, X, UserCog, Clock, Pencil } from "lucide-react";
 import type { AccessRequest, Profile, UserRole } from "@/lib/types";
 import { displayName } from "@/lib/names";
 
+const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
+  { value: "pending", label: "Pending" },
+  { value: "member", label: "Member" },
+  { value: "content_editor", label: "Content Editor" },
+  { value: "admin", label: "Admin" },
+];
+
 export default function MembersPage() {
   const [requests, setRequests] = useState<AccessRequest[]>([]);
   const [members, setMembers] = useState<Profile[]>([]);
@@ -232,6 +239,7 @@ export default function MembersPage() {
                     <div className="flex items-center gap-2 flex-wrap">
                       <UserCog className="h-5 w-5 text-muted-foreground" />
                       <Select
+                        items={ROLE_OPTIONS}
                         defaultValue={member.role}
                         onValueChange={(v) =>
                           handleRoleChange(member.id, v as UserRole)
@@ -241,12 +249,11 @@ export default function MembersPage() {
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="pending">Pending</SelectItem>
-                          <SelectItem value="member">Member</SelectItem>
-                          <SelectItem value="content_editor">
-                            Content Editor
-                          </SelectItem>
-                          <SelectItem value="admin">Admin</SelectItem>
+                          {ROLE_OPTIONS.map((r) => (
+                            <SelectItem key={r.value} value={r.value}>
+                              {r.label}
+                            </SelectItem>
+                          ))}
                         </SelectContent>
                       </Select>
                       <Button

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -6,11 +6,23 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { toast } from "sonner";
 
 interface SettingsMap {
   [key: string]: string;
 }
+
+const SERVING_LINK_MODE_OPTIONS = [
+  { value: "signed", label: "Signed links — members act without logging in (recommended)" },
+  { value: "login", label: "Login required — links redirect to the login page first" },
+];
 
 const SETTINGS_LABELS: Record<string, string> = {
   site_name: "Site Name",
@@ -92,17 +104,24 @@ export default function SettingsPage() {
               <div key={key} className="space-y-2">
                 <Label htmlFor={key} className="text-lg">{label}</Label>
                 {key === "serving_link_mode" ? (
-                  <select
-                    id={key}
+                  <Select
+                    items={SERVING_LINK_MODE_OPTIONS}
                     value={settings[key] || "signed"}
-                    onChange={(e) =>
-                      setSettings((prev) => ({ ...prev, [key]: e.target.value }))
+                    onValueChange={(v) =>
+                      setSettings((prev) => ({ ...prev, [key]: v ?? "signed" }))
                     }
-                    className="w-full rounded-md border border-input bg-background px-3 py-4 text-lg focus:outline-none focus:ring-2 focus:ring-brand-primary"
                   >
-                    <option value="signed">Signed links — members act without logging in (recommended)</option>
-                    <option value="login">Login required — links redirect to the login page first</option>
-                  </select>
+                    <SelectTrigger id={key} className="w-full text-lg py-5">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {SERVING_LINK_MODE_OPTIONS.map((o) => (
+                        <SelectItem key={o.value} value={o.value}>
+                          {o.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 ) : (
                   <Input
                     id={key}

--- a/app/household/HouseholdClient.tsx
+++ b/app/household/HouseholdClient.tsx
@@ -573,6 +573,7 @@ export function HouseholdClient({
                 Their relationship to your household
               </Label>
               <Select
+                items={LINK_RELATIONSHIPS}
                 value={linkRelationship}
                 onValueChange={(v) => setLinkRelationship(v as FamilyMemberRelationship)}
               >

--- a/app/household/member/HouseholdMemberEditClient.tsx
+++ b/app/household/member/HouseholdMemberEditClient.tsx
@@ -67,6 +67,7 @@ export function HouseholdMemberEditClient({ profile }: Props) {
               Relationship to household
             </Label>
             <Select
+              items={RELATIONSHIPS}
               value={relationship}
               onValueChange={(v) => handleRelationshipChange(v as FamilyMemberRelationship)}
               disabled={savingRelationship}

--- a/components/prayer/PrayerCallCard.tsx
+++ b/components/prayer/PrayerCallCard.tsx
@@ -12,6 +12,13 @@ import {
   ComboboxItem,
   ComboboxEmpty,
 } from "@/components/ui/combobox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { sessionLabel, telHref, WEEKDAY_LABELS } from "@/lib/prayer";
 import { savePrayerCallSessions, type SessionDraft } from "@/lib/prayerCalls";
 import type { MemberOption } from "@/components/giving/FundForm";
@@ -224,17 +231,25 @@ export function PrayerCallCard({
                   <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
                     Day
                   </span>
-                  <select
+                  <Select
+                    items={WEEKDAY_LABELS.map((label, w) => ({
+                      value: String(w),
+                      label,
+                    }))}
                     value={d.weekday}
-                    onChange={(e) => setField(i, "weekday", e.target.value)}
-                    className={inputClass}
+                    onValueChange={(v) => setField(i, "weekday", v ?? d.weekday)}
                   >
-                    {WEEKDAY_LABELS.map((label, w) => (
-                      <option key={label} value={w} className="text-foreground">
-                        {label}
-                      </option>
-                    ))}
-                  </select>
+                    <SelectTrigger className="w-full rounded-lg border-white/25 bg-white/10 text-background focus-visible:border-white/50">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {WEEKDAY_LABELS.map((label, w) => (
+                        <SelectItem key={label} value={String(w)}>
+                          {label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </label>
                 <label className="block">
                   <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">

--- a/components/prayer/PrayerCallCard.tsx
+++ b/components/prayer/PrayerCallCard.tsx
@@ -40,6 +40,11 @@ interface Draft {
 
 const NONE = "none";
 
+const WEEKDAY_OPTIONS = WEEKDAY_LABELS.map((label, w) => ({
+  value: String(w),
+  label,
+}));
+
 const toDraft = (s: PrayerCallSession): Draft => ({
   id: s.id,
   weekday: String(s.weekday),
@@ -232,10 +237,7 @@ export function PrayerCallCard({
                     Day
                   </span>
                   <Select
-                    items={WEEKDAY_LABELS.map((label, w) => ({
-                      value: String(w),
-                      label,
-                    }))}
+                    items={WEEKDAY_OPTIONS}
                     value={d.weekday}
                     onValueChange={(v) => setField(i, "weekday", v ?? d.weekday)}
                   >
@@ -243,9 +245,9 @@ export function PrayerCallCard({
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {WEEKDAY_LABELS.map((label, w) => (
-                        <SelectItem key={label} value={String(w)}>
-                          {label}
+                      {WEEKDAY_OPTIONS.map((o) => (
+                        <SelectItem key={o.value} value={o.value}>
+                          {o.label}
                         </SelectItem>
                       ))}
                     </SelectContent>

--- a/components/prayer/PrayerComposer.tsx
+++ b/components/prayer/PrayerComposer.tsx
@@ -3,6 +3,7 @@
 import { useState, type ReactNode } from "react";
 import { ChevronDown, HandHeart, Lock, Shield, UserRound } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { displayName, initials } from "@/lib/names";
 import { PRAYER_CATEGORIES, PRAYER_CATEGORY_KEYS } from "@/lib/prayer";
@@ -10,25 +11,24 @@ import type { PrayerCategory, PrayerWarrior } from "@/lib/types";
 import type { Me } from "@/components/prayer/PrayerBoard";
 
 function SwitchRow({
+  id,
   on,
   onToggle,
   title,
   sub,
   icon,
 }: {
+  id: string;
   on: boolean;
-  onToggle: () => void;
+  onToggle: (checked: boolean) => void;
   title: string;
   sub: string;
   icon: ReactNode;
 }) {
   return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={on}
-      onClick={onToggle}
-      className={`flex w-full items-center gap-3 rounded-xl border p-3 text-left transition-colors ${
+    <label
+      htmlFor={id}
+      className={`flex w-full cursor-pointer items-center gap-3 rounded-xl border p-3 text-left transition-colors ${
         on
           ? "border-brand-primary/40 bg-brand-warm"
           : "border-border bg-card hover:border-brand-primary/30"
@@ -51,19 +51,8 @@ function SwitchRow({
           {sub}
         </span>
       </span>
-      <span
-        aria-hidden="true"
-        className={`h-[23px] w-10 shrink-0 rounded-full p-0.5 transition-colors ${
-          on ? "bg-brand-primary" : "bg-muted"
-        }`}
-      >
-        <span
-          className={`block h-[19px] w-[19px] rounded-full bg-white shadow transition-transform ${
-            on ? "translate-x-[17px]" : ""
-          }`}
-        />
-      </span>
-    </button>
+      <Switch id={id} checked={on} onCheckedChange={onToggle} />
+    </label>
   );
 }
 
@@ -209,8 +198,9 @@ export function PrayerComposer({
 
       <div className="flex flex-col gap-2 p-5">
         <SwitchRow
+          id="prayer-anonymous"
           on={anonymous}
-          onToggle={() => setAnonymous((v) => !v)}
+          onToggle={setAnonymous}
           title="Share anonymously"
           sub="Your name is hidden — only the request is shown."
           icon={<UserRound className="h-4 w-4" aria-hidden="true" />}
@@ -220,8 +210,9 @@ export function PrayerComposer({
           Who can see this
         </div>
         <SwitchRow
+          id="prayer-warriors-only"
           on={toWarriors}
-          onToggle={() => setToWarriors((v) => !v)}
+          onToggle={setToWarriors}
           title="Prayer warriors only"
           sub="Off — everyone in the class can see it."
           icon={<Shield className="h-4 w-4" aria-hidden="true" />}


### PR DESCRIPTION
Fixes #236 (CWA-25)

## Problem

Three Base UI `Select` triggers rendered raw stored values (e.g. `content_editor`, `spouse`) instead of labels because the `Select` root was missing the `items` prop. Four other controls used native `<select>` elements or a hand-rolled toggle instead of the shared `Select`/`Switch` primitives, giving them inconsistent focus rings, sizing, and touch targets.

## Changes

**Raw-value fixes (`items` prop):**
- `app/admin/members/page.tsx` — role picker; new `ROLE_OPTIONS` constant replaces the hardcoded item list
- `app/household/member/HouseholdMemberEditClient.tsx` — relationship picker reuses the existing `RELATIONSHIPS` array
- `app/household/HouseholdClient.tsx` — link-account relationship picker reuses `LINK_RELATIONSHIPS`

**Shared-control swaps:**
- `app/admin/settings/page.tsx` — serving link mode now uses the shared `Select`
- `app/admin/lectures/new/page.tsx` and `app/admin/lectures/[id]/edit/page.tsx` — series pickers moved from uncontrolled native `<select>` + `FormData` to the shared `Select` with controlled state; "No series" uses a `"none"` sentinel translated to `null` at submit (same pattern as the ProfileForm family picker)
- `components/prayer/PrayerCallCard.tsx` — weekday picker uses the shared `Select` with trigger classes matched to the sibling inputs on the dark card
- `components/prayer/PrayerComposer.tsx` — `SwitchRow` keeps its card/icon layout but the hand-rolled track/thumb is replaced with the shared `Switch` (label wraps the row so the whole card still toggles)

No database changes.

## Validation

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run build` currently fails on main and this branch alike with a pre-existing `@blocknote/server-util` module-not-found error (verified against the unmodified tree); unrelated to this change

## Manual checks to do on review

- Role picker on `/admin/members` shows "Content Editor" etc. on load and after changing
- Household + link-account relationship triggers show labels
- `/admin/settings` serving link mode still saves
- Lecture create/edit: series persists, pre-selects on edit, and can be cleared
- Prayer call weekday saves the right day; weekday Select looks right on the dark card
- Prayer composer toggles still drive anonymous/warriors-only posting