### PR TITLE
Rebuild /admin as an actionable overview

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,14 +1,47 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import Link from "next/link";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Users, Calendar, Megaphone, BookOpen, Settings, Clock, FileText, Home, Info } from "lucide-react";
+import { Users, Calendar, Megaphone, Clock } from "lucide-react";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { siteConfig } from "@/lib/config";
+import { expandUpcomingEvents } from "@/lib/recurrence";
+import { displayName } from "@/lib/names";
+import type { AccessRequest, Event, Profile } from "@/lib/types";
 
 export const metadata = { title: `Admin | ${siteConfig.name}` };
+
+function timeAgo(iso: string): string {
+  const then = new Date(iso).getTime();
+  const minutes = Math.floor((Date.now() - then) / 60_000);
+  if (minutes < 1) return "Just now";
+  if (minutes < 60) return minutes === 1 ? "1 minute ago" : `${minutes} minutes ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return hours === 1 ? "1 hour ago" : `${hours} hours ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return "Yesterday";
+  if (days < 7) return `${days} days ago`;
+  const date = new Date(iso);
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function eventDateLabel(startTime: string): string {
+  const d = new Date(startTime);
+  const date = d.toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+  const time = d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+  return `${date} · ${time}`;
+}
+
+type RecentSignup = Pick<
+  Profile,
+  "id" | "first_name" | "last_name" | "preferred_name" | "role" | "created_at"
+>;
 
 export default async function AdminPage() {
   const supabase = await createClient();
@@ -26,84 +59,65 @@ export default async function AdminPage() {
 
   if (profile?.role !== "admin") redirect("/dashboard");
 
-  // Get stats
-  const { count: pendingRequests } = await supabase
-    .from("access_requests")
-    .select("*", { count: "exact", head: true })
-    .eq("status", "pending");
+  const nowDate = new Date();
+  const nowISO = nowDate.toISOString();
 
-  const { count: totalMembers } = await supabase
-    .from("profiles")
-    .select("*", { count: "exact", head: true })
-    .in("role", ["member", "content_editor", "admin"]);
+  // Stats + panel rows — all independent reads, fired together.
+  const [
+    { count: pendingRequests },
+    { count: totalMembers },
+    { count: upcomingEvents },
+    { count: publishedAnnouncements },
+    { data: pendingRows },
+    { data: signupRows },
+    { data: rawEvents },
+  ] = await Promise.all([
+    supabase
+      .from("access_requests")
+      .select("*", { count: "exact", head: true })
+      .eq("status", "pending"),
+    supabase
+      .from("profiles")
+      .select("*", { count: "exact", head: true })
+      .in("role", ["member", "content_editor", "admin"]),
+    supabase
+      .from("events")
+      .select("*", { count: "exact", head: true })
+      .gte("start_time", nowISO),
+    supabase
+      .from("announcements")
+      .select("*", { count: "exact", head: true })
+      .eq("is_published", true),
+    supabase
+      .from("access_requests")
+      .select("*")
+      .eq("status", "pending")
+      .order("created_at", { ascending: false })
+      .limit(5),
+    supabase
+      .from("profiles")
+      .select("id, first_name, last_name, preferred_name, role, created_at")
+      .order("created_at", { ascending: false })
+      .limit(5),
+    // Recurring series are stored as a single anchor row and expanded at
+    // render time, so also fetch still-active anchors with past start times.
+    supabase
+      .from("events")
+      .select("*")
+      .or(
+        `start_time.gte.${nowISO},` +
+        `and(recurrence_frequency.not.is.null,or(recurrence_until.is.null,recurrence_until.gte.${nowISO}))`
+      )
+      .order("start_time", { ascending: true })
+      .limit(50),
+  ]);
 
-  const { count: upcomingEvents } = await supabase
-    .from("events")
-    .select("*", { count: "exact", head: true })
-    .gte("start_time", new Date().toISOString());
+  const requests = (pendingRows ?? []) as AccessRequest[];
+  const signups = (signupRows ?? []) as RecentSignup[];
+  const nextEvents = expandUpcomingEvents((rawEvents ?? []) as Event[], nowDate).slice(0, 3);
 
-  const { count: publishedAnnouncements } = await supabase
-    .from("announcements")
-    .select("*", { count: "exact", head: true })
-    .eq("is_published", true);
-
-  const adminLinks = [
-    {
-      href: "/admin/members",
-      label: "Members",
-      description: "Manage members and access requests",
-      icon: Users,
-      badge: pendingRequests ? `${pendingRequests} pending` : undefined,
-    },
-    {
-      href: "/admin/families",
-      label: "Families",
-      description: "Group members into households",
-      icon: Home,
-    },
-    {
-      href: "/admin/events/new",
-      label: "Create Event",
-      description: "Add a new event",
-      icon: Calendar,
-    },
-    {
-      href: "/admin/calendars",
-      label: "Event Calendars",
-      description: "Create and manage shared calendars",
-      icon: Calendar,
-    },
-    {
-      href: "/admin/announcements/new",
-      label: "New Announcement",
-      description: "Post an announcement",
-      icon: Megaphone,
-    },
-    {
-      href: "/admin/lectures",
-      label: "Manage Lectures",
-      description: "Add, edit, or manage lecture recordings and series",
-      icon: BookOpen,
-    },
-    {
-      href: "/admin/pages",
-      label: "Pages",
-      description: "Edit content pages",
-      icon: FileText,
-    },
-    {
-      href: "/admin/about",
-      label: "About Page",
-      description: "Edit the class summary and teachers",
-      icon: Info,
-    },
-    {
-      href: "/admin/settings",
-      label: "Settings",
-      description: "Zoom links, giving, and other settings",
-      icon: Settings,
-    },
-  ];
+  const rowBorder = (i: number) =>
+    i > 0 ? { borderTop: "1px solid var(--color-border)" } : undefined;
 
   return (
     <PageContainer size="wide">
@@ -157,29 +171,123 @@ export default async function AdminPage() {
         </Card>
       </div>
 
-      {/* Quick actions */}
-      <h2 className="text-2xl font-bold text-brand-primary mb-4">Quick Actions</h2>
-      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {adminLinks.map((link) => (
-          <Link key={link.href} href={link.href}>
-            <Card className="hover:shadow-md transition-shadow cursor-pointer h-full">
-              <CardHeader className="pb-2">
-                <div className="flex items-center justify-between">
-                  <link.icon className="h-6 w-6 text-brand-primary" />
-                  {link.badge && (
-                    <Badge variant="destructive" className="text-sm">
-                      {link.badge}
-                    </Badge>
-                  )}
-                </div>
-                <CardTitle className="text-xl">{link.label}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-base text-muted-foreground">{link.description}</p>
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
+      <div className="grid gap-10 lg:grid-cols-3 lg:gap-6 items-start">
+        {/* Pending Requests */}
+        <div>
+          <div className="flex items-baseline justify-between mb-5">
+            <h2 className="font-serif text-[30px] font-medium text-foreground tracking-tight">
+              Pending Requests
+            </h2>
+            <Link
+              href="/admin/members"
+              className="font-sans text-base font-semibold text-brand-primary hover:underline"
+            >
+              View all →
+            </Link>
+          </div>
+          <Card>
+            <CardContent className="pt-6">
+              {requests.length > 0 ? (
+                requests.map((request, i) => (
+                  <div
+                    key={request.id}
+                    className="py-3 grid grid-cols-[1fr_auto] gap-4 items-baseline"
+                    style={rowBorder(i)}
+                  >
+                    <div className="min-w-0">
+                      <p className="text-base font-semibold text-foreground truncate">
+                        {request.name}
+                      </p>
+                      <p className="text-base text-muted-foreground truncate">{request.email}</p>
+                    </div>
+                    <p className="text-base text-muted-foreground whitespace-nowrap">
+                      {timeAgo(request.created_at)}
+                    </p>
+                  </div>
+                ))
+              ) : (
+                <p className="text-base text-muted-foreground py-3">No pending requests.</p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Recent Signups */}
+        <div>
+          <div className="flex items-baseline justify-between mb-5">
+            <h2 className="font-serif text-[30px] font-medium text-foreground tracking-tight">
+              Recent Signups
+            </h2>
+            <Link
+              href="/admin/members"
+              className="font-sans text-base font-semibold text-brand-primary hover:underline"
+            >
+              View all →
+            </Link>
+          </div>
+          <Card>
+            <CardContent className="pt-6">
+              {signups.length > 0 ? (
+                signups.map((signup, i) => (
+                  <div
+                    key={signup.id}
+                    className="py-3 grid grid-cols-[1fr_auto] gap-4 items-baseline"
+                    style={rowBorder(i)}
+                  >
+                    <div className="min-w-0 flex items-baseline gap-2">
+                      <p className="text-base font-semibold text-foreground truncate">
+                        {displayName(signup)}
+                      </p>
+                      {signup.role === "pending" && (
+                        <Badge variant="outline" className="text-sm shrink-0">
+                          Pending
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="text-base text-muted-foreground whitespace-nowrap">
+                      {timeAgo(signup.created_at)}
+                    </p>
+                  </div>
+                ))
+              ) : (
+                <p className="text-base text-muted-foreground py-3">No recent signups.</p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Upcoming Events */}
+        <div>
+          <div className="flex items-baseline justify-between mb-5">
+            <h2 className="font-serif text-[30px] font-medium text-foreground tracking-tight">
+              Upcoming Events
+            </h2>
+            <Link
+              href="/admin/calendars"
+              className="font-sans text-base font-semibold text-brand-primary hover:underline"
+            >
+              View all →
+            </Link>
+          </div>
+          <Card>
+            <CardContent className="pt-6">
+              {nextEvents.length > 0 ? (
+                nextEvents.map((event, i) => (
+                  <div key={`${event.id}-${event.start_time}`} className="py-3" style={rowBorder(i)}>
+                    <p className="text-base font-semibold text-foreground truncate">
+                      {event.title}
+                    </p>
+                    <p className="text-base text-muted-foreground">
+                      {eventDateLabel(event.start_time)}
+                    </p>
+                  </div>
+                ))
+              ) : (
+                <p className="text-base text-muted-foreground py-3">No upcoming events.</p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
       </div>
     </PageContainer>
   );

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -33,8 +33,13 @@ function eventDateLabel(startTime: string): string {
     weekday: "short",
     month: "short",
     day: "numeric",
+    timeZone: "America/New_York",
   });
-  const time = d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+  const time = d.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "America/New_York",
+  });
   return `${date} · ${time}`;
 }
 
@@ -68,9 +73,9 @@ export default async function AdminPage() {
     { count: totalMembers },
     { count: upcomingEvents },
     { count: publishedAnnouncements },
-    { data: pendingRows },
-    { data: signupRows },
-    { data: rawEvents },
+    { data: pendingRows, error: pendingError },
+    { data: signupRows, error: signupError },
+    { data: rawEvents, error: eventsError },
   ] = await Promise.all([
     supabase
       .from("access_requests")
@@ -111,6 +116,10 @@ export default async function AdminPage() {
       .order("start_time", { ascending: true })
       .limit(50),
   ]);
+
+  if (pendingError) console.error("admin overview: pending requests query failed", pendingError);
+  if (signupError) console.error("admin overview: recent signups query failed", signupError);
+  if (eventsError) console.error("admin overview: upcoming events query failed", eventsError);
 
   const requests = (pendingRows ?? []) as AccessRequest[];
   const signups = (signupRows ?? []) as RecentSignup[];
@@ -187,7 +196,9 @@ export default async function AdminPage() {
           </div>
           <Card>
             <CardContent className="pt-6">
-              {requests.length > 0 ? (
+              {pendingError ? (
+                <p className="text-base text-muted-foreground py-3">Couldn't load pending requests.</p>
+              ) : requests.length > 0 ? (
                 requests.map((request, i) => (
                   <div
                     key={request.id}
@@ -227,7 +238,9 @@ export default async function AdminPage() {
           </div>
           <Card>
             <CardContent className="pt-6">
-              {signups.length > 0 ? (
+              {signupError ? (
+                <p className="text-base text-muted-foreground py-3">Couldn't load recent signups.</p>
+              ) : signups.length > 0 ? (
                 signups.map((signup, i) => (
                   <div
                     key={signup.id}
@@ -271,7 +284,9 @@ export default async function AdminPage() {
           </div>
           <Card>
             <CardContent className="pt-6">
-              {nextEvents.length > 0 ? (
+              {eventsError ? (
+                <p className="text-base text-muted-foreground py-3">Couldn't load upcoming events.</p>
+              ) : nextEvents.length > 0 ? (
                 nextEvents.map((event, i) => (
                   <div key={`${event.id}-${event.start_time}`} className="py-3" style={rowBorder(i)}>
                     <p className="text-base font-semibold text-foreground truncate">

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -24,7 +24,11 @@ function timeAgo(iso: string): string {
   if (days === 1) return "Yesterday";
   if (days < 7) return `${days} days ago`;
   const date = new Date(iso);
-  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "America/New_York",
+  });
 }
 
 function eventDateLabel(startTime: string): string {
@@ -69,10 +73,10 @@ export default async function AdminPage() {
 
   // Stats + panel rows — all independent reads, fired together.
   const [
-    { count: pendingRequests },
-    { count: totalMembers },
-    { count: upcomingEvents },
-    { count: publishedAnnouncements },
+    { count: pendingRequests, error: pendingCountError },
+    { count: totalMembers, error: membersCountError },
+    { count: upcomingEvents, error: eventsCountError },
+    { count: publishedAnnouncements, error: announcementsCountError },
     { data: pendingRows, error: pendingError },
     { data: signupRows, error: signupError },
     { data: rawEvents, error: eventsError },
@@ -117,6 +121,10 @@ export default async function AdminPage() {
       .limit(50),
   ]);
 
+  if (pendingCountError) console.error("admin overview: pending requests count failed", pendingCountError);
+  if (membersCountError) console.error("admin overview: total members count failed", membersCountError);
+  if (eventsCountError) console.error("admin overview: upcoming events count failed", eventsCountError);
+  if (announcementsCountError) console.error("admin overview: announcements count failed", announcementsCountError);
   if (pendingError) console.error("admin overview: pending requests query failed", pendingError);
   if (signupError) console.error("admin overview: recent signups query failed", signupError);
   if (eventsError) console.error("admin overview: upcoming events query failed", eventsError);
@@ -129,10 +137,15 @@ export default async function AdminPage() {
     i > 0 ? { borderTop: "1px solid var(--color-border)" } : undefined;
 
   const stats = [
-    { label: "Pending Requests", value: pendingRequests, icon: Clock },
-    { label: "Total Members", value: totalMembers, icon: Users },
-    { label: "Upcoming Events", value: upcomingEvents, icon: Calendar },
-    { label: "Announcements", value: publishedAnnouncements, icon: Megaphone },
+    { label: "Pending Requests", value: pendingRequests, icon: Clock, error: pendingCountError },
+    { label: "Total Members", value: totalMembers, icon: Users, error: membersCountError },
+    { label: "Upcoming Events", value: upcomingEvents, icon: Calendar, error: eventsCountError },
+    {
+      label: "Announcements",
+      value: publishedAnnouncements,
+      icon: Megaphone,
+      error: announcementsCountError,
+    },
   ];
 
   return (
@@ -147,7 +160,9 @@ export default async function AdminPage() {
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-base text-muted-foreground">{stat.label}</p>
-                  <p className="text-3xl font-bold text-brand-primary">{stat.value || 0}</p>
+                  <p className="text-3xl font-bold text-brand-primary">
+                    {stat.error ? "—" : stat.value ?? 0}
+                  </p>
                 </div>
                 <stat.icon className="h-8 w-8 text-brand-primary" />
               </div>
@@ -173,7 +188,7 @@ export default async function AdminPage() {
           <Card>
             <CardContent className="pt-6">
               {pendingError ? (
-                <p className="text-base text-muted-foreground py-3">Couldn't load pending requests.</p>
+                <p className="text-base text-muted-foreground py-3">Couldn&apos;t load pending requests.</p>
               ) : requests.length > 0 ? (
                 requests.map((request, i) => (
                   <div
@@ -215,7 +230,7 @@ export default async function AdminPage() {
           <Card>
             <CardContent className="pt-6">
               {signupError ? (
-                <p className="text-base text-muted-foreground py-3">Couldn't load recent signups.</p>
+                <p className="text-base text-muted-foreground py-3">Couldn&apos;t load recent signups.</p>
               ) : signups.length > 0 ? (
                 signups.map((signup, i) => (
                   <div
@@ -261,7 +276,7 @@ export default async function AdminPage() {
           <Card>
             <CardContent className="pt-6">
               {eventsError ? (
-                <p className="text-base text-muted-foreground py-3">Couldn't load upcoming events.</p>
+                <p className="text-base text-muted-foreground py-3">Couldn&apos;t load upcoming events.</p>
               ) : nextEvents.length > 0 ? (
                 nextEvents.map((event, i) => (
                   <div key={`${event.id}-${event.start_time}`} className="py-3" style={rowBorder(i)}>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -128,56 +128,32 @@ export default async function AdminPage() {
   const rowBorder = (i: number) =>
     i > 0 ? { borderTop: "1px solid var(--color-border)" } : undefined;
 
+  const stats = [
+    { label: "Pending Requests", value: pendingRequests, icon: Clock },
+    { label: "Total Members", value: totalMembers, icon: Users },
+    { label: "Upcoming Events", value: upcomingEvents, icon: Calendar },
+    { label: "Announcements", value: publishedAnnouncements, icon: Megaphone },
+  ];
+
   return (
     <PageContainer size="wide">
       <PageHeader title="Admin Dashboard" />
 
       {/* Stats */}
       <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-10">
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-base text-muted-foreground">Pending Requests</p>
-                <p className="text-3xl font-bold text-brand-primary">{pendingRequests || 0}</p>
+        {stats.map((stat) => (
+          <Card key={stat.label}>
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-base text-muted-foreground">{stat.label}</p>
+                  <p className="text-3xl font-bold text-brand-primary">{stat.value || 0}</p>
+                </div>
+                <stat.icon className="h-8 w-8 text-brand-primary" />
               </div>
-              <Clock className="h-8 w-8 text-brand-primary" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-base text-muted-foreground">Total Members</p>
-                <p className="text-3xl font-bold text-brand-primary">{totalMembers || 0}</p>
-              </div>
-              <Users className="h-8 w-8 text-brand-primary" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-base text-muted-foreground">Upcoming Events</p>
-                <p className="text-3xl font-bold text-brand-primary">{upcomingEvents || 0}</p>
-              </div>
-              <Calendar className="h-8 w-8 text-brand-primary" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-base text-muted-foreground">Announcements</p>
-                <p className="text-3xl font-bold text-brand-primary">{publishedAnnouncements || 0}</p>
-              </div>
-              <Megaphone className="h-8 w-8 text-brand-primary" />
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+        ))}
       </div>
 
       <div className="grid gap-10 lg:grid-cols-3 lg:gap-6 items-start">

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -5,7 +5,6 @@ import { usePathname } from "next/navigation";
 import {
   LayoutDashboard,
   Calendar,
-  CalendarDays,
   ChevronDown,
   Megaphone,
   BookOpen,
@@ -13,17 +12,15 @@ import {
   Settings,
   Users,
   UserCircle,
-  Home,
-  MailPlus,
   HandHelping,
   HandCoins,
   HeartHandshake,
-  BarChart2,
   Info,
 } from "lucide-react";
 import { Fragment, useState, useEffect, type ComponentType } from "react";
 import type { PageContent, Profile } from "@/lib/types";
 import { createClient } from "@/lib/supabase/client";
+import { adminNav } from "@/lib/admin-nav";
 
 type PageLink = Pick<PageContent, "slug" | "title">;
 
@@ -53,19 +50,6 @@ const directorySubNav = [
   { href: "/directory/groups", label: "Groups" },
   { href: "/directory/birthdays", label: "Birthdays" },
   { href: "/directory/anniversaries", label: "Anniversaries" },
-];
-
-const adminNav = [
-  { href: "/admin", label: "Admin", icon: Settings, exact: true },
-  { href: "/admin/members", label: "Members", icon: Users },
-  { href: "/admin/families", label: "Families", icon: Home },
-  { href: "/admin/groups", label: "Groups", icon: Users },
-  { href: "/admin/invite", label: "Bulk Invite", icon: MailPlus },
-  { href: "/admin/calendars", label: "Calendars", icon: CalendarDays },
-  { href: "/admin/serving", label: "Serving Stats", icon: BarChart2 },
-  { href: "/admin/giving", label: "Giving", icon: HandCoins },
-  { href: "/admin/pages", label: "Manage Pages", icon: FileText },
-  { href: "/admin/about", label: "About Page", icon: Info },
 ];
 
 export function SidebarNav({

--- a/lib/admin-nav.ts
+++ b/lib/admin-nav.ts
@@ -1,0 +1,40 @@
+import type { ComponentType } from "react";
+import {
+  Settings,
+  Users,
+  Home,
+  MailPlus,
+  CalendarDays,
+  BarChart2,
+  HandCoins,
+  FileText,
+  Info,
+  BookOpen,
+} from "lucide-react";
+
+export interface AdminNavItem {
+  href: string;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  exact?: boolean;
+}
+
+/**
+ * Single source of truth for admin destinations. Consumed by the sidebar
+ * (client) and importable from server components — keep this file free of
+ * "use client" and hooks.
+ */
+export const adminNav: AdminNavItem[] = [
+  { href: "/admin", label: "Admin", icon: Settings, exact: true },
+  { href: "/admin/members", label: "Members", icon: Users },
+  { href: "/admin/families", label: "Families", icon: Home },
+  { href: "/admin/groups", label: "Groups", icon: Users },
+  { href: "/admin/invite", label: "Bulk Invite", icon: MailPlus },
+  { href: "/admin/calendars", label: "Calendars", icon: CalendarDays },
+  { href: "/admin/serving", label: "Serving Stats", icon: BarChart2 },
+  { href: "/admin/giving", label: "Giving", icon: HandCoins },
+  { href: "/admin/lectures", label: "Manage Lectures", icon: BookOpen },
+  { href: "/admin/pages", label: "Manage Pages", icon: FileText },
+  { href: "/admin/about", label: "About Page", icon: Info },
+  { href: "/admin/settings", label: "Settings", icon: Settings },
+];


### PR DESCRIPTION
## Summary

- Rebuilds `/admin` from a duplicate navigation launcher (Quick Actions grid) into an actionable overview: Pending Requests, Recent Signups, and Upcoming Events panels.
- Reconciles the two admin nav sources (dashboard grid + sidebar) into a single shared module (`lib/admin-nav.ts`), so admin nav items and labels no longer drift out of sync between the two surfaces.

## Changes

| File | Action | Notes |
|------|--------|-------|
| `lib/admin-nav.ts` | Create | Shared source of truth for the 12 admin nav items (incl. Manage Lectures + Settings) |
| `components/layout/SidebarNav.tsx` | Update | Sidebar now reads from the shared module instead of an inline `adminNav` list; removed now-unused icon imports (`CalendarDays`, `BarChart2`, `MailPlus`, `Home`) |
| `app/admin/page.tsx` | Update | Replaced the Quick Actions grid with Pending Requests / Recent Signups / Upcoming Events panels |

### Notable decisions

- **Upcoming Events count**: kept the existing head-count query for the stat tile as-is, and added a separate recurrence-aware row-level query for the panel, rather than feeding both from one `expandUpcomingEvents` call. This group's events are weekly recurring series, and `expandUpcomingEvents` with no `windowEnd` expands ~2 years out (up to 500 occurrences/series) — using it for the tile would have inflated the count from a small number to 100+. Keeps the tile consistent with the dashboard's existing count.
- **`HandCoins` icon import** was kept in `SidebarNav.tsx` (not removed with the other now-unused icons) because it's still used by `memberNav`'s `/give` entry.

## Validation

| Check | Result |
|-------|--------|
| Type check (`npx tsc --noEmit`) | ✅ Pass, no errors |
| Build (`npm run build`) | ✅ Pass — Turbopack build compiled in 10.4s, all 64 routes generated |
| Lint (`npx eslint .`) | ⚠️ Blocked repo-wide by a pre-existing `minimatch`/`brace-expansion` override crash (introduced in #255, present on `main` before this branch). Confirmed unrelated to this diff — manual import audit found no unused imports in either touched file. |
| Tests | N/A — repo has no test infrastructure |
| Manual browser verification | ⚠️ Deferred — this was a headless/autonomous run with no admin browser session available. **Please verify on the PR preview**: `/admin` shows 4 stat tiles + 3 panels (Pending Requests, Recent Signups, Upcoming Events), sidebar shows 12 admin items including Manage Lectures/Settings, a `content_editor` role still only sees Manage Pages/About Page, and empty states render correctly when there's no data. |

Fixes #237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the admin dashboard overview with improved summary statistics for requests, signups, and events.
  - Replaced quick actions with dedicated panels for Pending Requests, Recent Signups, and Upcoming Events.
  - Added clearer relative-time and date labels, along with badges and richer empty/error states.
  - Centralized admin navigation to keep admin destinations consistent across the UI.
- **Bug Fixes**
  - Improved dashboard loading performance by fetching overview data in parallel instead of sequentially.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->