### PR TITLE
Hash calendar subscription tokens and add sliding expiry

### DIFF
--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -29,12 +29,15 @@ export async function GET(request: Request) {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  // Sliding expiration: extend on every successful use so actively-polled
-  // subscriptions never expire, while abandoned/leaked links go stale.
-  await supabase
+  // Sliding expiration — see subscriptionTokenExpiryDate() for policy.
+  const { error: expiryError } = await supabase
     .from("calendar_subscription_tokens")
     .update({ expires_at: subscriptionTokenExpiryDate() })
     .eq("id", sub.id);
+
+  if (expiryError) {
+    console.error("Failed to extend calendar subscription expiry:", expiryError);
+  }
 
   // Validate calendarId if provided
   if (calendarId && !uuidRegex.test(calendarId)) {

--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -1,5 +1,9 @@
 import { createServiceClient } from "@/lib/supabase/server";
 import { generateCombinedICS, type ServingICSInput } from "@/lib/ics-utils";
+import {
+  hashSubscriptionToken,
+  subscriptionTokenExpiryDate,
+} from "@/lib/calendar/subscription-token";
 import type { Event } from "@/lib/types";
 
 export async function GET(request: Request) {
@@ -17,13 +21,20 @@ export async function GET(request: Request) {
 
   const { data: sub } = await supabase
     .from("calendar_subscription_tokens")
-    .select("id, user_id")
-    .eq("token", token)
+    .select("id, user_id, expires_at")
+    .eq("token_hash", hashSubscriptionToken(token))
     .single();
 
-  if (!sub) {
+  if (!sub || new Date(sub.expires_at) < new Date()) {
     return new Response("Unauthorized", { status: 401 });
   }
+
+  // Sliding expiration: extend on every successful use so actively-polled
+  // subscriptions never expire, while abandoned/leaked links go stale.
+  await supabase
+    .from("calendar_subscription_tokens")
+    .update({ expires_at: subscriptionTokenExpiryDate() })
+    .eq("id", sub.id);
 
   // Validate calendarId if provided
   if (calendarId && !uuidRegex.test(calendarId)) {

--- a/app/api/calendar/subscription-token/route.ts
+++ b/app/api/calendar/subscription-token/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import crypto from "crypto";
+import { createClient } from "@/lib/supabase/server";
+import {
+  hashSubscriptionToken,
+  subscriptionTokenExpiryDate,
+} from "@/lib/calendar/subscription-token";
+
+export async function POST() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  const isMember =
+    profile?.role === "member" ||
+    profile?.role === "content_editor" ||
+    profile?.role === "admin";
+
+  if (!isMember) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const token = crypto.randomUUID();
+
+  const { error } = await supabase
+    .from("calendar_subscription_tokens")
+    .upsert(
+      {
+        user_id: user.id,
+        token_hash: hashSubscriptionToken(token),
+        expires_at: subscriptionTokenExpiryDate(),
+      },
+      { onConflict: "user_id" }
+    );
+
+  if (error) {
+    console.error("Failed to create calendar subscription token:", error);
+    return NextResponse.json({ error: "Failed to create link" }, { status: 500 });
+  }
+
+  return NextResponse.json({ token });
+}

--- a/app/api/events/[id]/ics/route.ts
+++ b/app/api/events/[id]/ics/route.ts
@@ -32,12 +32,15 @@ export async function GET(
     return new Response("Unauthorized", { status: 401 });
   }
 
-  // Sliding expiration: extend on every successful use so actively-polled
-  // subscriptions never expire, while abandoned/leaked links go stale.
-  await supabase
+  // Sliding expiration — see subscriptionTokenExpiryDate() for policy.
+  const { error: expiryError } = await supabase
     .from("calendar_subscription_tokens")
     .update({ expires_at: subscriptionTokenExpiryDate() })
     .eq("id", sub.id);
+
+  if (expiryError) {
+    console.error("Failed to extend calendar subscription expiry:", expiryError);
+  }
 
   // The service client bypasses RLS, so re-check membership here:
   // events are only visible to member roles (see "Members can view all

--- a/app/api/events/[id]/ics/route.ts
+++ b/app/api/events/[id]/ics/route.ts
@@ -1,5 +1,9 @@
 import { createServiceClient } from "@/lib/supabase/server";
 import { generateSingleEventICS } from "@/lib/ics-utils";
+import {
+  hashSubscriptionToken,
+  subscriptionTokenExpiryDate,
+} from "@/lib/calendar/subscription-token";
 import type { Event } from "@/lib/types";
 
 export async function GET(
@@ -20,13 +24,20 @@ export async function GET(
 
   const { data: sub } = await supabase
     .from("calendar_subscription_tokens")
-    .select("id, user_id")
-    .eq("token", token)
+    .select("id, user_id, expires_at")
+    .eq("token_hash", hashSubscriptionToken(token))
     .single();
 
-  if (!sub) {
+  if (!sub || new Date(sub.expires_at) < new Date()) {
     return new Response("Unauthorized", { status: 401 });
   }
+
+  // Sliding expiration: extend on every successful use so actively-polled
+  // subscriptions never expire, while abandoned/leaked links go stale.
+  await supabase
+    .from("calendar_subscription_tokens")
+    .update({ expires_at: subscriptionTokenExpiryDate() })
+    .eq("id", sub.id);
 
   // The service client bypasses RLS, so re-check membership here:
   // events are only visible to member roles (see "Members can view all

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -102,17 +102,6 @@ export default async function EventDetailPage({
     profile?.role === "content_editor" ||
     isAdmin;
 
-  // Fetch the user's calendar subscription token
-  let subscriptionToken: string | null = null;
-  if (user && isMember) {
-    const { data: tokenRow } = await supabase
-      .from("calendar_subscription_tokens")
-      .select("token")
-      .eq("user_id", user.id)
-      .single();
-    subscriptionToken = tokenRow?.token ?? null;
-  }
-
   // Fetch current user's RSVP
   let userRsvp: Rsvp | null = null;
   if (user && isMember) {
@@ -413,10 +402,7 @@ export default async function EventDetailPage({
                       location={event.location}
                       description={event.description}
                     />
-                    <SubscribeToEventButton
-                      eventId={event.id}
-                      subscriptionToken={subscriptionToken}
-                    />
+                    {isMember && <SubscribeToEventButton eventId={event.id} />}
                   </div>
                 </div>
               </div>
@@ -457,10 +443,7 @@ export default async function EventDetailPage({
                   location={event.location}
                   description={event.description}
                 />
-                <SubscribeToEventButton
-                  eventId={event.id}
-                  subscriptionToken={subscriptionToken}
-                />
+                {isMember && <SubscribeToEventButton eventId={event.id} />}
               </div>
             )}
 

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -61,27 +61,6 @@ export default async function EventsPage() {
     console.error("Failed to fetch event calendars:", calendarsError);
   }
 
-  // Fetch or create the user's calendar subscription token
-  let subscriptionToken: string | null = null;
-  if (user && isMember) {
-    const { data: existingToken } = await supabase
-      .from("calendar_subscription_tokens")
-      .select("token")
-      .eq("user_id", user.id)
-      .single();
-
-    if (existingToken) {
-      subscriptionToken = existingToken.token;
-    } else {
-      const { data: newToken } = await supabase
-        .from("calendar_subscription_tokens")
-        .insert({ user_id: user.id })
-        .select("token")
-        .single();
-      subscriptionToken = newToken?.token ?? null;
-    }
-  }
-
   // Fetch user's RSVPs if logged in
   let userRsvps: Record<string, Rsvp> = {};
   if (user && isMember) {
@@ -108,7 +87,6 @@ export default async function EventsPage() {
         userId={user?.id ?? null}
         isMember={isMember}
         isAdmin={isAdmin}
-        subscriptionToken={subscriptionToken}
       />
     </PageContainer>
   );

--- a/components/events/EventsPageClient.tsx
+++ b/components/events/EventsPageClient.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { toast } from "sonner";
 import type { Event, EventCalendar, Rsvp } from "@/lib/types";
 
 type View = "calendar" | "list";
@@ -32,7 +33,6 @@ interface EventsPageClientProps {
   userId: string | null;
   isMember: boolean;
   isAdmin: boolean;
-  subscriptionToken: string | null;
 }
 
 export function EventsPageClient({
@@ -42,7 +42,6 @@ export function EventsPageClient({
   userId,
   isMember,
   isAdmin,
-  subscriptionToken,
 }: EventsPageClientProps) {
   const [view, setView] = useState<View>("calendar");
 
@@ -50,10 +49,31 @@ export function EventsPageClient({
   // where `window` is undefined. Resolve the host on the client after mount.
   const [host, setHost] = useState("");
   useEffect(() => setHost(window.location.host), []);
-  const feedBase =
-    host && subscriptionToken
-      ? `webcal://${host}/api/calendar/feed.ics?token=${subscriptionToken}`
-      : undefined;
+
+  // The token is hashed at rest and can't be re-read from the server, so it's
+  // minted lazily on first use and cached only for this page view. Every menu
+  // item reuses the same minted token; a fresh page load mints a new one.
+  const [mintedToken, setMintedToken] = useState<string | null>(null);
+  async function ensureToken(): Promise<string | null> {
+    if (mintedToken) return mintedToken;
+    const res = await fetch("/api/calendar/subscription-token", { method: "POST" });
+    if (!res.ok) {
+      toast.error("Couldn't create your calendar link. Please try again.");
+      return null;
+    }
+    const { token } = (await res.json()) as { token: string };
+    setMintedToken(token);
+    return token;
+  }
+
+  async function openCalendarFeed(calendarId?: string) {
+    const token = await ensureToken();
+    if (!token || !host) return;
+    const url = `webcal://${host}/api/calendar/feed.ics?token=${token}${
+      calendarId ? `&calendar=${calendarId}` : ""
+    }`;
+    window.location.href = url;
+  }
 
   // For the list view, expand recurring events from the ±1-year window and
   // filter to upcoming occurrences (so "never-ending" series show future dates).
@@ -100,7 +120,7 @@ export function EventsPageClient({
         title="Calendar"
         actions={
           <>
-            {subscriptionToken && (
+            {isMember && (
               <DropdownMenu>
                 <DropdownMenuTrigger render={
                   <Button
@@ -113,18 +133,18 @@ export function EventsPageClient({
                   </Button>
                 } />
                 <DropdownMenuContent align="end" className="w-56 rounded-2xl">
-                  <DropdownMenuItem render={<a href={feedBase} />}>
+                  <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+                    Getting a link below replaces any earlier one — older
+                    calendar links stop working.
+                  </DropdownMenuLabel>
+                  <DropdownMenuItem onClick={() => openCalendarFeed()}>
                     All Calendars
                   </DropdownMenuItem>
                   {calendars.map((cal) => (
                     <DropdownMenuItem
                       key={cal.id}
                       className="gap-2"
-                      render={
-                        <a
-                          href={feedBase ? `${feedBase}&calendar=${cal.id}` : undefined}
-                        />
-                      }
+                      onClick={() => openCalendarFeed(cal.id)}
                     >
                       <span
                         className="inline-block h-2 w-2 shrink-0 rounded-full"

--- a/components/events/EventsPageClient.tsx
+++ b/components/events/EventsPageClient.tsx
@@ -56,14 +56,19 @@ export function EventsPageClient({
   const [mintedToken, setMintedToken] = useState<string | null>(null);
   async function ensureToken(): Promise<string | null> {
     if (mintedToken) return mintedToken;
-    const res = await fetch("/api/calendar/subscription-token", { method: "POST" });
-    if (!res.ok) {
+    try {
+      const res = await fetch("/api/calendar/subscription-token", { method: "POST" });
+      if (!res.ok) {
+        toast.error("Couldn't create your calendar link. Please try again.");
+        return null;
+      }
+      const { token } = (await res.json()) as { token: string };
+      setMintedToken(token);
+      return token;
+    } catch {
       toast.error("Couldn't create your calendar link. Please try again.");
       return null;
     }
-    const { token } = (await res.json()) as { token: string };
-    setMintedToken(token);
-    return token;
   }
 
   async function openCalendarFeed(calendarId?: string) {

--- a/components/events/SubscribeToEventButton.tsx
+++ b/components/events/SubscribeToEventButton.tsx
@@ -21,7 +21,10 @@ export function SubscribeToEventButton({ eventId }: SubscribeToEventButtonProps)
         return;
       }
       const { token } = (await res.json()) as { token: string };
+      toast.info("This replaces any earlier calendar link — older links stop working.");
       window.location.href = `webcal://${window.location.host}/api/events/${eventId}/ics?token=${token}`;
+    } catch {
+      toast.error("Couldn't create your calendar link. Please try again.");
     } finally {
       setLoading(false);
     }

--- a/components/events/SubscribeToEventButton.tsx
+++ b/components/events/SubscribeToEventButton.tsx
@@ -1,27 +1,42 @@
 "use client";
 
+import { useState } from "react";
 import { Rss } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
 
 interface SubscribeToEventButtonProps {
   eventId: string;
-  subscriptionToken: string | null;
 }
 
-export function SubscribeToEventButton({ eventId, subscriptionToken }: SubscribeToEventButtonProps) {
-  if (!subscriptionToken) return null;
+export function SubscribeToEventButton({ eventId }: SubscribeToEventButtonProps) {
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/calendar/subscription-token", { method: "POST" });
+      if (!res.ok) {
+        toast.error("Couldn't create your calendar link. Please try again.");
+        return;
+      }
+      const { token } = (await res.json()) as { token: string };
+      window.location.href = `webcal://${window.location.host}/api/events/${eventId}/ics?token=${token}`;
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <Button
-      onClick={() => {
-        window.location.href = `webcal://${window.location.host}/api/events/${eventId}/ics?token=${subscriptionToken}`;
-      }}
+      onClick={handleClick}
+      disabled={loading}
       variant="outline"
       size="lg"
       className="h-10 gap-2 border-slate-200 bg-white px-6 text-base text-slate-600 shadow-sm hover:border-brand-primary/30 hover:bg-white hover:text-brand-primary"
     >
       <Rss className="h-4 w-4" />
-      Subscribe to Event
+      {loading ? "Preparing…" : "Subscribe to Event"}
     </Button>
   );
 }

--- a/lib/calendar/subscription-token.ts
+++ b/lib/calendar/subscription-token.ts
@@ -1,0 +1,18 @@
+import crypto from "crypto";
+
+/**
+ * Sliding TTL: extended on every successful ICS fetch, so actively-polled
+ * subscriptions never expire in practice, while abandoned or leaked links
+ * go stale after this many days of disuse.
+ */
+export const SUBSCRIPTION_TOKEN_TTL_DAYS = 400;
+
+export function hashSubscriptionToken(token: string): string {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+export function subscriptionTokenExpiryDate(): string {
+  return new Date(
+    Date.now() + SUBSCRIPTION_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000
+  ).toISOString();
+}

--- a/supabase/migrations/20260726000000_calendar_subscription_token_security.sql
+++ b/supabase/migrations/20260726000000_calendar_subscription_token_security.sql
@@ -1,0 +1,22 @@
+-- Calendar subscription tokens were stored in plaintext and never expired
+-- (issue #219). Move to a hashed-at-rest token with a sliding expiry, and
+-- add the RLS policy needed for users to rotate (regenerate) their own
+-- token. Existing plaintext tokens are treated as compromised — everyone
+-- gets a fresh hashed token the next time they open the calendar page.
+
+alter table public.calendar_subscription_tokens
+  add column token_hash text,
+  add column expires_at timestamptz;
+
+delete from public.calendar_subscription_tokens;
+
+alter table public.calendar_subscription_tokens
+  drop column token,
+  alter column token_hash set not null,
+  alter column expires_at set not null,
+  add constraint calendar_subscription_tokens_token_hash_key unique (token_hash);
+
+create policy "Members can update own subscription token"
+  on public.calendar_subscription_tokens for update
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);

--- a/supabase/migrations/20260726000000_calendar_subscription_token_security.sql
+++ b/supabase/migrations/20260726000000_calendar_subscription_token_security.sql
@@ -1,8 +1,9 @@
 -- Calendar subscription tokens were stored in plaintext and never expired
 -- (issue #219). Move to a hashed-at-rest token with a sliding expiry, and
 -- add the RLS policy needed for users to rotate (regenerate) their own
--- token. Existing plaintext tokens are treated as compromised — everyone
--- gets a fresh hashed token the next time they open the calendar page.
+-- token. Existing plaintext tokens are treated as compromised — everyone's
+-- row is cleared, and a fresh hashed token is minted lazily the next time
+-- they use "Subscribe to Calendar" or "Subscribe to Event".
 
 alter table public.calendar_subscription_tokens
   add column token_hash text,


### PR DESCRIPTION
## Summary

Calendar subscription tokens (used for the `.ics` feed URLs on the events page and per-event pages) were stored in plaintext in the database and never expired. A leaked or logged token — from browser history, a shared screenshot, a proxy log, etc. — granted indefinite read access to a member's calendar feed.

This PR:
- Hashes subscription tokens at rest instead of storing them in plaintext
- Adds a sliding expiry so tokens lapse if unused, and refreshes it on each successful fetch
- Wipes the existing plaintext token rows (they're regenerated on next use, so nothing is lost)
- Moves token minting server-side into a dedicated endpoint, mint-on-first-use/mint-on-click in the UI, instead of the client seeing the raw token from a page load

Fixes #219

## Changes

- `lib/calendar/subscription-token.ts` (new) — hashing/expiry helper module
- `supabase/migrations/20260726000000_calendar_subscription_token_security.sql` (new) — adds `token_hash` + `expires_at`, drops the plaintext token column, updates RLS policy, wipes existing rows
- `app/api/calendar/subscription-token/route.ts` (new) — member-gated POST endpoint to mint/rotate a token, RLS-scoped client
- `app/api/calendar/feed.ics/route.ts` — looks up by hash, checks expiry, slides expiry forward on valid fetch
- `app/api/events/[id]/ics/route.ts` — same hash/expiry treatment (owner-role re-check left untouched)
- `app/events/page.tsx` — removed server-side plaintext token fetch/insert and the prop that carried it to the client
- `app/events/[id]/page.tsx` — removed plaintext token fetch; subscribe button now gated on `isMember` only
- `components/events/EventsPageClient.tsx` — mint-on-first-use dropdown, caches the token client-side, warns that regenerating replaces the old link
- `components/events/SubscribeToEventButton.tsx` — mint-on-click with a loading state

## Validation

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` | ✅ No errors |
| `npm run lint` | ✅ No issues |
| `npm run build` | ✅ Compiled successfully, 64/64 routes generated |
| Tests | N/A — repo has no test framework configured |
| Local migration | ✅ Applied; schema + 3 RLS policies verified via `\d` |

Runtime verification against a local dev server (seeded/deleted synthetic token row):

| Scenario | Result |
|----------|--------|
| `GET feed.ics?token=<valid>` | ✅ 200, ICS body |
| `GET feed.ics?token=<wrong uuid>` | ✅ 401 |
| Sliding expiry (fetch ~1 day before expiry) | ✅ 200, `expires_at` slid forward |
| `GET feed.ics?token=<expired>` | ✅ 401 |
| `GET events/[id]/ics?token=<expired>` | ✅ 401 |
| `GET events/[id]/ics?token=<valid>` | ✅ 200, ICS body |
| `POST /api/calendar/subscription-token` unauthenticated | ✅ 401 |

## Notes for reviewers

- **Migration ordering**: open PR #273 (`archon/task-fix-issue-215`) adds migration `20260725000000_site_settings_is_public.sql`. This branch adds `20260726000000_...` against a different table with no semantic conflict, but has a later timestamp — PR #273 should merge first so remote migration timestamps stay in order.
- Existing plaintext subscription tokens are wiped by the migration; any calendar app currently subscribed to a feed URL will need to re-subscribe using a freshly minted link.
