### PR TITLE
Add shared page shell (PageContainer + PageHeader), adopt on first pages

### DIFF
--- a/app/admin/about/AboutEditor.tsx
+++ b/app/admin/about/AboutEditor.tsx
@@ -18,6 +18,8 @@ import {
 import { BlockEditor } from "@/components/editor";
 import { toast } from "sonner";
 import { ArrowDown, ArrowUp, Pencil, Plus, Search, X } from "lucide-react";
+import { PageContainer } from "@/components/layout/PageContainer";
+import { PageHeader } from "@/components/layout/PageHeader";
 import { displayName, initials } from "@/lib/names";
 import type { Block, PartialBlock } from "@blocknote/core";
 import type { ClassTeacherWithProfile } from "@/lib/types";
@@ -215,13 +217,15 @@ export function AboutEditor({ initialBody, initialTeachers }: AboutEditorProps) 
   };
 
   return (
-    <div className="container mx-auto px-4 py-12 max-w-4xl space-y-8">
-      <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-bold text-brand-primary">About Page</h1>
-        <Button variant="outline" nativeButton={false} render={<Link href="/about" />}>
-          View page
-        </Button>
-      </div>
+    <PageContainer size="default" className="space-y-8">
+      <PageHeader
+        title="About Page"
+        actions={
+          <Button variant="outline" nativeButton={false} render={<Link href="/about" />}>
+            View page
+          </Button>
+        }
+      />
 
       <Card>
         <CardHeader>
@@ -449,6 +453,6 @@ export function AboutEditor({ initialBody, initialTeachers }: AboutEditorProps) 
           )}
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContainer>
   );
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Users, Calendar, Megaphone, BookOpen, Settings, Clock, FileText, Home, Info } from "lucide-react";
+import { PageContainer } from "@/components/layout/PageContainer";
+import { PageHeader } from "@/components/layout/PageHeader";
 import { siteConfig } from "@/lib/config";
 
 export const metadata = { title: `Admin | ${siteConfig.name}` };
@@ -104,10 +106,8 @@ export default async function AdminPage() {
   ];
 
   return (
-    <div className="container mx-auto px-4 py-12">
-      <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-10">
-        Admin Dashboard
-      </h1>
+    <PageContainer size="wide">
+      <PageHeader title="Admin Dashboard" />
 
       {/* Stats */}
       <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-10">
@@ -181,6 +181,6 @@ export default async function AdminPage() {
           </Link>
         ))}
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -1,6 +1,8 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { AnnouncementCard } from "@/components/announcements/AnnouncementCard";
+import { PageContainer } from "@/components/layout/PageContainer";
+import { PageHeader } from "@/components/layout/PageHeader";
 import { siteConfig } from "@/lib/config";
 
 export const metadata = { title: `Announcements | ${siteConfig.name}` };
