### PR TITLE
docs: allow PR merges only on explicit instruction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Next.js + Supabase app for a church small group, deployed on Vercel. Open source
 ## Git & PRs
 
 - Conventional commits. Only `fix`, `feat`, `perf`, and breaking changes trigger a release. Use `ci:` / `ci(scope):` commits on `ci/` branches for CI/infra changes; `docs:` / `chore:` for other non-release changes.
-- **Never merge a PR** — not even when CI is green or you're told to "merge it in". Open the PR (draft is fine) and stop; Cody reviews and merges personally.
+- **Merge a PR only when the maintainer explicitly and directly tells you to merge that specific PR** (e.g. "merge #123", "merge it in now"). Never infer or assume merge intent — green CI, "looks good", "ship it", an approved plan, or an implied next step do NOT authorize a merge. Default to opening the PR (draft is fine) and stopping. If it's at all ambiguous whether an instruction is an explicit merge directive, leave the PR open and ask.
 - Do not include Claude/AI session links in PR titles or bodies.
 
 ## Local dev


### PR DESCRIPTION
## Change

Updates the `Git & PRs` merge rule in `CLAUDE.md`.

**Before:** "Never merge a PR — not even when you're told to merge it in."

**After:** Merge a PR **only when the maintainer explicitly and directly instructs** a merge of that specific PR (e.g. "merge #123"). Never infer merge intent — green CI, "looks good", "ship it", an approved plan, or an implied next step do **not** authorize a merge. Default to leaving the PR open; when ambiguous, ask.

## Why

The old rule was absolute and blocked merging even on a direct instruction. The intent is: agents shouldn't *guess* when to merge, but a clear, explicit instruction is sufficient authorization. This keeps the guardrail against inferred/assumed merges while allowing deliberate ones.

Also drops the personal name from this section in favor of "the maintainer".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request merging guidance to require explicit, direct maintainer approval for a specific pull request.
  * Clarified that ambiguous requests should not result in merging, and the pull request should remain open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->