### PR TITLE
fix: raise auth and join pages to senior a11y floor (#247)

### DIFF
--- a/app/(auth)/_components/AuthShell.tsx
+++ b/app/(auth)/_components/AuthShell.tsx
@@ -52,7 +52,7 @@ export function AuthShell({
             <div className="font-serif text-[1.25rem] font-semibold leading-tight tracking-[-0.01em]">
               {siteConfig.name}
             </div>
-            <div className="font-sans text-[0.65rem] font-medium tracking-[0.18em] uppercase text-white/70 mt-0.5">
+            <div className="font-sans text-base font-medium tracking-[0.18em] uppercase text-white/70 mt-0.5">
               {siteConfig.brandLine}
             </div>
           </div>
@@ -70,13 +70,13 @@ export function AuthShell({
           <p className="font-serif italic text-[2rem] leading-[1.25] tracking-[-0.025em] text-white">
             Encourage one another and build each other up.
           </p>
-          <p className="font-sans text-[0.7rem] font-bold tracking-[0.2em] uppercase text-brand-accent mt-4">
+          <p className="font-sans text-base font-bold tracking-[0.2em] uppercase text-brand-accent mt-4">
             1 Thessalonians 5:11
           </p>
         </div>
 
         {/* Bottom: micro-tagline — hidden on mobile */}
-        <div className="relative hidden md:block font-sans text-xs text-white/70 leading-relaxed">
+        <div className="relative hidden md:block font-sans text-base text-white/70 leading-relaxed">
           A Sunday class for every season of life — come as you are.
         </div>
       </div>
@@ -87,7 +87,7 @@ export function AuthShell({
           {/* Eyebrow */}
           <div className="flex items-center gap-2.5 mb-5">
             <div className="w-5 h-px bg-brand-accent" aria-hidden />
-            <span className="font-sans text-[0.65rem] font-bold tracking-[0.2em] uppercase text-brand-accent">
+            <span className="font-sans text-base font-bold tracking-[0.2em] uppercase text-brand-accent">
               {eyebrow}
             </span>
           </div>
@@ -109,7 +109,7 @@ export function AuthShell({
           {/* Alt link (optional) */}
           {altPrompt && altLabel && altHref && (
             <div className="mt-8 pt-6 border-t border-border">
-              <p className="font-sans text-sm text-muted-foreground">
+              <p className="font-sans text-lg text-muted-foreground">
                 {altPrompt}{" "}
                 <Link
                   href={altHref}

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -61,7 +61,7 @@ export default function ForgotPasswordPage() {
         <div className="space-y-1.5">
           <Label
             htmlFor="email"
-            className="font-sans text-xs font-semibold tracking-[0.08em] uppercase text-foreground"
+            className="font-sans text-lg font-semibold tracking-[0.08em] uppercase text-foreground"
           >
             Email
           </Label>
@@ -71,7 +71,7 @@ export default function ForgotPasswordPage() {
             type="email"
             required
             placeholder="your@email.com"
-            className="h-11"
+            className="h-12 text-lg"
           />
         </div>
         <Button

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -70,7 +70,7 @@ export default function LoginPage() {
         <div className="space-y-1.5">
           <Label
             htmlFor="email"
-            className="font-sans text-xs font-semibold tracking-[0.08em] uppercase text-foreground"
+            className="font-sans text-lg font-semibold tracking-[0.08em] uppercase text-foreground"
           >
             Email
           </Label>
@@ -80,13 +80,13 @@ export default function LoginPage() {
             type="email"
             required
             placeholder="your@email.com"
-            className="h-11"
+            className="h-12 text-lg"
           />
         </div>
         <div className="space-y-1.5">
           <Label
             htmlFor="password"
-            className="font-sans text-xs font-semibold tracking-[0.08em] uppercase text-foreground"
+            className="font-sans text-lg font-semibold tracking-[0.08em] uppercase text-foreground"
           >
             Password
           </Label>
@@ -96,7 +96,7 @@ export default function LoginPage() {
             type="password"
             required
             placeholder="Your password"
-            className="h-11"
+            className="h-12 text-lg"
           />
         </div>
         <Button

--- a/app/(auth)/setup-account/page.tsx
+++ b/app/(auth)/setup-account/page.tsx
@@ -187,7 +187,7 @@ export default function SetupAccountPage() {
         <div className="space-y-1.5">
           <Label
             htmlFor="email"
-            className="font-sans text-xs font-semibold tracking-[0.08em] uppercase text-foreground"
+            className="font-sans text-lg font-semibold tracking-[0.08em] uppercase text-foreground"
           >
             Email
           </Label>
@@ -196,13 +196,13 @@ export default function SetupAccountPage() {
             type="email"
             value={tokenData?.email || ""}
             disabled
-            className="h-11 bg-muted"
+            className="h-12 text-lg bg-muted"
           />
         </div>
         <div className="space-y-1.5">
           <Label
             htmlFor="password"
-            className="font-sans text-xs font-semibold tracking-[0.08em] uppercase text-foreground"
+            className="font-sans text-lg font-semibold tracking-[0.08em] uppercase text-foreground"
           >
             Password
           </Label>
@@ -213,13 +213,13 @@ export default function SetupAccountPage() {
             required
             minLength={8}
             placeholder="At least 8 characters"
-            className="h-11"
+            className="h-12 text-lg"
           />
         </div>
         <div className="space-y-1.5">
           <Label
             htmlFor="confirmPassword"
-            className="font-sans text-xs font-semibold tracking-[0.08em] uppercase text-foreground"
+            className="font-sans text-lg font-semibold tracking-[0.08em] uppercase text-foreground"
           >
             Confirm Password
           </Label>
@@ -230,7 +230,7 @@ export default function SetupAccountPage() {
             required
             minLength={8}
             placeholder="Confirm your password"
-            className="h-11"
+            className="h-12 text-lg"
           />
         </div>
         <Button

--- a/app/(auth)/update-password/page.tsx
+++ b/app/(auth)/update-password/page.tsx
@@ -79,7 +79,7 @@ export default function UpdatePasswordPage() {
         <div className="space-y-1.5">
           <Label
             htmlFor="password"
-            className="font-sans text-xs font-semibold tracking-[0.08em] uppercase text-foreground"
+            className="font-sans text-lg font-semibold tracking-[0.08em] uppercase text-foreground"
           >
             New Password
           </Label>
@@ -90,13 +90,13 @@ export default function UpdatePasswordPage() {
             required
             minLength={8}
             placeholder="At least 8 characters"
-            className="h-11"
+            className="h-12 text-lg"
           />
         </div>
         <div className="space-y-1.5">
           <Label
             htmlFor="confirmPassword"
-            className="font-sans text-xs font-semibold tracking-[0.08em] uppercase text-foreground"
+            className="font-sans text-lg font-semibold tracking-[0.08em] uppercase text-foreground"
           >
             Confirm Password
           </Label>
@@ -107,7 +107,7 @@ export default function UpdatePasswordPage() {
             required
             minLength={8}
             placeholder="Confirm your password"
-            className="h-11"
+            className="h-12 text-lg"
           />
         </div>
         <Button

--- a/app/join/family/[token]/page.tsx
+++ b/app/join/family/[token]/page.tsx
@@ -3,9 +3,9 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Users, ArrowRight } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import { siteConfig } from "@/lib/config";
+import { AuthShell } from "@/app/(auth)/_components/AuthShell";
 
 interface PageProps {
   params: Promise<{ token: string }>;
@@ -96,75 +96,54 @@ export default async function FamilyJoinPage({ params }: PageProps) {
   const joinUrl = `/join?invite_token=${encodeURIComponent(token)}&email=${encodeURIComponent(invite.invite_email)}`;
 
   return (
-    <div className="container mx-auto px-4 py-12 max-w-lg">
-      <Card>
-        <CardHeader>
-          <div className="flex items-center gap-3 mb-2">
-            <div className="w-10 h-10 bg-brand-primary/10 rounded-full flex items-center justify-center">
-              <Users className="h-5 w-5 text-brand-primary" />
-            </div>
-            <Badge variant="secondary" className="capitalize">
-              {familyMember?.relationship ?? "Family"} invite
-            </Badge>
-          </div>
-          <CardTitle className="text-2xl text-brand-primary">
-            You&apos;ve been invited to join {siteConfig.name}!
-          </CardTitle>
-          <CardDescription className="text-base">
-            {familyUnit?.family_name && (
-              <>
-                You&apos;ve been added to the{" "}
-                <strong>{familyUnit.family_name}</strong> household.
-              </>
-            )}{" "}
-            Create your own account to appear in the member directory and
-            connect with the group.
-          </CardDescription>
-        </CardHeader>
-
-        <CardContent className="space-y-6">
-          <div className="rounded-lg bg-muted/50 border p-4 space-y-1">
-            <p className="text-sm text-muted-foreground">Invited as</p>
-            <p className="font-semibold text-lg">{memberName}</p>
-            {familyUnit?.family_name && (
-              <p className="text-sm text-muted-foreground">
-                {familyUnit.family_name}
-              </p>
-            )}
-          </div>
-
-          <div className="space-y-3">
-            <p className="text-sm text-muted-foreground">
-              Your invite was sent to{" "}
-              <span className="font-medium text-foreground">
-                {invite.invite_email}
-              </span>
-              . Use that email address when you sign up.
+    <AuthShell
+      eyebrow={`${familyMember?.relationship ?? "Family"} invite`}
+      title="You've been invited to join"
+      em={siteConfig.name}
+      kicker={
+        familyUnit?.family_name
+          ? `You've been added to the ${familyUnit.family_name} household. Create your own account to appear in the member directory and connect with the group.`
+          : "Create your own account to appear in the member directory and connect with the group."
+      }
+      altPrompt="Already have an account?"
+      altLabel="Log in →"
+      altHref="/login"
+    >
+      <div className="space-y-6">
+        <div className="rounded-lg bg-muted/50 border p-4 space-y-1">
+          <p className="text-lg text-muted-foreground">Invited as</p>
+          <p className="font-semibold text-lg">{memberName}</p>
+          {familyUnit?.family_name && (
+            <p className="text-lg text-muted-foreground">
+              {familyUnit.family_name}
             </p>
-            <p className="text-sm text-muted-foreground">
-              After you request access, an admin will review and approve your
-              account. This usually takes less than a day.
-            </p>
-          </div>
+          )}
+        </div>
 
-          <Link href={joinUrl} className="block">
-            <Button
-              size="lg"
-              className="w-full text-base py-6 bg-brand-primary hover:bg-brand-primary/90 text-white flex items-center justify-center gap-2"
-            >
-              Request Access
-              <ArrowRight className="h-4 w-4" />
-            </Button>
-          </Link>
-
-          <p className="text-xs text-center text-muted-foreground">
-            Already have an account?{" "}
-            <Link href="/login" className="text-brand-primary underline">
-              Log in
-            </Link>
+        <div className="space-y-3">
+          <p className="text-lg text-muted-foreground">
+            Your invite was sent to{" "}
+            <span className="font-medium text-foreground">
+              {invite.invite_email}
+            </span>
+            . Use that email address when you sign up.
           </p>
-        </CardContent>
-      </Card>
-    </div>
+          <p className="text-lg text-muted-foreground">
+            After you request access, an admin will review and approve your
+            account. This usually takes less than a day.
+          </p>
+        </div>
+
+        <Link href={joinUrl} className="block">
+          <Button
+            size="lg"
+            className="w-full bg-brand-primary hover:bg-brand-primary/90 text-white flex items-center justify-center gap-2"
+          >
+            Request Access
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </Link>
+      </div>
+    </AuthShell>
   );
 }

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -5,10 +5,11 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { createClient } from "@/lib/supabase/client";
 import { toast } from "sonner";
 import { useSearchParams } from "next/navigation";
+import { AuthShell } from "@/app/(auth)/_components/AuthShell";
 
 function JoinForm() {
   const [loading, setLoading] = useState(false);
@@ -65,68 +66,63 @@ function JoinForm() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-12 max-w-lg">
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-3xl text-brand-primary">Join Our Group</CardTitle>
-          <CardDescription className="text-lg">
-            Fill out the form below and an admin will review your request.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-6">
-            <div className="space-y-2">
-              <Label htmlFor="name" className="text-lg">Full Name</Label>
-              <Input
-                id="name"
-                name="name"
-                required
-                placeholder="Your full name"
-                className="text-lg py-6"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="email" className="text-lg">Email</Label>
-              <Input
-                id="email"
-                name="email"
-                type="email"
-                required
-                defaultValue={prefilledEmail}
-                readOnly={!!prefilledEmail}
-                placeholder="your@email.com"
-                className={`text-lg py-6${prefilledEmail ? " bg-muted" : ""}`}
-              />
-              {prefilledEmail && (
-                <p className="text-xs text-muted-foreground">
-                  Your invite was sent to this email address — please use it to sign up.
-                </p>
-              )}
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="message" className="text-lg">
-                Message <span className="text-muted-foreground">(optional)</span>
-              </Label>
-              <Textarea
-                id="message"
-                name="message"
-                placeholder="Tell us a little about yourself..."
-                rows={4}
-                className="text-lg"
-              />
-            </div>
-            <Button
-              type="submit"
-              size="lg"
-              className="w-full text-lg py-6 bg-brand-primary hover:bg-brand-primary/90 text-white"
-              disabled={loading}
-            >
-              {loading ? "Submitting..." : "Submit Request"}
-            </Button>
-          </form>
-        </CardContent>
-      </Card>
-    </div>
+    <AuthShell
+      eyebrow="REQUEST ACCESS"
+      title="Join"
+      em="our group"
+      kicker="Fill out the form below and an admin will review your request."
+    >
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="space-y-2">
+          <Label htmlFor="name" className="text-lg">Full Name</Label>
+          <Input
+            id="name"
+            name="name"
+            required
+            placeholder="Your full name"
+            className="text-lg py-6"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="email" className="text-lg">Email</Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            required
+            defaultValue={prefilledEmail}
+            readOnly={!!prefilledEmail}
+            placeholder="your@email.com"
+            className={`text-lg py-6${prefilledEmail ? " bg-muted" : ""}`}
+          />
+          {prefilledEmail && (
+            <p className="text-lg text-muted-foreground">
+              Your invite was sent to this email address — please use it to sign up.
+            </p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="message" className="text-lg">
+            Message <span className="text-muted-foreground">(optional)</span>
+          </Label>
+          <Textarea
+            id="message"
+            name="message"
+            placeholder="Tell us a little about yourself..."
+            rows={4}
+            className="text-lg"
+          />
+        </div>
+        <Button
+          type="submit"
+          size="lg"
+          className="w-full text-lg py-6 bg-brand-primary hover:bg-brand-primary/90 text-white"
+          disabled={loading}
+        >
+          {loading ? "Submitting..." : "Submit Request"}
+        </Button>
+      </form>
+    </AuthShell>
   );
 }
 


### PR DESCRIPTION
Fixes #247 (CWA-36)

## Problem

The auth pages had regressed below the shared senior-accessibility floor: every form field label rendered at 12px uppercase (`text-xs`), inputs were hardcoded to 44px (`h-11`), and `AuthShell`'s brand/eyebrow text sat at 10–14px. Separately, `/join` and `/join/family/[token]` each used a bespoke `max-w-lg` Card container instead of the shared `AuthShell`, with 12–14px captions and hints.

## Changes

- **`AuthShell.tsx`** — decorative text (brand line, verse reference, tagline, eyebrow) raised to 16px; the shared alt-prompt line ("New here?" / "Already have an account?") raised to 18px.
- **`login`, `forgot-password`, `setup-account`, `update-password`** — all 8 field labels `text-xs` → `text-lg` (18px); all 8 inputs `h-11` → `h-12 text-lg` (48px tap target, 18px text). The disabled email input on setup-account keeps its `bg-muted` treatment.
- **`/join`** — request form now renders through the shared `AuthShell` (same two-column shell as login) instead of a bespoke Card; the invite-email hint raised from 12px to 18px. Field markup was already compliant (`text-lg py-6`) and is unchanged.
- **`/join/family/[token]`** — invited state now renders through `AuthShell`; the three hint paragraphs raised from 14px to 18px; the standalone "Already have an account?" line is folded into `AuthShell`'s shared alt-prompt slot. The `<strong>` emphasis on the household name in the old CardDescription becomes plain text because `AuthShell`'s `kicker` prop is string-typed.

## Not changed (intentionally)

- Submit buttons — already 56px via the shared `Button` `size="lg"` (raised in #233/#250); the issue's h-9 claim was stale.
- `/join`'s submitted-success state and Suspense fallback, and the family invite's "Invite Already Used" state — not cited by the issue and already ≥16px.
- Label uppercase/letter-spacing treatment — size-only change per the issue scope.

## Validation

- `npx tsc --noEmit` — clean
- `npm run build` — succeeds, all routes compile
- `npm run lint` — crashes with a pre-existing `minimatch` error; verified the identical crash occurs on an unmodified tree, so it is unrelated to this change
- No database migrations; no remote Supabase interaction

## Reviewer QA suggestions

Walk `/login`, `/forgot-password`, `/setup-account`, `/update-password`, `/join` (with and without `invite_token`/`email` params), and `/join/family/<token>` (valid + already-accepted); check a 200% zoom pass on `/login` and `/join` for clipping.