### PR TITLE
ci: skip dependency and CI PRs in CodeRabbit auto-review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,6 +14,16 @@ reviews:
       - main
     ignore_usernames:
       - "renovate[bot]"
+    # Skip dependency/CI housekeeping PRs so they don't spend a review.
+    # (Renovate PRs are already covered by ignore_usernames above.)
+    ignore_title_keywords:
+      - "chore(deps)"
+      - "fix(deps)"
+      - "ci:"
+      - "build(deps)"
+    # Opt any PR out of auto-review by adding the "skip-review" label.
+    labels:
+      - "!skip-review"
   path_filters:
     - "!node_modules/**"
     - "!.next/**"


### PR DESCRIPTION
## Why

Keep CodeRabbit auto-review for real feature PRs, but stop it from spending a review on dependency/CI housekeeping (like the `y-prosemirror`/dep-bump and `typescript` pin PRs).

## Change

Adds to the existing `reviews.auto_review` config (nothing else touched):

- **`ignore_title_keywords`**: `chore(deps)`, `fix(deps)`, `ci:`, `build(deps)` — skips human-authored dependency/CI PRs by title. (Renovate PRs were already skipped via `ignore_usernames: renovate[bot]`.)
- **`labels: ["!skip-review"]`**: adding the `skip-review` label to any PR opts it out of auto-review on demand.

Auto-review stays **on** for everything else, so real PRs still get reviewed automatically — no need to remember to trigger them.

## Usage

- Dep/CI PRs whose titles start with those prefixes are skipped automatically.
- For a one-off (e.g. a `fix:`-titled PR that's really just deps), add the **`skip-review`** label. You can also comment `@coderabbitai ignore` on any single PR.