@@ -21,13 +23,11 @@ export default async function AnnouncementsPage() {
     .order("published_at", { ascending: false });
 
   return (
-    <div className="container mx-auto px-4 py-12 max-w-3xl">
-      <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-2">
-        Announcements
-      </h1>
-      <p className="text-lg text-muted-foreground mb-10">
-        Stay up to date with the latest news from our group.
-      </p>
+    <PageContainer>
+      <PageHeader
+        title="Announcements"
+        subtitle="News and updates from our group."
+      />
 
       {announcements && announcements.length > 0 ? (
         <div className="space-y-6">
@@ -38,6 +38,6 @@ export default async function AnnouncementsPage() {
       ) : (
         <p className="text-xl text-muted-foreground">No announcements yet.</p>
       )}
-    </div>
+    </PageContainer>
   );
 }

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { EventsPageClient } from "@/components/events/EventsPageClient";
+import { PageContainer } from "@/components/layout/PageContainer";
 import { siteConfig } from "@/lib/config";
 import type { Event, EventCalendar, Rsvp } from "@/lib/types";
 
@@ -99,7 +100,7 @@ export default async function EventsPage() {
   const calendars = (calendarsRaw ?? []) as EventCalendar[];
 
   return (
-    <div className="container mx-auto px-4 py-12">
+    <PageContainer size="wide">
       <EventsPageClient
         allEvents={allEvents}
         calendars={calendars}
@@ -109,6 +110,6 @@ export default async function EventsPage() {
         isAdmin={isAdmin}
         subscriptionToken={subscriptionToken}
       />
-    </div>
+    </PageContainer>
   );
 }

--- a/app/give/page.tsx
+++ b/app/give/page.tsx
@@ -3,6 +3,8 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { PageContainer } from "@/components/layout/PageContainer";
+import { PageHeader } from "@/components/layout/PageHeader";
 import { siteConfig } from "@/lib/config";
 import { displayName, initials } from "@/lib/names";
 import { resolveFundMethods } from "@/lib/giving/methods";
@@ -127,24 +129,24 @@ export default async function GivePage() {
   });
 
   return (
-    <div className="container mx-auto px-4 py-12 max-w-3xl">
-      <div className="flex items-start justify-between gap-4">
-        <h1 className="text-3xl md:text-4xl font-bold text-brand-primary">
-          Give
-        </h1>
-        {canCreate && (
-          <Button
-            nativeButton={false}
-            render={<Link href="/give/new" />}
-            className="shrink-0 bg-brand-primary hover:bg-brand-primary/90 text-white"
-          >
-            <Plus className="mr-1.5 h-4 w-4" />
-            Add fund
-          </Button>
-        )}
-      </div>
+    <PageContainer>
+      <PageHeader
+        title="Give"
+        actions={
+          canCreate && (
+            <Button
+              nativeButton={false}
+              render={<Link href="/give/new" />}
+              className="bg-brand-primary hover:bg-brand-primary/90 text-white"
+            >
+              <Plus className="mr-1.5 h-4 w-4" />
+              Add fund
+            </Button>
+          )
+        }
+      />
 
-      <div className="mt-10">
+      <div>
         {views.length > 0 ? (
           <GiveList funds={views} />
         ) : (
@@ -163,6 +165,6 @@ export default async function GivePage() {
           </div>
         )}
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/app/give/page.tsx
+++ b/app/give/page.tsx
@@ -146,25 +146,23 @@ export default async function GivePage() {
         }
       />
 
-      <div>
-        {views.length > 0 ? (
-          <GiveList funds={views} />
-        ) : (
-          <div className="rounded-2xl border border-dashed border-border px-6 py-12 text-center">
-            <p className="text-xl text-muted-foreground">No funds yet.</p>
-            {canCreate && (
-              <p className="mt-2 text-muted-foreground">
-                <Link
-                  href="/give/new"
-                  className="font-semibold text-brand-primary hover:underline"
-                >
-                  Add the first fund
-                </Link>
-              </p>
-            )}
-          </div>
-        )}
-      </div>
+      {views.length > 0 ? (
+        <GiveList funds={views} />
+      ) : (
+        <div className="rounded-2xl border border-dashed border-border px-6 py-12 text-center">
+          <p className="text-xl text-muted-foreground">No funds yet.</p>
+          {canCreate && (
+            <p className="mt-2 text-muted-foreground">
+              <Link
+                href="/give/new"
+                className="font-semibold text-brand-primary hover:underline"
+              >
+                Add the first fund
+              </Link>
+            </p>
+          )}
+        </div>
+      )}
     </PageContainer>
   );
 }

--- a/app/household/page.tsx
+++ b/app/household/page.tsx
@@ -1,8 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { ArrowLeft } from "lucide-react";
+import { PageContainer } from "@/components/layout/PageContainer";
+import { PageHeader } from "@/components/layout/PageHeader";
 import { siteConfig } from "@/lib/config";
 import type { Profile, FamilyUnit, FamilyMember } from "@/lib/types";
 import { HouseholdClient } from "./HouseholdClient";
@@ -58,23 +57,13 @@ export default async function HouseholdPage() {
   if (!family) redirect("/profile");
 
   return (
-    <div className="container mx-auto px-4 py-12 max-w-3xl">
-      <Button
-        variant="ghost"
-        size="sm"
-        nativeButton={false}
-        render={<Link href="/profile" />}
-        className="mb-4"
-      >
-        <ArrowLeft className="mr-2 h-4 w-4" />
-        Back to my profile
-      </Button>
-      <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-2">
-        My Household
-      </h1>
-      <p className="text-base text-muted-foreground mb-8">
-        Manage your household&apos;s contact info and family members.
-      </p>
+    <PageContainer>
+      <PageHeader
+        title="My Household"
+        subtitle="Manage your household's contact info and family members."
+        backHref="/profile"
+        backLabel="Back to my profile"
+      />
 
       <HouseholdClient
         currentProfile={profile}
@@ -82,6 +71,6 @@ export default async function HouseholdPage() {
         initialFamilyMembers={familyMembers ?? []}
         householdProfiles={householdProfiles ?? []}
       />
-    </div>
+    </PageContainer>
   );
 }

--- a/components/events/EventsPageClient.tsx
+++ b/components/events/EventsPageClient.tsx
@@ -22,6 +22,9 @@ import type { Event, EventCalendar, Rsvp } from "@/lib/types";
 
 type View = "calendar" | "list";
 
+const outlineButtonClass =
+  "h-11 rounded-xl border-slate-200 bg-white px-4 text-sm font-medium text-slate-600 shadow-sm hover:border-brand-primary/30 hover:bg-white hover:text-brand-primary";
+
 interface EventsPageClientProps {
   allEvents: (Event & { calendar?: EventCalendar | null })[];
   calendars: EventCalendar[];
@@ -102,7 +105,7 @@ export function EventsPageClient({
               <>
                 <Button
                   variant="outline"
-                  className="h-11 rounded-xl border-slate-200 bg-white px-4 text-sm font-medium text-slate-600 shadow-sm hover:border-brand-primary/30 hover:bg-white hover:text-brand-primary"
+                  className={outlineButtonClass}
                   nativeButton={false}
                   render={<Link href="/admin/events/new" />}
                 >
@@ -110,7 +113,7 @@ export function EventsPageClient({
                 </Button>
                 <Button
                   variant="outline"
-                  className="h-11 rounded-xl border-slate-200 bg-white px-4 text-sm font-medium text-slate-600 shadow-sm hover:border-brand-primary/30 hover:bg-white hover:text-brand-primary"
+                  className={outlineButtonClass}
                   nativeButton={false}
                   render={<Link href="/admin/calendars" />}
                 >

--- a/components/events/EventsPageClient.tsx
+++ b/components/events/EventsPageClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Rss, ChevronDown, SlidersHorizontal } from "lucide-react";
 import { EventCalendarView } from "@/components/events/EventCalendarView";
 import { EventListView } from "@/components/events/EventListView";
+import { PageHeader } from "@/components/layout/PageHeader";
 import { expandUpcomingEvents } from "@/lib/recurrence";
 import { Button } from "@/components/ui/button";
 import {
@@ -92,18 +93,11 @@ export function EventsPageClient({
 
   return (
     <div>
-      <div className="mb-6 rounded-[2rem] border border-border bg-white p-5 shadow-sm md:p-6">
-        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div className="space-y-2">
-            <div>
-              <h1 className="text-3xl md:text-4xl font-bold text-brand-primary">Calendar</h1>
-              <p className="mt-2 text-lg text-muted-foreground">
-                Browse the shared calendar for our group.
-              </p>
-            </div>
-          </div>
-
-          <div className="flex flex-wrap items-center justify-end gap-3 md:shrink-0">
+      <PageHeader
+        title="Calendar"
+        subtitle="Browse the shared calendar for our group."
+        actions={
+          <>
             {isAdmin && (
               <>
                 <Button
@@ -161,87 +155,87 @@ export function EventsPageClient({
                 </DropdownMenuContent>
               </DropdownMenu>
             )}
-          </div>
+          </>
+        }
+      />
+
+      <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="inline-flex w-fit items-center rounded-xl border border-slate-200 bg-white p-1 shadow-sm">
+          <Button
+            onClick={() => setView("calendar")}
+            variant="ghost"
+            className={`h-10 rounded-lg px-5 text-sm font-semibold ${
+              view === "calendar"
+                ? "bg-brand-primary text-white shadow-sm hover:bg-brand-primary/90 hover:text-white"
+                : "text-slate-600 hover:bg-slate-50 hover:text-brand-primary"
+            }`}
+          >
+            Calendar
+          </Button>
+          <Button
+            onClick={() => setView("list")}
+            variant="ghost"
+            className={`h-10 rounded-lg px-5 text-sm font-semibold ${
+              view === "list"
+                ? "bg-brand-primary text-white shadow-sm hover:bg-brand-primary/90 hover:text-white"
+                : "text-slate-600 hover:bg-slate-50 hover:text-brand-primary"
+            }`}
+          >
+            List
+          </Button>
         </div>
 
-        <div className="mt-5 flex flex-col gap-4 pt-1 md:flex-row md:items-center md:justify-between">
-          <div className="inline-flex w-fit items-center rounded-xl border border-slate-200 bg-white p-1 shadow-sm">
-            <Button
-              onClick={() => setView("calendar")}
-              variant="ghost"
-              className={`h-10 rounded-lg px-5 text-sm font-semibold ${
-                view === "calendar"
-                  ? "bg-brand-primary text-white shadow-sm hover:bg-brand-primary/90 hover:text-white"
-                  : "text-slate-600 hover:bg-slate-50 hover:text-brand-primary"
-              }`}
-            >
-              Calendar
-            </Button>
-            <Button
-              onClick={() => setView("list")}
-              variant="ghost"
-              className={`h-10 rounded-lg px-5 text-sm font-semibold ${
-                view === "list"
-                  ? "bg-brand-primary text-white shadow-sm hover:bg-brand-primary/90 hover:text-white"
-                  : "text-slate-600 hover:bg-slate-50 hover:text-brand-primary"
-              }`}
-            >
-              List
-            </Button>
+        {view === "calendar" && (calendars.length > 0 || hasUncategorized) && (
+          <div className="flex flex-col gap-2 md:items-end">
+            <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+              Calendars
+            </span>
+            <DropdownMenu>
+              <DropdownMenuTrigger render={
+                <Button
+                  variant="outline"
+                  className="h-11 min-w-52 justify-between gap-3 rounded-xl border-slate-200 bg-white px-4 text-sm font-medium text-slate-600 shadow-sm hover:border-brand-primary/30 hover:bg-white hover:text-brand-primary"
+                >
+                  <span className="flex items-center gap-2">
+                    <SlidersHorizontal className="h-4 w-4" />
+                    {calendarFilterSummary}
+                  </span>
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+              } />
+              <DropdownMenuContent align="end" className="w-64 rounded-2xl">
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel>Visible Calendars</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {calendars.map((cal) => (
+                    <DropdownMenuCheckboxItem
+                      key={cal.id}
+                      checked={visibleCalendarIds.has(cal.id)}
+                      onCheckedChange={() => toggleCalendar(cal.id)}
+                      className="gap-2"
+                    >
+                      <span
+                        className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                        style={{ backgroundColor: cal.color ?? "var(--color-brand-primary)" }}
+                      />
+                      {cal.name}
+                    </DropdownMenuCheckboxItem>
+                  ))}
+                  {hasUncategorized && (
+                    <DropdownMenuCheckboxItem
+                      checked={visibleCalendarIds.has(null)}
+                      onCheckedChange={() => toggleCalendar(null)}
+                      className="gap-2"
+                    >
+                      <span className="inline-block h-2.5 w-2.5 shrink-0 rounded-full bg-slate-400" />
+                      Other
+                    </DropdownMenuCheckboxItem>
+                  )}
+                </DropdownMenuGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
-
-          {view === "calendar" && (calendars.length > 0 || hasUncategorized) && (
-            <div className="flex flex-col gap-2 md:items-end">
-              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-                Calendars
-              </span>
-              <DropdownMenu>
-                <DropdownMenuTrigger render={
-                  <Button
-                    variant="outline"
-                    className="h-11 min-w-52 justify-between gap-3 rounded-xl border-slate-200 bg-white px-4 text-sm font-medium text-slate-600 shadow-sm hover:border-brand-primary/30 hover:bg-white hover:text-brand-primary"
-                  >
-                    <span className="flex items-center gap-2">
-                      <SlidersHorizontal className="h-4 w-4" />
-                      {calendarFilterSummary}
-                    </span>
-                    <ChevronDown className="h-4 w-4" />
-                  </Button>
-                } />
-                <DropdownMenuContent align="end" className="w-64 rounded-2xl">
-                  <DropdownMenuGroup>
-                    <DropdownMenuLabel>Visible Calendars</DropdownMenuLabel>
-                    <DropdownMenuSeparator />
-                    {calendars.map((cal) => (
-                      <DropdownMenuCheckboxItem
-                        key={cal.id}
-                        checked={visibleCalendarIds.has(cal.id)}
-                        onCheckedChange={() => toggleCalendar(cal.id)}
-                        className="gap-2"
-                      >
-                        <span
-                          className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
-                          style={{ backgroundColor: cal.color ?? "var(--color-brand-primary)" }}
-                        />
-                        {cal.name}
-                      </DropdownMenuCheckboxItem>
-                    ))}
-                    {hasUncategorized && (
-                      <DropdownMenuCheckboxItem
-                        checked={visibleCalendarIds.has(null)}
-                        onCheckedChange={() => toggleCalendar(null)}
-                        className="gap-2"
-                      >
-                        <span className="inline-block h-2.5 w-2.5 shrink-0 rounded-full bg-slate-400" />
-                        Other
-                      </DropdownMenuCheckboxItem>
-                    )}
-                  </DropdownMenuGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          )}
-        </div>
+        )}
       </div>
 
       {view === "calendar" ? (

--- a/components/layout/PageContainer.tsx
+++ b/components/layout/PageContainer.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+
+type PageContainerSize = "narrow" | "default" | "wide" | "full";
+
+interface PageContainerProps {
+  size?: PageContainerSize;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const sizeClasses: Record<PageContainerSize, string> = {
+  /** Forms and focused single-column flows */
+  narrow: "max-w-2xl",
+  /** Standard content pages */
+  default: "max-w-4xl",
+  /** Data-dense pages: tables, boards, wide grids */
+  wide: "max-w-6xl",
+  /** No width cap — page manages its own inner layout */
+  full: "",
+};
+
+/**
+ * Canonical page wrapper: one max-width scale, responsive gutters, and
+ * standard vertical padding. Every page.tsx should use this instead of
+ * hand-rolling `container mx-auto max-w-* px-4 py-12`.
+ */
+export function PageContainer({
+  size = "default",
+  className,
+  children,
+}: PageContainerProps) {
+  return (
+    <div
+      className={cn(
+        "container mx-auto px-4 py-12 sm:px-6 lg:px-8",
+        sizeClasses[size],
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/layout/PageContainer.tsx
+++ b/components/layout/PageContainer.tsx
@@ -32,7 +32,8 @@ export function PageContainer({
   return (
     <div
       className={cn(
-        "container mx-auto px-4 py-12 sm:px-6 lg:px-8",
+        "mx-auto px-4 py-12 sm:px-6 lg:px-8",
+        size !== "full" && "container",
         sizeClasses[size],
         className,
       )}

--- a/components/layout/PageHeader.tsx
+++ b/components/layout/PageHeader.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface PageHeaderProps {
+  title: React.ReactNode;
+  /** Plain, functional copy — one sentence describing what the page does */
+  subtitle?: React.ReactNode;
+  /** Right-aligned action buttons */
+  actions?: React.ReactNode;
+  backHref?: string;
+  /** Visible label next to the back arrow, e.g. "Back to Directory" */
+  backLabel?: string;
+  className?: string;
+}
+
+/**
+ * Canonical page heading: one H1 type ramp, optional subtitle, optional
+ * right-aligned actions, and one back-nav affordance (arrow + visible text
+ * label, 44px touch target). Replaces per-page bespoke headers.
+ */
+export function PageHeader({
+  title,
+  subtitle,
+  actions,
+  backHref,
+  backLabel,
+  className,
+}: PageHeaderProps) {
+  return (
+    <header className={cn("mb-8", className)}>
+      {backHref && (
+        <Link
+          href={backHref}
+          className="mb-3 inline-flex min-h-11 items-center gap-2 text-base font-semibold text-brand-primary underline underline-offset-4 hover:text-brand-primary/80"
+        >
+          <ArrowLeft className="h-5 w-5" aria-hidden="true" />
+          {backLabel ?? "Back"}
+        </Link>
+      )}
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="font-serif text-4xl font-medium tracking-tight text-foreground md:text-5xl">
+            {title}
+          </h1>
+          {subtitle && (
+            <p className="mt-3 text-lg leading-relaxed text-muted-foreground">
+              {subtitle}
+            </p>
+          )}
+        </div>
+        {actions && (
+          <div className="flex shrink-0 flex-wrap items-center gap-3">
+            {actions}
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a shared page shell — `PageContainer` and `PageHeader` — and adopts it on the first wave of pages. This replaces hand-rolled `container mx-auto max-w-*` wrappers and two competing H1 treatments that had spread across ~47 page.tsx files (8+ divergent max-width values, inconsistent heading styles, and two different back-nav patterns).

## Changes

- **`components/layout/PageContainer.tsx`** (new): canonical page wrapper — one `container mx-auto px-4 py-12 sm:px-6 lg:px-8` gutter/padding convention with a `size` prop (`narrow` / `default` / `wide` / `full`) collapsing the repo's 8 ad-hoc `max-w-*` values into a small, intentional set.
- **`components/layout/PageHeader.tsx`** (new): canonical page heading — one H1 type ramp, optional subtitle (plain functional copy, no cute subtitles), optional right-aligned actions slot, and a single back-nav affordance (arrow icon + visible text label, 44px+ touch target) replacing the old `BackLink` vs. ghost-`Button` split.
- Adopted the new shell on:
  - `app/admin/page.tsx`
  - `app/admin/about/AboutEditor.tsx`
  - `app/announcements/page.tsx`
  - `app/events/page.tsx`
  - `app/give/page.tsx`
  - `app/household/page.tsx`
  - `components/events/EventsPageClient.tsx`

This is the first wave; the remaining page.tsx files are follow-up work to adopt the same shell (issue #232 calls out ~47 pages total).

## Accessibility

Sizing/contrast choices follow the repo's senior-friendly design floors (members up to their late 80s): 16px+ body text, WCAG 4.5:1 contrast for body / 3:1 for large text, 44×44px minimum touch targets, and icon+visible-label pairing for the back-nav (never icon-only).

## Validation

- `npx tsc --noEmit` — pass, no errors
- `npm run lint` — pass, no issues
- `npm run build` — fails, but reproduced identically on base `main` (`cd252ef`) with this branch's changes stashed; pre-existing `y-prosemirror` missing-peer-dependency issue in `@blocknote/core`'s yjs integration, unrelated to this diff (none of the changed files touch the editor/blocknote code path). Recommend tracking that lockfile gap as its own fix.
- No database migrations in this change.

Fixes #232
