### PR TITLE
fix(ui): remove decorative textures and ambient animations (#235)

### DIFF
--- a/app/(auth)/_components/AuthShell.tsx
+++ b/app/(auth)/_components/AuthShell.tsx
@@ -2,14 +2,6 @@ import React from "react";
 import Link from "next/link";
 import { siteConfig } from "@/lib/config";
 
-// Paper-grain texture URI (matches app/page.tsx)
-const PAPER_TEXTURE_URI =
-  "url(\"data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' seed='3'/%3E%3CfeColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.5 0'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E\")";
-
-// Linen texture: subtle white diagonal stripes for the brand panel
-const LINEN_TEXTURE_URI =
-  "repeating-linear-gradient(135deg, rgba(255,255,255,0.06) 0px, rgba(255,255,255,0.06) 1px, transparent 1px, transparent 8px)";
-
 export interface AuthShellProps {
   eyebrow: string;
   title: string;
@@ -26,7 +18,7 @@ export interface AuthShellProps {
  * Full-bleed two-column auth layout shell.
  *
  * Left column: brand panel (morning blue, devotional quote).
- * Right column: form area (warm cream background, paper texture).
+ * Right column: form area (warm cream background).
  *
  * Mobile: stacks to single column with a short brand banner on top.
  */
@@ -49,13 +41,6 @@ export function AuthShell({
         className="relative bg-brand-primary text-white flex flex-col justify-between px-8 py-12 md:px-14 md:py-14 overflow-hidden"
         // On mobile: cap height so it reads as a banner, not a half-page
       >
-        {/* Linen texture overlay */}
-        <div
-          className="absolute inset-0 pointer-events-none"
-          style={{ backgroundImage: LINEN_TEXTURE_URI, opacity: 1 }}
-          aria-hidden
-        />
-
         {/* Top: monogram + group name */}
         <div className="relative flex items-center gap-3.5">
           <div className="w-9 h-9 rounded-md border-2 border-white/80 flex items-center justify-center shrink-0">
@@ -98,13 +83,6 @@ export function AuthShell({
 
       {/* ── RIGHT — form panel ── */}
       <div className="relative bg-background flex flex-col justify-center px-6 py-12 md:px-16 md:py-14">
-        {/* Paper-grain texture overlay */}
-        <div
-          className="absolute inset-0 pointer-events-none opacity-[0.025]"
-          style={{ backgroundImage: PAPER_TEXTURE_URI }}
-          aria-hidden
-        />
-
         <div className="relative w-full max-w-[420px] mx-auto md:mx-0">
           {/* Eyebrow */}
           <div className="flex items-center gap-2.5 mb-5">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -332,15 +332,6 @@ export default async function DashboardPage() {
                 boxShadow: "0 14px 40px #2F6BA833",
               }}
             >
-              {/* Subtle linen overlay */}
-              <div
-                className="absolute inset-0 opacity-10 pointer-events-none"
-                style={{
-                  backgroundImage:
-                    "repeating-linear-gradient(0deg, rgba(255,255,255,0.4) 0px, rgba(255,255,255,0.4) 1px, transparent 1px, transparent 4px)",
-                }}
-              />
-
               <div className="relative text-white">
                 {/* Top pill */}
                 <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-white/20 bg-white/16 text-[11px] font-bold uppercase tracking-[1.5px] mb-6">

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -244,15 +244,6 @@ export default async function EventDetailPage({
 
   return (
     <div className="relative min-h-screen bg-background">
-      {/* Subtle paper-grain texture overlay — same as homepage hero */}
-      <div
-        className="absolute inset-0 opacity-[0.025] pointer-events-none"
-        style={{
-          backgroundImage:
-            "url(\"data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' seed='3'/%3E%3CfeColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.5 0'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E\")",
-        }}
-      />
-
       <div className="relative container mx-auto px-4 py-8 md:py-12 max-w-6xl">
         {/* ── Breadcrumb ── */}
         <div className="flex items-center justify-between mb-8">
@@ -383,16 +374,6 @@ export default async function EventDetailPage({
                   boxShadow: "0 14px 40px rgba(47,107,168,0.2)",
                 }}
               >
-                {/* Subtle linen texture overlay */}
-                <div
-                  className="absolute inset-0 pointer-events-none"
-                  style={{
-                    opacity: 0.1,
-                    backgroundImage:
-                      "repeating-linear-gradient(0deg, rgba(255,255,255,0.4) 0px, rgba(255,255,255,0.4) 1px, transparent 1px, transparent 4px)",
-                  }}
-                />
-
                 <div className="relative text-white">
                   <EventRsvpPanel
                     eventId={event.id}
@@ -446,14 +427,6 @@ export default async function EventDetailPage({
                   boxShadow: "0 14px 40px rgba(47,107,168,0.2)",
                 }}
               >
-                <div
-                  className="absolute inset-0 pointer-events-none"
-                  style={{
-                    opacity: 0.1,
-                    backgroundImage:
-                      "repeating-linear-gradient(0deg, rgba(255,255,255,0.4) 0px, rgba(255,255,255,0.4) 1px, transparent 1px, transparent 4px)",
-                  }}
-                />
                 <div className="relative">
                   <JoinMeetingBlock
                     meetingUrl={meeting.meeting_url}

--- a/app/globals.css
+++ b/app/globals.css
@@ -116,17 +116,6 @@ html[data-textsize="larger"] {
   --text-scale: 1.22;
 }
 
-@keyframes float {
-  0%, 100% { transform: translateY(0px) scale(1); }
-  50% { transform: translateY(-24px) scale(1.04); }
-}
-
-@keyframes float-slow {
-  0%, 100% { transform: translateY(0px) scale(1) rotate(0deg); }
-  33% { transform: translateY(-18px) scale(1.02) rotate(3deg); }
-  66% { transform: translateY(-8px) scale(0.98) rotate(-2deg); }
-}
-
 @keyframes fade-up {
   from { opacity: 0; transform: translateY(28px); }
   to   { opacity: 1; transform: translateY(0); }
@@ -142,25 +131,22 @@ html[data-textsize="larger"] {
   100% { background-position: 200% center; }
 }
 
-/* Live-now indicator on the Join meeting block */
-@keyframes join-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.3; }
-}
-
-@keyframes join-ring {
-  0% { transform: scale(1); opacity: 0.55; }
-  100% { transform: scale(2.8); opacity: 0; }
-}
-
-.animate-float { animation: float 6s ease-in-out infinite; }
-.animate-float-slow { animation: float-slow 9s ease-in-out infinite; }
-.animate-float-delayed { animation: float 7s ease-in-out 2s infinite; }
 .animate-fade-up { animation: fade-up 0.7s ease-out forwards; }
 .animate-fade-up-delay-1 { animation: fade-up 0.7s ease-out 0.15s forwards; opacity: 0; }
 .animate-fade-up-delay-2 { animation: fade-up 0.7s ease-out 0.3s forwards; opacity: 0; }
 .animate-fade-up-delay-3 { animation: fade-up 0.7s ease-out 0.45s forwards; opacity: 0; }
 .animate-fade-in { animation: fade-in 0.6s ease-out forwards; }
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-up,
+  .animate-fade-up-delay-1,
+  .animate-fade-up-delay-2,
+  .animate-fade-up-delay-3,
+  .animate-fade-in {
+    animation: none;
+    opacity: 1;
+  }
+}
 
 .font-serif {
   font-family: var(--font-serif);

--- a/app/lectures/[id]/page.tsx
+++ b/app/lectures/[id]/page.tsx
@@ -42,9 +42,6 @@ function formatLongDate(dateStr: string): string {
   });
 }
 
-const PAPER_TEXTURE =
-  "url(\"data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' seed='3'/%3E%3CfeColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.5 0'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E\")";
-
 export async function generateMetadata({
   params,
 }: {
@@ -108,11 +105,6 @@ export default async function LectureDetailPage({
     <div>
       {/* ── Hero ── */}
       <section className="relative overflow-hidden bg-background">
-        <div
-          className="absolute inset-0 opacity-[0.035] pointer-events-none"
-          style={{ backgroundImage: PAPER_TEXTURE }}
-        />
-
         <div className="relative px-6 md:px-14 py-12 md:py-16">
           {/* Back link */}
           <Link

--- a/app/lectures/page.tsx
+++ b/app/lectures/page.tsx
@@ -42,11 +42,6 @@ function formatDate(dateStr: string): string {
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
-// ── Paper texture SVG (same as homepage hero) ─────────────────────────────────
-
-const PAPER_TEXTURE =
-  "url(\"data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' seed='3'/%3E%3CfeColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.5 0'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E\")";
-
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 export default async function LecturesPage({
@@ -106,12 +101,6 @@ export default async function LecturesPage({
     <div>
       {/* ── Section 1: Hero Banner ── */}
       <section className="relative overflow-hidden bg-background">
-        {/* Paper-grain texture overlay */}
-        <div
-          className="absolute inset-0 opacity-[0.035] pointer-events-none"
-          style={{ backgroundImage: PAPER_TEXTURE }}
-        />
-
         <div className="relative px-6 md:px-14 py-16 md:py-24">
           {/* Eyebrow */}
           <div className="flex items-center gap-3 mb-6">

--- a/app/lectures/series/[id]/page.tsx
+++ b/app/lectures/series/[id]/page.tsx
@@ -28,9 +28,6 @@ function formatMonthYear(dateStr: string): string {
   return d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
 }
 
-const PAPER_TEXTURE =
-  "url(\"data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' seed='3'/%3E%3CfeColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.5 0'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E\")";
-
 export async function generateMetadata({
   params,
 }: {
@@ -92,11 +89,6 @@ export default async function SeriesDetailPage({
     <div>
       {/* ── Hero ── */}
       <section className="relative overflow-hidden bg-background">
-        <div
-          className="absolute inset-0 opacity-[0.035] pointer-events-none"
-          style={{ backgroundImage: PAPER_TEXTURE }}
-        />
-
         <div className="relative px-6 md:px-14 py-12 md:py-16">
           {/* Back link */}
           <Link

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,14 +8,6 @@ export default function HomePage() {
     <div>
       {/* ── Hero ── */}
       <section className="relative overflow-hidden bg-background">
-        {/* Subtle paper-grain texture overlay */}
-        <div
-          className="absolute inset-0 opacity-[0.035] pointer-events-none"
-          style={{
-            backgroundImage: "url(\"data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' seed='3'/%3E%3CfeColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.5 0'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E\")",
-          }}
-        />
-
         <div className="relative container mx-auto px-4 py-20 md:py-32">
           <div className="max-w-2xl">
             {/* Eyebrow label */}

--- a/app/profile/setup/page.tsx
+++ b/app/profile/setup/page.tsx
@@ -34,7 +34,7 @@ export default async function ProfileSetupPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-brand-bg-light to-white">
+    <div className="min-h-screen bg-background">
       <div className="container mx-auto px-4 py-12 max-w-2xl">
         <div className="text-center mb-10">
           <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-3">

--- a/components/events/JoinMeetingBlock.tsx
+++ b/components/events/JoinMeetingBlock.tsx
@@ -185,16 +185,10 @@ export function JoinMeetingBlock({
       style={{ background: "rgba(255,255,255,0.15)", border: "1px solid rgba(255,255,255,0.22)" }}
     >
       <div className={statusRowClass}>
-        <span className="relative inline-block h-[9px] w-[9px]">
-          <span
-            className="absolute inset-0 rounded-full"
-            style={{ background: "#E8A93C", animation: "join-ring 1.6s ease-out infinite" }}
-          />
-          <span
-            className="absolute inset-0 rounded-full"
-            style={{ background: "#E8A93C", animation: "join-pulse 1.6s ease-in-out infinite" }}
-          />
-        </span>
+        <span
+          className="inline-block h-[9px] w-[9px] rounded-full"
+          style={{ background: "#E8A93C" }}
+        />
         <span style={{ color: "#E8A93C" }}>Live now</span>
       </div>
       <a


### PR DESCRIPTION
Fixes #235 (CWA-24, root cause #5 of the UI cleanup spec).

Removes decorative texture overlays and ambient motion; keeps only purposeful transitions.

## Textures removed
- Landing hero fractal-noise overlay (`app/page.tsx`)
- Auth shell paper + linen overlays and their data-URI constants (`app/(auth)/_components/AuthShell.tsx`) — applies to every auth screen
- `PAPER_TEXTURE` overlays on lectures index, lecture detail, and series detail
- Event detail page noise overlay + linen overlays on the RSVP and join cards (`app/events/[id]/page.tsx`)
- Dashboard next-event hero linen overlay (`app/dashboard/page.tsx`)
- Profile setup decorative gradient → plain `bg-background` (`app/profile/setup/page.tsx`)

## Animations removed
- `@keyframes float` / `float-slow` and the `.animate-float*` utilities (no remaining call sites)
- JoinMeetingBlock live-state `join-ring` / `join-pulse` pulsing → static live indicator dot; unused keyframes deleted
- Remaining `animate-fade-*` entrance utilities are now disabled under `prefers-reduced-motion`

## Validation
- `npx tsc --noEmit` — no errors
- `npm run lint` — no issues
- Zero database migrations

10 files changed, +17/−130.