### PR TITLE
ci: pin typescript below v7 until typescript-eslint supports it

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,6 +17,13 @@
     // nosemgrep: package_managers.renovate.renovate-missing-minimum-release-age
     // minimumReleaseAge is inherited from local>cwaits6/renovate-config.
     {
+      "description": "Keep TypeScript on v6 until typescript-eslint supports TS 7 (peer range is <6.1.0 as of typescript-eslint 8.x)",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7.0.0"
+    },
+    // nosemgrep: package_managers.renovate.renovate-missing-minimum-release-age
+    // minimumReleaseAge is inherited from local>cwaits6/renovate-config.
+    {
       "description": "Group all non-major npm dependency updates into a single PR",
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "non-major dependencies"


### PR DESCRIPTION
## Why

Renovate keeps proposing a bump to **TypeScript 7** (PR #193), but our lint stack can't take it yet:

- `eslint-config-next` pulls in **`typescript-eslint@8.64.0`**, which declares:
  ```
  peerDependencies: { typescript: ">=4.8.4 <6.1.0" }
  ```
- TypeScript 7 is well outside that range (we're on `6.0.3`), so linting would break under TS7.

## Change

Add a Renovate `packageRule` capping `typescript` at `<7.0.0`, exactly mirroring the existing `eslint <10.0.0` hold. Renovate will close/stop reproposing the v7 update until we lift the cap.

## When to remove

Drop this rule once `typescript-eslint` publishes a release whose `typescript` peer range includes v7, then let the v7 bump through.

Closes the intent of #193 (that PR can be closed once this merges).