### PR TITLE
fix: use private Cache-Control on token-bearing ICS routes

### DIFF
--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -81,7 +81,7 @@ export async function GET(request: Request) {
     status: 200,
     headers: {
       "Content-Type": "text/calendar; charset=utf-8",
-      "Cache-Control": "public, max-age=3600",
+      "Cache-Control": "private, max-age=3600",
     },
   });
 }

--- a/app/api/events/[id]/ics/route.ts
+++ b/app/api/events/[id]/ics/route.ts
@@ -53,7 +53,7 @@ export async function GET(
     headers: {
       "Content-Type": "text/calendar; charset=utf-8",
       "Content-Disposition": "inline",
-      "Cache-Control": "public, max-age=300",
+      "Cache-Control": "private, max-age=300",
     },
   });
 }


### PR DESCRIPTION
## Summary
- `feed.ics` and `events/[id]/ics` embed a personal subscription token in the URL query string. Both set `Cache-Control: public`, which invites shared/intermediate caches (proxies, CDNs) to store a response tied to a member's private calendar token.
- Switch both routes to `Cache-Control: private` so only the requesting client caches the response, preserving the existing `max-age` values (3600 / 300).

Fixes #217

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] Diff limited to the two `Cache-Control` header values, no other code touched
- [ ] Manual: hit `/api/calendar/feed.ics?token=...` and `/api/events/<id>/ics?token=...` and confirm response header reads `Cache-Control: private, max-age=...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy for calendar feed and event calendar downloads by preventing shared caching.
  * Calendar responses remain temporarily cached for faster access while being restricted to private caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->