### PR TITLE
fix: raise directory/profile/household text sizes and touch targets

### DIFF
--- a/app/household/HouseholdClient.tsx
+++ b/app/household/HouseholdClient.tsx
@@ -403,7 +403,7 @@ export function HouseholdClient({
           {/* Current user */}
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <Avatar className="h-9 w-9">
+              <Avatar className="h-12 w-12">
                 {currentProfile.avatar_url && (
                   <AvatarImage src={currentProfile.avatar_url} alt={displayName(currentProfile)} />
                 )}
@@ -412,11 +412,11 @@ export function HouseholdClient({
                 </AvatarFallback>
               </Avatar>
               <div>
-                <span className="text-sm font-medium">{displayName(currentProfile)}</span>
-                <Badge variant="outline" className="ml-2 text-xs capitalize">
+                <span className="text-base font-medium">{displayName(currentProfile)}</span>
+                <Badge variant="outline" className="ml-2 text-base capitalize">
                   {currentProfile.relationship}
                 </Badge>
-                <Badge variant="secondary" className="ml-1 text-xs">
+                <Badge variant="secondary" className="ml-1 text-base">
                   You
                 </Badge>
               </div>
@@ -430,7 +430,7 @@ export function HouseholdClient({
           {householdProfiles.map((p) => (
             <div key={p.id} className="flex items-center justify-between">
               <div className="flex items-center gap-3">
-                <Avatar className="h-9 w-9">
+                <Avatar className="h-12 w-12">
                   {p.avatar_url && (
                     <AvatarImage src={p.avatar_url} alt={displayName(p)} />
                   )}
@@ -439,8 +439,8 @@ export function HouseholdClient({
                   </AvatarFallback>
                 </Avatar>
                 <div>
-                  <span className="text-sm font-medium">{displayName(p)}</span>
-                  <Badge variant="outline" className="ml-2 text-xs capitalize">
+                  <span className="text-base font-medium">{displayName(p)}</span>
+                  <Badge variant="outline" className="ml-2 text-base capitalize">
                     {p.relationship}
                   </Badge>
                 </div>
@@ -456,7 +456,7 @@ export function HouseholdClient({
                   Edit profile
                 </Button>
               ) : (
-                <span className="text-xs text-muted-foreground">Contact admin to edit</span>
+                <span className="text-base text-muted-foreground">Contact admin to edit</span>
               )}
             </div>
           ))}
@@ -507,7 +507,7 @@ export function HouseholdClient({
               className="flex items-center justify-between bg-muted/40 rounded-md px-3 py-2"
             >
               <div className="flex items-center gap-3">
-                <Avatar className="h-9 w-9">
+                <Avatar className="h-12 w-12">
                   {fm.avatar_url && (
                     <AvatarImage
                       src={fm.avatar_url}
@@ -519,11 +519,11 @@ export function HouseholdClient({
                   </AvatarFallback>
                 </Avatar>
                 <div>
-                  <span className="text-sm font-medium">
+                  <span className="text-base font-medium">
                     {fm.preferred_name || fm.first_name}
                     {fm.last_name && ` ${fm.last_name}`}
                   </span>
-                  <Badge variant="outline" className="ml-2 text-xs capitalize">
+                  <Badge variant="outline" className="ml-2 text-base capitalize">
                     {fm.relationship}
                   </Badge>
                 </div>
@@ -540,7 +540,7 @@ export function HouseholdClient({
                 </Button>
                 <Button
                   variant="ghost"
-                  size="icon-sm"
+                  size="icon"
                   onClick={() => handleDeleteMember(fm)}
                 >
                   <Trash2 className="h-4 w-4 text-destructive" />

--- a/app/household/member/fm/FamilyMemberForm.tsx
+++ b/app/household/member/fm/FamilyMemberForm.tsx
@@ -185,10 +185,10 @@ export function FamilyMemberForm({ member }: Props) {
                   type="button"
                   onClick={() => fileInputRef.current?.click()}
                   disabled={uploadingAvatar}
-                  className="absolute -bottom-1 -right-1 bg-brand-primary hover:bg-brand-primary/90 text-white rounded-full p-2 shadow-md transition-colors disabled:opacity-50"
+                  className="absolute -bottom-1 -right-1 flex h-12 w-12 items-center justify-center rounded-full bg-brand-primary text-white shadow-md transition-colors hover:bg-brand-primary/90 disabled:opacity-50"
                   aria-label="Upload photo"
                 >
-                  <Camera className="h-4 w-4" />
+                  <Camera className="h-5 w-5" />
                 </button>
                 <input
                   ref={fileInputRef}

--- a/app/profile/setup/SetupWizard.tsx
+++ b/app/profile/setup/SetupWizard.tsx
@@ -141,7 +141,7 @@ function MemberAddForm({
       <p className="font-medium text-sm">{title}</p>
       <div className="grid sm:grid-cols-2 gap-3">
         <div className="space-y-1">
-          <Label className="text-sm">First name *</Label>
+          <Label className="text-base">First name *</Label>
           <Input
             value={form.first_name}
             onChange={(e) =>
@@ -623,7 +623,7 @@ export function SetupWizard({ profile, userEmail }: SetupWizardProps) {
                 {done ? <Check className="h-4 w-4" /> : num}
               </div>
               <span
-                className={`text-xs mt-1 text-center hidden sm:block ${active ? "text-brand-primary font-medium" : "text-muted-foreground"}`}
+                className={`text-base mt-1 text-center hidden sm:block ${active ? "text-brand-primary font-medium" : "text-muted-foreground"}`}
               >
                 {label}
               </span>
@@ -643,7 +643,7 @@ export function SetupWizard({ profile, userEmail }: SetupWizardProps) {
           <CardContent className="pt-6 space-y-6">
             <div>
               <h2 className="text-xl font-semibold mb-1">Who are you?</h2>
-              <p className="text-sm text-muted-foreground">
+              <p className="text-base text-muted-foreground">
                 This is how you&apos;ll appear in the member directory.
               </p>
             </div>
@@ -663,10 +663,10 @@ export function SetupWizard({ profile, userEmail }: SetupWizardProps) {
                   type="button"
                   onClick={() => fileInputRef.current?.click()}
                   disabled={uploadingAvatar}
-                  className="absolute -bottom-1 -right-1 bg-brand-primary hover:bg-brand-primary/90 text-white rounded-full p-1.5 shadow-md disabled:opacity-50"
+                  className="absolute -bottom-1 -right-1 flex h-12 w-12 items-center justify-center rounded-full bg-brand-primary text-white shadow-md transition-colors hover:bg-brand-primary/90 disabled:opacity-50"
                   aria-label="Upload photo"
                 >
-                  <Camera className="h-3.5 w-3.5" />
+                  <Camera className="h-5 w-5" />
                 </button>
                 <input
                   ref={fileInputRef}
@@ -678,7 +678,7 @@ export function SetupWizard({ profile, userEmail }: SetupWizardProps) {
               </div>
               <div>
                 <p className="text-sm font-medium">Profile photo</p>
-                <p className="text-xs text-muted-foreground">
+                <p className="text-base text-muted-foreground">
                   {uploadingAvatar
                     ? "Uploading..."
                     : "Optional — click the camera icon to add one."}
@@ -1050,7 +1050,7 @@ export function SetupWizard({ profile, userEmail }: SetupWizardProps) {
                     {pendingMembers.map((m) => (
                       <div
                         key={m.tempId}
-                        className="flex items-center justify-between rounded-md border px-3 py-2 text-sm"
+                        className="flex items-center justify-between rounded-md border px-3 py-2 text-base"
                       >
                         <span>
                           <span className="font-medium">

--- a/app/profile/setup/page.tsx
+++ b/app/profile/setup/page.tsx
@@ -34,7 +34,7 @@ export default async function ProfileSetupPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-dvh bg-background">
       <div className="container mx-auto px-4 py-12 max-w-2xl">
         <div className="text-center mb-10">
           <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-3">

--- a/components/directory/DirRow.tsx
+++ b/components/directory/DirRow.tsx
@@ -47,7 +47,7 @@ export function DirRow({
       <span className="min-w-0 flex-1">
         <span className="block font-semibold text-foreground">{title}</span>
         {subtitle && (
-          <span className="block text-sm text-muted-foreground">{subtitle}</span>
+          <span className="block text-base text-muted-foreground">{subtitle}</span>
         )}
       </span>
       {trailing}
@@ -82,7 +82,7 @@ export function DirRow({
 /** Muted section label used above groups of rows (A–Z letters, month names) */
 export function DirSectionLabel({ children }: { children: ReactNode }) {
   return (
-    <p className="mt-6 mb-2.5 first:mt-0 text-sm font-bold tracking-widest text-muted-foreground">
+    <p className="mt-6 mb-2.5 first:mt-0 text-base font-bold tracking-widest text-muted-foreground">
       {children}
     </p>
   );

--- a/components/directory/GroupBadge.tsx
+++ b/components/directory/GroupBadge.tsx
@@ -3,21 +3,16 @@ import type { GroupChip } from "@/lib/types";
 
 interface GroupBadgeProps {
   group: GroupChip;
-  size?: "xs" | "sm";
 }
 
 /** Colored group chip with the group's icon and name */
-export function GroupBadge({ group, size = "sm" }: GroupBadgeProps) {
-  const sizing =
-    size === "xs"
-      ? "px-1.5 py-px text-[10px] gap-0.5"
-      : "px-2 py-0.5 text-xs gap-1";
+export function GroupBadge({ group }: GroupBadgeProps) {
   return (
     <span
-      className={`inline-flex items-center rounded-full font-medium text-white ${sizing}`}
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-sm font-medium text-white"
       style={{ backgroundColor: group.color || "var(--color-brand-neutral)" }}
     >
-      <GroupIcon name={group.icon} className={size === "xs" ? "h-2.5 w-2.5" : "h-3 w-3"} />
+      <GroupIcon name={group.icon} className="h-3 w-3" />
       {group.name}
     </span>
   );

--- a/components/directory/PersonCard.tsx
+++ b/components/directory/PersonCard.tsx
@@ -43,7 +43,7 @@ function ContactLine({
         aria-hidden="true"
       />
       <span className="min-w-0 text-base">{children}</span>
-      {kind && <span className="text-sm text-muted-foreground">{kind}</span>}
+      {kind && <span className="text-base text-muted-foreground">{kind}</span>}
     </div>
   );
 }
@@ -91,7 +91,7 @@ export function PersonCard({ profile, family }: PersonCardProps) {
             <p className="text-base text-muted-foreground">{family.family_name}</p>
           )}
           {profile.relationship && profile.relationship !== "primary" && (
-            <Badge variant="outline" className="text-xs mt-1 capitalize">
+            <Badge variant="outline" className="text-base mt-1 capitalize">
               {relLabel(profile.relationship)}
             </Badge>
           )}
@@ -115,13 +115,13 @@ export function PersonCard({ profile, family }: PersonCardProps) {
             <a href={`tel:${profile.phone_mobile}`} className={telLink}>
               {formatPhone(profile.phone_mobile)}
             </a>
-            <span className="text-sm text-muted-foreground">mobile</span>
+            <span className="text-base text-muted-foreground">mobile</span>
             <a
               href={`sms:${profile.phone_mobile}`}
-              className="ml-auto text-brand-primary hover:text-brand-primary/80"
-              aria-label={`Text ${displayName(profile)}`}
+              className="ml-auto flex items-center gap-1.5 text-brand-primary hover:text-brand-primary/80"
             >
-              <MessageSquare className="h-5 w-5" />
+              <MessageSquare className="h-5 w-5" aria-hidden="true" />
+              <span className="text-base font-medium">Text</span>
             </a>
           </div>
         )}
@@ -188,7 +188,7 @@ export function PersonCard({ profile, family }: PersonCardProps) {
             <span>
               {profile.occupation}
               {profile.employer && (
-                <span className="block text-sm text-muted-foreground">
+                <span className="block text-base text-muted-foreground">
                   {profile.employer}
                 </span>
               )}

--- a/components/profile/MyProfileView.tsx
+++ b/components/profile/MyProfileView.tsx
@@ -40,7 +40,7 @@ interface MyProfileViewProps {
 }
 
 const eyebrow =
-  "text-sm font-bold uppercase tracking-wider text-muted-foreground";
+  "text-base font-bold uppercase tracking-wider text-muted-foreground";
 
 function MemberTile({
   name,
@@ -219,7 +219,7 @@ export function MyProfileView({
                   <span className="text-base">
                     {formatPhone(family.phone_home)}
                   </span>
-                  <span className="text-sm text-muted-foreground">home</span>
+                  <span className="text-base text-muted-foreground">home</span>
                 </div>
               )}
             </div>


### PR DESCRIPTION
Fixes #245 (CWA-34)

A11y and polish sweep across the directory, profile, and household surfaces, per the issue checklist. Pure Tailwind class-level changes — no route restructuring (that's CWA-27), no DB migrations.

## Changes

- **DirRow**: row subtitles and A–Z/month section labels raised from 14px to 16px (`text-base`).
- **PersonCard**: "mobile"/"home"/"work" qualifiers, relationship badge, and employer line raised to 16px; the icon-only SMS action now shows a visible "Text" label next to the icon (redundant `aria-label` dropped since the accessible name is now visible text).
- **GroupBadge**: the unreadable 10px `xs` variant is removed; the chip is a single 14px size. Its only caller (`PersonCard`) never passed `size`, so this is a pure simplification.
- **Household page**: all three member-row blocks (you, other enrolled members, family members without accounts) get 48px avatars and 16px names/badges to match directory row density; the icon-only remove button goes from `icon-sm` (40px) to `icon` (48px).
- **Setup wizard**: step labels, step-1 description, photo helper text, first-name label, and pending-member rows raised to 16px; the icon-only camera upload button over the avatar enlarged to a 48px touch target.
- **FamilyMemberForm**: same 48px camera-upload treatment for consistency between the two avatar-upload entry points.
- **MyProfileView**: "How others see you" / "Family members" eyebrows and the "home" phone qualifier raised to 16px.
- **Setup page**: `min-h-screen` → `min-h-dvh` so the page matches the real mobile viewport height.

## Validation

- `npm run build` passes (exit 0, project-wide type check, 64/64 pages generated).
- `npx next lint`: 0 errors, 0 warnings. (`npm run lint` crashes with a pre-existing `minimatch` dependency error unrelated to this change.)
- Verified `GroupBadge` has no other callers before removing the `size` prop.
- No files changed outside the 8 cited by the issue plan; zero migrations.