### PR TITLE
ci: hold FullCalendar on v6 and watch for stable v7

### DIFF
--- a/.github/workflows/fullcalendar-v7-watch.yml
+++ b/.github/workflows/fullcalendar-v7-watch.yml
@@ -1,0 +1,58 @@
+name: Watch FullCalendar v7 stability
+
+# Opens a tracking issue when a stable v7 exists for every @fullcalendar
+# package, so the v7 upgrade can be enabled without watching release forums.
+# Paired with the "fullcalendar-v7-guard" rule in renovate.json5 — this
+# workflow self-deactivates once that guard is lifted.
+
+on:
+  schedule:
+    - cron: '0 8 * * 1' # Mondays 08:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: Check for stable v7
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Notify when all FullCalendar packages have stable v7
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Self-deactivate once the guard has been lifted.
+          if ! grep -q 'fullcalendar-v7-guard' renovate.json5; then
+            echo "FullCalendar guard already lifted — nothing to watch."
+            exit 0
+          fi
+
+          all_v7=true
+          summary=""
+          for p in core react daygrid timegrid interaction; do
+            v="$(npm view "@fullcalendar/$p" version)"
+            summary="${summary}- @fullcalendar/${p}: ${v}"$'\n'
+            [ "${v%%.*}" -lt 7 ] && all_v7=false
+          done
+          printf '%s\n' "$summary"
+
+          if [ "$all_v7" != true ]; then
+            echo "Not all @fullcalendar packages have stable v7 yet."
+            exit 0
+          fi
+
+          title="FullCalendar v7 is fully stable — enable the Renovate upgrade"
+          if [ "$(gh issue list --state open --search "$title in:title" --json number --jq 'length')" != "0" ]; then
+            echo "Tracking issue already open."
+            exit 0
+          fi
+
+          body="$(printf 'All `@fullcalendar` packages now have a stable v7 release:\n\n%s\n**To enable the upgrade:** in `renovate.json5`, change the FullCalendar rule'\''s `allowedVersions` from `"<7.0.0"` to `"<8.0.0"` (or delete the rule). Renovate will open a single grouped PR bumping all five packages to v7 with a fresh lockfile.\n\nThe only code consumer is `components/events/EventCalendarView.impl.tsx` — if the Vercel build fails, check it against the [FullCalendar v7 upgrade guide](https://fullcalendar.io/docs/upgrading-from-v6).\n\nAfter the upgrade merges, delete `.github/workflows/fullcalendar-v7-watch.yml` (or it self-deactivates once the guard is gone).\n\n_Opened automatically by the fullcalendar-v7-watch workflow._' "$summary")"
+
+          gh issue create --title "$title" --body "$body"

--- a/renovate.json5
+++ b/renovate.json5
@@ -23,6 +23,21 @@
     },
     // nosemgrep: package_managers.renovate.renovate-missing-minimum-release-age
     // minimumReleaseAge is inherited from local>cwaits6/renovate-config.
+    //
+    // fullcalendar-v7-guard: watched by .github/workflows/fullcalendar-v7-watch.yml.
+    // core/react shipped stable v7 (7.0.2) but daygrid/timegrid/interaction are
+    // still beta/rc — mixing majors breaks the build. Hold all @fullcalendar
+    // packages on v6 until every one has a stable v7. To enable: bump
+    // allowedVersions to "<8.0.0" (or delete this rule). groupName keeps the
+    // eventual bump to a single atomic PR across all five packages.
+    {
+      "description": "Keep FullCalendar on v6 until stable v7 ships for all packages",
+      "matchPackageNames": ["@fullcalendar/**"],
+      "allowedVersions": "<7.0.0",
+      "groupName": "fullcalendar"
+    },
+    // nosemgrep: package_managers.renovate.renovate-missing-minimum-release-age
+    // minimumReleaseAge is inherited from local>cwaits6/renovate-config.
     {
       "description": "Group all non-major npm dependency updates into a single PR",
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## Why

Renovate raised #227 to bump the FullCalendar monorepo to v7, but only `@fullcalendar/core` and `@fullcalendar/react` have a **stable** v7 (7.0.2). `daygrid`, `timegrid`, and `interaction` are still `7.0.0-beta`/`rc` — their stable `latest` is 6.1.21. Mixing v7 core/react with v6 plugins is an invalid peer-dep combination, which is why #227 fails the lockfile update, Vercel build, Trivy, and ZAP.

## What

- **`renovate.json5` guard** — pin all `@fullcalendar/*` to `<7.0.0` (same pattern as the existing ESLint `<10` and TypeScript `<7` holds), keeping the five packages consistent on v6. `groupName: "fullcalendar"` ensures the eventual v7 bump arrives as a single atomic PR.
- **`fullcalendar-v7-watch.yml`** — a weekly workflow (`workflow_dispatch` too) that checks npm for every `@fullcalendar` package and opens a tracking issue once all five have stable v7. It self-deactivates when the guard is lifted.

## Enabling v7 later

The watch issue will spell it out: change `allowedVersions` from `<7.0.0` to `<8.0.0` (or delete the rule). Renovate then opens one grouped PR. The only code consumer is `components/events/EventCalendarView.impl.tsx`.

Intended to replace #227 (close that once this merges).