### PR TITLE
fix: scope anon read of site_settings to public rows

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -463,6 +463,7 @@ export interface SiteSetting {
   value: string | null;
   updated_by: string | null;
   updated_at: string | null;
+  is_public: boolean;
 }
 
 export interface PageContent {

--- a/supabase/migrations/20260725000000_site_settings_is_public.sql
+++ b/supabase/migrations/20260725000000_site_settings_is_public.sql
@@ -1,0 +1,23 @@
+-- Anon-readable site_settings exposed weekly_zoom_url / weekly_prayer_call_url /
+-- call times to unauthenticated REST clients (issue #215 / CWA-13). Add a
+-- per-row visibility flag so only rows explicitly marked public are
+-- anon-readable; logged-in members keep full read access as before.
+-- Future migrations seeding a setting meant to be public-by-design must
+-- explicitly set is_public = true; new rows default to private.
+
+alter table public.site_settings
+  add column is_public boolean not null default false;
+
+update public.site_settings
+  set is_public = true
+  where key = 'site_name';
+
+drop policy if exists "Anyone can read settings" on public.site_settings;
+
+create policy "Anon can read public settings"
+  on public.site_settings for select
+  using (is_public);
+
+create policy "Members can read settings"
+  on public.site_settings for select
+  using ((select public.is_member()));

--- a/supabase/tests/site_settings_rls.sql
+++ b/supabase/tests/site_settings_rls.sql
@@ -1,0 +1,54 @@
+-- Regression guard for the site_settings RLS policies added in
+-- 20260725000000_site_settings_is_public.sql (issue #215).
+--
+-- Plain-SQL smoke test — no pgTAP dependency, since the repo has no test
+-- runner installed. Run against the local Supabase stack:
+--
+--   docker exec -i supabase_db_small-group-hub \
+--     psql -U postgres -d postgres -f - < supabase/tests/site_settings_rls.sql
+--
+-- Fails loudly (raises an exception) if a future migration reopens the
+-- anon-read hole this PR closed, or exposes a non-public key.
+
+begin;
+
+do $$
+declare
+  anon_public_count bigint;
+  anon_private_count bigint;
+  member_private_count bigint;
+  admin_id uuid := 'a0000000-0000-0000-0000-000000000001';
+begin
+  -- anon (no JWT) can read only rows explicitly marked is_public
+  set local role anon;
+  reset request.jwt.claims;
+
+  select count(*) into anon_public_count
+    from public.site_settings where key = 'site_name';
+  if anon_public_count <> 1 then
+    raise exception 'anon should read site_name (is_public = true), got % rows', anon_public_count;
+  end if;
+
+  select count(*) into anon_private_count
+    from public.site_settings
+    where key in ('weekly_zoom_url', 'weekly_prayer_call_url', 'serving_link_mode', 'giving_manage_mode');
+  if anon_private_count <> 0 then
+    raise exception 'anon should NOT read private settings, got % rows', anon_private_count;
+  end if;
+
+  -- a logged-in member (seeded admin profile) can still read everything
+  set local role authenticated;
+  perform set_config('request.jwt.claims', json_build_object('sub', admin_id)::text, true);
+
+  select count(*) into member_private_count
+    from public.site_settings
+    where key in ('weekly_zoom_url', 'weekly_prayer_call_url', 'serving_link_mode', 'giving_manage_mode');
+  if member_private_count <> 4 then
+    raise exception 'member should read all private settings via is_member(), got % of 4 rows', member_private_count;
+  end if;
+
+  reset role;
+  raise notice 'site_settings RLS smoke test passed';
+end $$;
+
+rollback;


### PR DESCRIPTION
## Summary

`public.site_settings` had a single, blanket `using (true)` SELECT policy with no role or row scoping, so any unauthenticated caller could hit the Supabase REST endpoint with only the public anon key and read `weekly_zoom_url`, `weekly_prayer_call_url`, and the associated call/meeting times — no login required. This adds a per-row `is_public` flag and scopes anonymous read access to only rows explicitly marked public, while logged-in members keep full read access as before.

## Changes

- **`supabase/migrations/20260725000000_site_settings_is_public.sql`** (new)
  - Adds `is_public boolean not null default false` to `public.site_settings` (private by default).
  - Backfills `is_public = true` only for the `site_name` row — the one key the issue calls out as safe to expose publicly.
  - Drops the old blanket `"Anyone can read settings"` policy.
  - Adds `"Anon can read public settings"` (`using (is_public)`) and `"Members can read settings"` (`using ((select public.is_member()))`) as two named permissive SELECT policies, matching this codebase's existing one-policy-per-rule convention and the wrapped-subquery helper-call style used elsewhere in `20260712000000_rls_helper_perf.sql`.
- **`lib/types.ts`** — adds `is_public: boolean` to the hand-written `SiteSetting` interface to keep it in sync with the schema. This interface has no current importers, so it's a self-contained change.

No application code changes were needed: every reader of `site_settings` goes through the RLS-enforced client, and all call sites for the newly-restricted keys (`app/dashboard`, `app/prayer`, `app/give`, `lib/serving/config.ts`, `lib/giving/server.ts`) already null-coalesce or gracefully handle a missing/`null` row.

## Validation

- `supabase migration up --db-url postgresql://postgres:postgres@127.0.0.1:54322/postgres` — applied cleanly to local stack.
- Anon REST read of all rows (`apikey`/`Authorization: Bearer <anon-key>` only) returns exactly `[{"key":"site_name","value":"","is_public":true}]`.
- Anon REST read filtered to `key=eq.weekly_zoom_url` returns `[]`.
- Member-role check (`set role authenticated` + member JWT claims in `psql`) sees all 10 rows, confirming existing member/admin read access is unaffected.
- `npm run build` — passes, all routes (including RLS-backed pages) compile and generate successfully.
- `npm run lint` — fails, but with a pre-existing environment crash (`TypeError: expand is not a function` in `minimatch`, a dependency version-skew issue already broken on `main`) unrelated to this diff of one migration file + one interface field.
- In-app manual click-through as a logged-in member/admin was not performed in this automated run; RLS behavior was verified directly at the database/REST layer instead, and all app call sites were traced to confirm safe fallback behavior.

## Scope

Out of scope for this fix (tracked separately): an admin UI toggle for `is_public`, the `(org_id, key)` composite-key re-key mentioned in the issue as future work, and the other Part 9a security findings (ICS IDOR, ICS cache headers, `email_announcements` opt-out enforcement, non-expiring calendar tokens, pg_cron schedules not in migrations, no test infra).

Fixes #215


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility controls for site settings.
  * Public visitors can now access only settings explicitly marked as public, while authorized members retain access to all settings.

* **Bug Fixes**
  * Improved protection for private site configuration values through updated access controls.

* **Tests**
  * Added coverage to verify public and member access behavior for site settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->