### PR TITLE
fix: unify page-header and container shell across people surfaces

### DIFF
--- a/app/admin/families/page.tsx
+++ b/app/admin/families/page.tsx
@@ -38,6 +38,8 @@ import {
   formatPhoneAsYouType,
 } from "@/lib/sanitize";
 import { displayName } from "@/lib/names";
+import { PageContainer } from "@/components/layout/PageContainer";
+import { PageHeader } from "@/components/layout/PageHeader";
 
 const MONTHS = [
   { value: "1", label: "January" },
@@ -449,32 +451,28 @@ export default function FamiliesPage() {
 
   if (loading) {
     return (
-      <div className="container mx-auto px-4 py-12">
+      <PageContainer>
         <p className="text-xl text-muted-foreground">Loading...</p>
-      </div>
+      </PageContainer>
     );
   }
 
   return (
-    <div className="container mx-auto px-4 py-12 max-w-4xl">
-      <div className="flex items-center justify-between mb-8">
-        <div>
-          <h1 className="text-3xl md:text-4xl font-bold text-brand-primary">
-            Families
-          </h1>
-          <p className="text-base text-muted-foreground mt-1">
-            Group members into households with shared address and home phone.
-          </p>
-        </div>
-        <Button
-          size="lg"
-          onClick={openCreate}
-          className="bg-brand-primary hover:bg-brand-primary/90 text-white"
-        >
-          <Plus className="mr-2 h-5 w-5" />
-          New Family
-        </Button>
-      </div>
+    <PageContainer>
+      <PageHeader
+        title="Families"
+        subtitle="Group members into households with shared address and home phone."
+        actions={
+          <Button
+            size="lg"
+            onClick={openCreate}
+            className="bg-brand-primary hover:bg-brand-primary/90 text-white"
+          >
+            <Plus className="mr-2 h-5 w-5" />
+            New Family
+          </Button>
+        }
+      />
 
       {families.length === 0 ? (
         <Card>
@@ -992,6 +990,6 @@ export default function FamiliesPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContainer>
   );
 }

--- a/app/admin/groups/page.tsx
+++ b/app/admin/groups/page.tsx
@@ -32,6 +32,8 @@ import type { MemberGroup } from "@/lib/types";
 import { siteConfig } from "@/lib/config";
 import { GroupRosterDialog } from "./GroupRosterDialog";
 import { IconPicker } from "./IconPicker";
+import { PageContainer } from "@/components/layout/PageContainer";
+import { PageHeader } from "@/components/layout/PageHeader";
 
 interface GroupFormState {
   name: string;
@@ -224,33 +226,28 @@ export default function GroupsPage() {
 
   if (loading) {
     return (
-      <div className="container mx-auto px-4 py-12">
+      <PageContainer>
         <p className="text-xl text-muted-foreground">Loading...</p>
-      </div>
+      </PageContainer>
     );
   }
 
   return (
-    <div className="container mx-auto px-4 py-12 max-w-3xl">
-      <div className="flex items-center justify-between mb-8">
-        <div>
-          <h1 className="text-3xl md:text-4xl font-bold text-brand-primary">
-            Member Groups
-          </h1>
-          <p className="text-base text-muted-foreground mt-1">
-            Create and manage groups. Control which groups appear as filter
-            chips in the member directory.
-          </p>
-        </div>
-        <Button
-          size="lg"
-          onClick={openCreate}
-          className="bg-brand-primary hover:bg-brand-primary/90 text-white"
-        >
-          <Plus className="mr-2 h-5 w-5" />
-          New Group
-        </Button>
-      </div>
+    <PageContainer>
+      <PageHeader
+        title="Member Groups"
+        subtitle="Create and manage groups. Control which groups appear as filter chips in the member directory."
+        actions={
+          <Button
+            size="lg"
+            onClick={openCreate}
+            className="bg-brand-primary hover:bg-brand-primary/90 text-white"
+          >
+            <Plus className="mr-2 h-5 w-5" />
+            New Group
+          </Button>
+        }
+      />
 
       {groups.length === 0 ? (
         <Card>
@@ -504,6 +501,6 @@ export default function GroupsPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContainer>
   );
 }

--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -18,6 +18,8 @@ import { toast } from "sonner";
 import { Check, X, UserCog, Clock, Pencil } from "lucide-react";
 import type { AccessRequest, Profile, UserRole } from "@/lib/types";
 import { displayName } from "@/lib/names";
+import { PageContainer } from "@/components/layout/PageContainer";
+import { PageHeader } from "@/components/layout/PageHeader";
 
 const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
   { value: "pending", label: "Pending" },
@@ -117,17 +119,15 @@ export default function MembersPage() {
 
   if (loading) {
     return (
-      <div className="container mx-auto px-4 py-12">
+      <PageContainer>
         <p className="text-xl text-muted-foreground">Loading...</p>
-      </div>
+      </PageContainer>
     );
   }
 
   return (
-    <div className="container mx-auto px-4 py-12">
-      <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-10">
-        Manage Members
-      </h1>
+    <PageContainer>
+      <PageHeader title="Manage Members" />
 
       <Tabs defaultValue="requests">
         <TabsList className="mb-6">
@@ -273,6 +273,6 @@ export default function MembersPage() {
           </div>
         </TabsContent>
       </Tabs>
-    </div>
+    </PageContainer>
   );
 }

--- a/app/directory/page.tsx
+++ b/app/directory/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { Cake, ChevronRight, Heart, House, Users } from "lucide-react";
 import type { ComponentType } from "react";
+import { PageContainer } from "@/components/layout/PageContainer";
+import { PageHeader } from "@/components/layout/PageHeader";
 
 export const metadata = {
   title: "Directory",
@@ -19,10 +21,8 @@ const tiles: {
 
 export default function DirectoryPage() {
   return (
-    <div className="container mx-auto px-4 py-12 max-w-4xl">
-      <h1 className="font-serif text-4xl md:text-5xl font-medium tracking-tight text-foreground mb-8">
-        Directory
-      </h1>
+    <PageContainer>
+      <PageHeader title="Directory" />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
         {tiles.map((tile) => (
@@ -42,6 +42,6 @@ export default function DirectoryPage() {
           </Link>
         ))}
       </div>
-    </div>
+    </PageContainer>
   );
 }


### PR DESCRIPTION
## Summary

`/directory`, `/admin/members`, `/admin/families`, and `/admin/groups` each rendered people/household data with a different header treatment and container width:

- `/directory` — serif H1, `max-w-4xl`
- `/admin/members` — bold sans brand-blue H1, no max-width (full-bleed)
- `/admin/families` — bold sans brand-blue H1, `max-w-4xl`
- `/admin/groups` — bold sans brand-blue H1, `max-w-3xl`

This PR adopts the shared `PageContainer` + `PageHeader` shell (introduced in #232 / PR #253, already merged to `main`) on all four, so they render the same serif H1 typography and the same `max-w-4xl` container width.

## Changes

- `app/directory/page.tsx` — swapped raw `<div>` + `<h1>` for `PageContainer` + `PageHeader title="Directory"`. No visual change (this page already matched the target style).
- `app/admin/members/page.tsx` — swapped full-bleed container + bold-sans H1 (loading and loaded states) for `PageContainer` + `PageHeader title="Manage Members"`. Container is now `max-w-4xl` instead of full-bleed — intentional, per the issue's named inconsistency.
- `app/admin/families/page.tsx` — swapped bold-sans H1 + inline header row for `PageHeader` with `subtitle` (existing copy preserved verbatim) and the "New Family" button moved into the `actions` slot.
- `app/admin/groups/page.tsx` — same pattern as families; "New Group" button moved into `actions`. Container widens from `max-w-3xl` to `max-w-4xl` — intentional, for parity with the other three pages.

## Scope decision: admin component reuse

The issue's fix direction says admin should "ideally" reuse the directory's read-only sheet/detail components (`FamilyCard`, `PersonCard`, `GroupCard`), with unifying the header/container as the "at minimum" bar. This PR targets the "at minimum" bar deliberately:

- Directory's display components are read-only, built against member-scoped (RLS/privacy-filtered) data shapes.
- The admin pages are write-heavy — inline edit dialogs, role changes, family-member sub-forms, group roster assignment, photo upload — none of which the directory's components support today.
- Building an adapter layer (or rewriting admin's editing flow into an in-panel sheet like the directory's) is a materially larger, higher-risk change than a header/container unification, with real regression risk to admin editing flows. That's a good candidate for its own follow-up issue rather than bundling it here.

No schema or migration changes — this is `page.tsx` JSX restructuring only.

## Validation

- `npx tsc --noEmit` — pass, no errors
- `npm run build` — pass, all 64 routes generated
- `npm run lint` — blocked by a pre-existing, unrelated repo-wide issue: `brace-expansion@5.x`'s API change breaks `minimatch@3.1.5` (pulled in transitively by eslint plugins), causing ESLint to crash before evaluating any file. Confirmed identical on `main` (`git diff main -- package.json package-lock.json` is empty) and reproduces on a clean `npm ci` — not a regression from this change. Manual review of the diff confirms no unused imports and correct `PageContainer`/`PageHeader` prop usage.
- Manual browser verification (loading each route, exercising New Family/New Group dialogs, role changes, approve/deny) was not performed in this session (no browser access) — recommended as a follow-up check before merge.

Fixes #239


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized the Families, Groups, Members, and Directory pages with consistent shared layouts and headers.
  * Improved visual consistency for page titles, subtitles, actions, and loading states.
  * Preserved existing page functionality and content while updating the presentation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->