### PR TITLE
fix: raise undersized text and touch targets on serving, giving, prayer

### DIFF
--- a/app/admin/giving/page.tsx
+++ b/app/admin/giving/page.tsx
@@ -107,11 +107,11 @@ export default async function AdminGivingPage() {
               >
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
-                    <span className="font-serif text-lg text-foreground">
+                    <span className="text-lg font-semibold text-foreground">
                       {fund.name}
                     </span>
                     <span
-                      className={`rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide ${
+                      className={`rounded-full px-2 py-0.5 text-xs font-bold uppercase tracking-wide ${
                         status.live
                           ? "bg-brand-warm text-brand-primary"
                           : "bg-muted text-muted-foreground"
@@ -142,7 +142,7 @@ export default async function AdminGivingPage() {
                 </div>
                 <Button
                   variant="outline"
-                  size="sm"
+                  size="default"
                   nativeButton={false}
                   render={<Link href={`/give/${fund.id}/edit`} />}
                 >

--- a/app/admin/serving/page.tsx
+++ b/app/admin/serving/page.tsx
@@ -171,7 +171,7 @@ export default function ServingStatsPage() {
               key={r.value}
               type="button"
               onClick={() => setRange(r.value)}
-              className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
+              className={`px-4 py-3 rounded-lg text-base font-medium border transition-colors ${
                 range === r.value
                   ? "bg-brand-primary text-white border-brand-primary"
                   : "border-border text-muted-foreground hover:border-brand-primary/50"
@@ -208,7 +208,7 @@ export default function ServingStatsPage() {
           </CardHeader>
           <CardContent className="p-0">
             <div className="overflow-x-auto">
-              <table className="w-full text-sm">
+              <table className="w-full text-base">
                 <thead>
                   <tr className="border-b border-border bg-muted/40">
                     <th className="text-left px-6 py-3 font-semibold text-muted-foreground">

--- a/components/giving/FundForm.tsx
+++ b/components/giving/FundForm.tsx
@@ -308,7 +308,7 @@ export function FundForm({
                   {steward?.name ?? "You"}
                 </p>
               )}
-              <p className="mt-1.5 text-xs text-muted-foreground">
+              <p className="mt-1.5 text-sm text-muted-foreground">
                 Money goes to this person&apos;s accounts.
               </p>
             </div>
@@ -335,7 +335,7 @@ export function FundForm({
                   </ComboboxList>
                 </ComboboxPopup>
               </Combobox>
-              <p className="mt-1.5 text-xs text-muted-foreground">
+              <p className="mt-1.5 text-sm text-muted-foreground">
                 A spouse or co-collector, for display.
               </p>
             </div>
@@ -366,7 +366,7 @@ export function FundForm({
                 onChange={(e) => setRetireOn(e.target.value)}
                 className="mt-1.5 text-base py-5"
               />
-              <p className="mt-1.5 text-xs text-muted-foreground">
+              <p className="mt-1.5 text-sm text-muted-foreground">
                 Hidden from the Give page after this date.
               </p>
             </div>
@@ -412,7 +412,7 @@ export function FundForm({
                           className="font-mono text-sm"
                         />
                         {missing && (
-                          <p className="mt-1.5 text-xs font-medium text-brand-accent">
+                          <p className="mt-1.5 text-sm font-medium text-brand-accent">
                             Enter a handle for {meta.name}{' '}or this method won&apos;t be saved.
                           </p>
                         )}
@@ -477,11 +477,11 @@ export function FundForm({
             )}
             <div className="min-w-0 flex-1">
               <div className="flex flex-wrap items-center gap-2">
-                <span className="font-serif text-lg">
+                <span className="text-lg font-semibold">
                   {name.trim() || "Fund name"}
                 </span>
                 {previewTag && (
-                  <span className="rounded-full bg-brand-bg-light px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide">
+                  <span className="rounded-full bg-brand-bg-light px-2 py-0.5 text-xs font-bold uppercase tracking-wide">
                     {previewTag}
                   </span>
                 )}

--- a/components/giving/GiveList.tsx
+++ b/components/giving/GiveList.tsx
@@ -50,11 +50,11 @@ export function GiveList({ funds }: { funds: FundView[] }) {
               <AvatarCluster people={fund.stewards} />
               <span className="min-w-0 flex-1">
                 <span className="flex flex-wrap items-center gap-2">
-                  <span className="font-serif text-xl text-foreground">
+                  <span className="text-xl font-semibold text-foreground">
                     {fund.name}
                   </span>
                   {fund.tag && (
-                    <span className="rounded-full bg-brand-bg-light px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-foreground">
+                    <span className="rounded-full bg-brand-bg-light px-2 py-0.5 text-xs font-bold uppercase tracking-wide text-foreground">
                       {fund.tag}
                     </span>
                   )}
@@ -75,7 +75,7 @@ export function GiveList({ funds }: { funds: FundView[] }) {
             {open && (
               <div className="px-4 pb-4 sm:px-5 sm:pb-5">
                 {fund.description && (
-                  <p className="mb-3.5 text-[15px] leading-relaxed text-muted-foreground">
+                  <p className="mb-3.5 text-base leading-relaxed text-muted-foreground">
                     {fund.description}
                   </p>
                 )}

--- a/components/prayer/PrayerBoard.tsx
+++ b/components/prayer/PrayerBoard.tsx
@@ -198,7 +198,7 @@ export function PrayerBoard({
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search requests…"
           aria-label="Search requests"
-          className="w-full bg-transparent text-[15px] outline-none placeholder:text-muted-foreground"
+          className="w-full bg-transparent text-base outline-none placeholder:text-muted-foreground"
         />
         {query && (
           <button
@@ -221,7 +221,7 @@ export function PrayerBoard({
               key={f}
               type="button"
               onClick={() => setStatus(f)}
-              className={`rounded-full border px-3.5 py-1.5 text-sm transition-colors ${
+              className={`rounded-full border px-4 py-3 text-base transition-colors ${
                 active
                   ? "border-foreground bg-foreground font-semibold text-background"
                   : "border-border bg-card font-medium text-muted-foreground hover:text-foreground"
@@ -240,7 +240,7 @@ export function PrayerBoard({
         >
           <SelectTrigger
             aria-label="Filter by prayer type"
-            className={`h-auto! rounded-full! px-3.5 py-1.5 text-sm transition-colors ${
+            className={`h-auto! rounded-full! px-4 py-3 text-base transition-colors ${
               typeMeta
                 ? "font-semibold [&_svg]:text-white"
                 : "border-border bg-card font-medium text-muted-foreground hover:text-foreground"

--- a/components/prayer/PrayerCallCard.tsx
+++ b/components/prayer/PrayerCallCard.tsx
@@ -200,7 +200,7 @@ export function PrayerCallCard({
         )}
       </div>
 
-      <h2 className="font-serif text-2xl text-background">The prayer call</h2>
+      <h2 className="text-2xl font-semibold text-background">The prayer call</h2>
       <p className="mt-2 mb-4 text-sm leading-relaxed text-background/80">
         We gather by phone to pray through the wall. Everyone is welcome to
         join. Each call is also on the group calendar.
@@ -233,7 +233,7 @@ export function PrayerCallCard({
               </div>
               <div className="grid grid-cols-2 gap-2.5">
                 <label className="col-span-2 block">
-                  <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-wider text-background/85">
                     Day
                   </span>
                   <Select
@@ -254,7 +254,7 @@ export function PrayerCallCard({
                   </Select>
                 </label>
                 <label className="block">
-                  <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-wider text-background/85">
                     Starts
                   </span>
                   <input
@@ -265,7 +265,7 @@ export function PrayerCallCard({
                   />
                 </label>
                 <label className="block">
-                  <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-wider text-background/85">
                     Ends (optional)
                   </span>
                   <input
@@ -276,7 +276,7 @@ export function PrayerCallCard({
                   />
                 </label>
                 <div className="col-span-2">
-                  <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-wider text-background/85">
                     Call leader
                   </span>
                   <Combobox
@@ -302,7 +302,7 @@ export function PrayerCallCard({
                   </Combobox>
                 </div>
                 <label className="block">
-                  <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-wider text-background/85">
                     Dial in
                   </span>
                   <input
@@ -313,7 +313,7 @@ export function PrayerCallCard({
                   />
                 </label>
                 <label className="block">
-                  <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-wider text-background/85">
                     PIN
                   </span>
                   <input
@@ -324,7 +324,7 @@ export function PrayerCallCard({
                   />
                 </label>
                 <label className="col-span-2 block">
-                  <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-background/55">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-wider text-background/85">
                     Join link (optional)
                   </span>
                   <input
@@ -365,18 +365,18 @@ export function PrayerCallCard({
                     />
                   </span>
                   <div className="min-w-0 flex-1">
-                    <div className="text-[15px] font-bold">{sessionLabel(s)}</div>
+                    <div className="text-base font-bold">{sessionLabel(s)}</div>
                     {leaderName && (
-                      <div className="mt-0.5 text-xs text-background/70">
+                      <div className="mt-0.5 text-sm text-background/85">
                         Led by {leaderName}
                       </div>
                     )}
                     {(s.dial_in || s.pin) && (
-                      <div className="mt-0.5 font-mono text-xs text-background/70">
+                      <div className="mt-0.5 font-mono text-sm text-background/85">
                         {s.dial_in && (
                           <a
                             href={telHref(s.dial_in, s.pin)}
-                            className="hover:underline"
+                            className="inline-block py-1 hover:underline"
                           >
                             {s.dial_in}
                           </a>

--- a/components/prayer/PrayerCard.tsx
+++ b/components/prayer/PrayerCard.tsx
@@ -66,23 +66,23 @@ export function PrayerCard({
 
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="font-serif text-lg text-foreground">
+            <span className="text-lg font-semibold text-foreground">
               {authorName}
             </span>
             {row.mine && (
-              <span className="rounded-full bg-brand-warm px-2 py-0.5 text-[11px] font-bold text-brand-primary">
+              <span className="rounded-full bg-brand-warm px-2 py-0.5 text-xs font-bold text-brand-primary">
                 You
               </span>
             )}
             {restricted && (
-              <span className="flex items-center gap-1 rounded-full bg-brand-bg-light px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-brand-accent-text">
+              <span className="flex items-center gap-1 rounded-full bg-brand-bg-light px-2 py-0.5 text-xs font-bold uppercase tracking-wide text-brand-accent-text">
                 <Lock className="h-2.5 w-2.5" aria-hidden="true" />
                 Prayer warriors
               </span>
             )}
             {row.is_answered && (
               <span
-                className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide"
+                className="flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-bold uppercase tracking-wide"
                 style={{ backgroundColor: `${ANSWERED}1A`, color: ANSWERED }}
               >
                 <Check className="h-2.5 w-2.5" aria-hidden="true" />
@@ -103,7 +103,7 @@ export function PrayerCard({
         </span>
       </div>
 
-      <p className="mt-3 whitespace-pre-wrap text-[15px] leading-relaxed text-foreground/80">
+      <p className="mt-3 whitespace-pre-wrap text-base leading-relaxed text-foreground/80">
         {row.body}
       </p>
 

--- a/components/prayer/PrayerComposer.tsx
+++ b/components/prayer/PrayerComposer.tsx
@@ -155,7 +155,7 @@ export function PrayerComposer({
               {me.initials}
             </AvatarFallback>
           </Avatar>
-          <h2 className="font-serif text-xl text-foreground">
+          <h2 className="text-xl font-semibold text-foreground">
             Share a request
           </h2>
         </div>
@@ -166,7 +166,7 @@ export function PrayerComposer({
           placeholder="What can we pray with you about?"
           rows={4}
           maxLength={2000}
-          className="bg-background text-[15px]"
+          className="bg-background text-base"
         />
 
         <div className="mt-4 mb-2 text-[11px] font-bold uppercase tracking-widest text-muted-foreground">
@@ -182,7 +182,7 @@ export function PrayerComposer({
                 type="button"
                 onClick={() => setCategory(key)}
                 aria-pressed={active}
-                className="rounded-full border px-3 py-1.5 text-[13px] font-semibold transition-colors"
+                className="rounded-full border px-4 py-3 text-base font-semibold transition-colors"
                 style={
                   active
                     ? { backgroundColor: meta.color, borderColor: meta.color, color: "var(--primary-foreground)" }

--- a/components/serving/AdminServingSetup.tsx
+++ b/components/serving/AdminServingSetup.tsx
@@ -60,7 +60,7 @@ export function AdminServingSetup({ groups }: AdminServingSetupProps) {
               <span className="flex-1 min-w-0 font-medium truncate">{g.name}</span>
               <Button
                 variant="outline"
-                size="sm"
+                size="default"
                 disabled={busy === g.id}
                 onClick={() => enable(g.id, g.name)}
               >

--- a/components/serving/RoleRoster.tsx
+++ b/components/serving/RoleRoster.tsx
@@ -36,7 +36,7 @@ export function RoleRoster({ members }: { members: RosterMember[] }) {
           </Avatar>
           <span className="text-foreground">{displayName(m)}</span>
           {m.is_leader && (
-            <span className="text-[10px] font-bold uppercase tracking-wide text-brand-accent">
+            <span className="text-xs font-bold uppercase tracking-wide text-brand-accent">
               Leader
             </span>
           )}

--- a/components/serving/ServingSchedule.tsx
+++ b/components/serving/ServingSchedule.tsx
@@ -175,7 +175,7 @@ export function ServingSchedule({
               {entry && !mine && canManage && (
                 <Button
                   variant="ghost"
-                  size="icon-sm"
+                  size="icon"
                   disabled={busy}
                   onClick={() => cancel(entry)}
                   aria-label={`Remove ${entry.label}`}

--- a/components/serving/ServingSettingsDialog.tsx
+++ b/components/serving/ServingSettingsDialog.tsx
@@ -91,7 +91,7 @@ export function ServingSettingsDialog({ groupId, settings }: ServingSettingsDial
           {/* Reminder days */}
           <div className="space-y-2">
             <Label className="text-base">Reminder days</Label>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               Send reminder emails on these days of the week.
             </p>
             <div className="flex flex-wrap gap-2 pt-1">
@@ -118,7 +118,7 @@ export function ServingSettingsDialog({ groupId, settings }: ServingSettingsDial
             <Label htmlFor="st-weeks" className="text-base">
               Schedule window (weeks)
             </Label>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               How many upcoming Sundays to show (1–26).
             </p>
             <input


### PR DESCRIPTION
## Summary

Raises undersized text and touch targets across the serving, giving, and prayer surfaces so they meet the senior-friendly minimums (≥16px core content, ≥12–14px pills/helper text, ≥44–48px touch targets) and reads legibly (sans instead of serif under 28px on names/titles). Pure Tailwind class-string and `size=` prop edits — no logic, layout, or schema changes.

## Changes

| File | Fix |
|------|-----|
| `components/prayer/PrayerCard.tsx` | Body text, You/Prayer-warriors/Answered pills, author-name serif→sans |
| `components/prayer/PrayerComposer.tsx` | Compose textarea 15→16px, category chips ~48px, title serif→sans |
| `components/prayer/PrayerBoard.tsx` | Wall search 15→16px, status chips + type-filter trigger ~48px |
| `components/prayer/PrayerCallCard.tsx` | 7 field labels 10px/55%→12px/85% opacity, session label 15→16px, Led-by/dial-in 12→14px/85%, tel-link tap area, title serif→sans |
| `components/giving/GiveList.tsx` | Fund description 15→16px, retire pill 10→12px, fund-name serif→sans |
| `components/giving/FundForm.tsx` | 4 helper lines 12→14px, preview pill 10→12px, preview name serif→sans |
| `app/admin/giving/page.tsx` | Live/Retired pill 10→12px, fund-name serif→sans, Edit button 40→48px |
| `components/serving/RoleRoster.tsx` | "Leader" pill 10→12px |
| `app/admin/serving/page.tsx` | Range toggles ~48px, stats table 14→16px |
| `components/serving/AdminServingSetup.tsx` | "Enable signups" button 40→48px |
| `components/serving/ServingSchedule.tsx` | Remove-teammate icon button icon-sm→icon (48px) |
| `components/serving/ServingSettingsDialog.tsx` | 2 helper-text lines 12→14px |

12 files, +42/−42 lines. No files created or deleted, no database migrations, no new Tailwind utilities or Button variants.

## Validation

- Type check (`npx tsc --noEmit`): pass, no errors
- Build (`npm run build`): pass, all routes compiled
- Lint (`npm run lint`): pre-existing crash unrelated to this change (`brace-expansion`/`minimatch` flat-config incompatibility) — verified via stash test that it fails identically on unmodified `main`, before and after these edits. Recommend a separate follow-up to fix the dependency pin.
- Scope check: only the 12 files above touched; items explicitly out of scope for this sweep (`ServingSettingsDialog` trigger button, `FundForm` MethodChip, `PrayerCallCard` Edit/Save toggle + "Session N" label, day-of-week toggles) left untouched.

Fixes #246
