### PR TITLE
fix: require member role for single-event ICS downloads

### DIFF
--- a/app/api/events/[id]/ics/route.ts
+++ b/app/api/events/[id]/ics/route.ts
@@ -71,7 +71,7 @@ export async function GET(
     headers: {
       "Content-Type": "text/calendar; charset=utf-8",
       "Content-Disposition": "inline",
-      "Cache-Control": "public, max-age=300",
+      "Cache-Control": "private, max-age=300",
     },
   });
 }

--- a/app/api/events/[id]/ics/route.ts
+++ b/app/api/events/[id]/ics/route.ts
@@ -30,13 +30,17 @@ export async function GET(
 
   // The service client bypasses RLS, so re-check membership here:
   // events are only visible to member roles (see "Members can view all
-  // events" policy). A token minted by a pending or removed profile must
-  // not grant access to arbitrary events by UUID.
-  const { data: owner } = await supabase
+  // events" policy). A token minted by a pending, deleted, or otherwise
+  // non-member profile must not grant access to arbitrary events by UUID.
+  const { data: owner, error: ownerError } = await supabase
     .from("profiles")
     .select("role")
     .eq("id", sub.user_id)
     .single();
+
+  if (ownerError) {
+    console.error("Failed to look up token owner's profile:", ownerError);
+  }
 
   if (!owner || !["member", "content_editor", "admin"].includes(owner.role)) {
     return new Response("Unauthorized", { status: 401 });

--- a/app/api/events/[id]/ics/route.ts
+++ b/app/api/events/[id]/ics/route.ts
@@ -20,11 +20,25 @@ export async function GET(
 
   const { data: sub } = await supabase
     .from("calendar_subscription_tokens")
-    .select("id")
+    .select("id, user_id")
     .eq("token", token)
     .single();
 
   if (!sub) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  // The service client bypasses RLS, so re-check membership here:
+  // events are only visible to member roles (see "Members can view all
+  // events" policy). A token minted by a pending or removed profile must
+  // not grant access to arbitrary events by UUID.
+  const { data: owner } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", sub.user_id)
+    .single();
+
+  if (!owner || !["member", "content_editor", "admin"].includes(owner.role)) {
     return new Response("Unauthorized", { status: 401 });
   }
 


### PR DESCRIPTION
## Summary

Fixes the IDOR reported in #216 (CWA-14). `app/api/events/[id]/ics/route.ts` validated only that a calendar subscription token row existed, then fetched **any event by UUID** through the RLS-bypassing service client.

The token INSERT policy only requires `auth.uid() = user_id`, so any authenticated profile — including `pending` (unapproved) or demoted ones — can mint a token and read arbitrary events.

## Changes

- Select the token owner's `user_id` alongside the token row.
- Before the event lookup, verify the owner's profile role is `member`, `content_editor`, or `admin` — mirroring the `"Members can view all events"` RLS policy (`is_member()`). Return `401 Unauthorized` otherwise.

No database migrations; code-only change scoped to the one file the issue cites.

## Validation

- `npx tsc --noEmit` — no errors.
- `npm run lint` — pre-existing ESLint 9 / `minimatch` crash on this branch's base (unrelated to this change).
- No test script exists in the repo.

## Note for reviewers

The sibling feed route `app/api/calendar/feed.ics/route.ts` has the same membership gap (a non-member's token returns the full events feed). Left untouched per the issue's scope; worth a follow-up issue.

Fixes #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar feed security by revalidating the token owner’s account role before granting access.
  * Unauthorized requests are now rejected when the account profile is unavailable or lacks an eligible role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->