### PR TITLE
feat: single admin entry point with dedicated /admin area

### DIFF
--- a/app/admin/PendingRequestsList.tsx
+++ b/app/admin/PendingRequestsList.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { toast } from "sonner";
+import { Check, X } from "lucide-react";
+
+export interface PendingRequest {
+  id: string;
+  name: string;
+  email: string;
+  created_at: string;
+}
+
+interface PendingRequestsListProps {
+  initialRequests: PendingRequest[];
+}
+
+export function PendingRequestsList({ initialRequests }: PendingRequestsListProps) {
+  const [requests, setRequests] = useState(initialRequests);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const supabase = useMemo(() => createClient(), []);
+
+  async function handleRequest(id: string, action: "approved" | "denied") {
+    setBusyId(id);
+    try {
+      if (action === "approved") {
+        const request = requests.find((r) => r.id === id);
+        if (request) {
+          const res = await fetch("/api/admin/approve", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email: request.email, name: request.name }),
+          });
+          if (!res.ok) {
+            toast.error("Failed to approve request.");
+            return;
+          }
+        }
+      } else {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) {
+          toast.error("Session expired. Please log in again.");
+          return;
+        }
+        const { error } = await supabase
+          .from("access_requests")
+          .update({
+            status: action,
+            reviewed_by: user.id,
+            reviewed_at: new Date().toISOString(),
+          })
+          .eq("id", id);
+
+        if (error) {
+          toast.error("Failed to update request.");
+          return;
+        }
+      }
+
+      toast.success(`Request ${action}.`);
+      setRequests((prev) => prev.filter((r) => r.id !== id));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  if (requests.length === 0) {
+    return <p className="text-lg text-muted-foreground">All caught up.</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {requests.map((req) => (
+        <Card key={req.id}>
+          <CardContent className="pt-6">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+              <div>
+                <p className="text-xl font-semibold">{req.name}</p>
+                <p className="text-base text-muted-foreground">{req.email}</p>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Requested access {new Date(req.created_at).toLocaleDateString()}
+                </p>
+              </div>
+              <div className="flex gap-2 shrink-0">
+                <Button
+                  size="lg"
+                  className="bg-brand-primary hover:bg-brand-primary/90 text-lg"
+                  disabled={busyId === req.id}
+                  onClick={() => handleRequest(req.id, "approved")}
+                >
+                  <Check className="mr-1 h-5 w-5" />
+                  Approve
+                </Button>
+                <Button
+                  size="lg"
+                  variant="destructive"
+                  className="text-lg"
+                  disabled={busyId === req.id}
+                  onClick={() => handleRequest(req.id, "denied")}
+                >
+                  <X className="mr-1 h-5 w-5" />
+                  Deny
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/app/admin/PendingRequestsList.tsx
+++ b/app/admin/PendingRequestsList.tsx
@@ -27,6 +27,9 @@ export function PendingRequestsList({ initialRequests }: PendingRequestsListProp
     setBusyId(id);
     try {
       if (action === "approved") {
+        // Approving needs elevated privileges (revalidates admin role server-side,
+        // sends the invite email) that a client Supabase call can't do — route
+        // through the API instead of updating access_requests directly.
         const request = requests.find((r) => r.id === id);
         if (request) {
           const res = await fetch("/api/admin/approve", {
@@ -35,7 +38,8 @@ export function PendingRequestsList({ initialRequests }: PendingRequestsListProp
             body: JSON.stringify({ email: request.email, name: request.name }),
           });
           if (!res.ok) {
-            toast.error("Failed to approve request.");
+            const data = await res.json().catch(() => null);
+            toast.error(data?.error || "Failed to approve request.");
             return;
           }
         }
@@ -57,6 +61,7 @@ export function PendingRequestsList({ initialRequests }: PendingRequestsListProp
           .eq("id", id);
 
         if (error) {
+          console.error(error);
           toast.error("Failed to update request.");
           return;
         }
@@ -64,6 +69,9 @@ export function PendingRequestsList({ initialRequests }: PendingRequestsListProp
 
       toast.success(`Request ${action}.`);
       setRequests((prev) => prev.filter((r) => r.id !== id));
+    } catch (err) {
+      console.error(err);
+      toast.error("Network error. Please try again.");
     } finally {
       setBusyId(null);
     }

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,33 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { AdminSidebarNav } from "@/components/layout/AdminSidebarNav";
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile || !["admin", "content_editor"].includes(profile.role)) {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col md:flex-row">
+      <AdminSidebarNav role={profile.role} />
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,12 +1,11 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import Link from "next/link";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Users, Calendar, Megaphone, BookOpen, Settings, Clock, FileText, Home, Info } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { siteConfig } from "@/lib/config";
+import { PendingRequestsList } from "./PendingRequestsList";
 
 export const metadata = { title: `Admin | ${siteConfig.name}` };
 
@@ -24,163 +23,64 @@ export default async function AdminPage() {
     .eq("id", user.id)
     .single();
 
-  if (profile?.role !== "admin") redirect("/dashboard");
+  if (!profile || !["admin", "content_editor"].includes(profile.role)) {
+    redirect("/dashboard");
+  }
+  const isAdminRole = profile.role === "admin";
 
-  // Get stats
-  const { count: pendingRequests } = await supabase
-    .from("access_requests")
-    .select("*", { count: "exact", head: true })
-    .eq("status", "pending");
+  // access_requests SELECT is admin-only under RLS; skip the query entirely
+  // for content_editor rather than reading a guaranteed-empty result.
+  const pendingRequests = isAdminRole
+    ? ((
+        await supabase
+          .from("access_requests")
+          .select("id, name, email, created_at")
+          .eq("status", "pending")
+          .order("created_at", { ascending: true })
+      ).data ?? [])
+    : [];
 
-  const { count: totalMembers } = await supabase
-    .from("profiles")
-    .select("*", { count: "exact", head: true })
-    .in("role", ["member", "content_editor", "admin"]);
-
-  const { count: upcomingEvents } = await supabase
-    .from("events")
-    .select("*", { count: "exact", head: true })
-    .gte("start_time", new Date().toISOString());
-
-  const { count: publishedAnnouncements } = await supabase
-    .from("announcements")
-    .select("*", { count: "exact", head: true })
-    .eq("is_published", true);
-
-  const adminLinks = [
-    {
-      href: "/admin/members",
-      label: "Members",
-      description: "Manage members and access requests",
-      icon: Users,
-      badge: pendingRequests ? `${pendingRequests} pending` : undefined,
-    },
-    {
-      href: "/admin/families",
-      label: "Families",
-      description: "Group members into households",
-      icon: Home,
-    },
-    {
-      href: "/admin/events/new",
-      label: "Create Event",
-      description: "Add a new event",
-      icon: Calendar,
-    },
-    {
-      href: "/admin/calendars",
-      label: "Event Calendars",
-      description: "Create and manage shared calendars",
-      icon: Calendar,
-    },
-    {
-      href: "/admin/announcements/new",
-      label: "New Announcement",
-      description: "Post an announcement",
-      icon: Megaphone,
-    },
-    {
-      href: "/admin/lectures",
-      label: "Manage Lectures",
-      description: "Add, edit, or manage lecture recordings and series",
-      icon: BookOpen,
-    },
-    {
-      href: "/admin/pages",
-      label: "Pages",
-      description: "Edit content pages",
-      icon: FileText,
-    },
-    {
-      href: "/admin/about",
-      label: "About Page",
-      description: "Edit the class summary and teachers",
-      icon: Info,
-    },
-    {
-      href: "/admin/settings",
-      label: "Settings",
-      description: "Zoom links, giving, and other settings",
-      icon: Settings,
-    },
-  ];
+  const quickActions = isAdminRole
+    ? [
+        { href: "/admin/invite", label: "Invite member" },
+        { href: "/admin/events/new", label: "Create event" },
+        { href: "/admin/announcements/new", label: "Post announcement" },
+      ]
+    : [
+        { href: "/admin/pages", label: "Edit pages" },
+        { href: "/admin/about", label: "Edit about page" },
+      ];
 
   return (
     <PageContainer size="wide">
-      <PageHeader title="Admin Dashboard" />
+      <PageHeader title="Admin" />
 
-      {/* Stats */}
-      <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-10">
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-base text-muted-foreground">Pending Requests</p>
-                <p className="text-3xl font-bold text-brand-primary">{pendingRequests || 0}</p>
-              </div>
-              <Clock className="h-8 w-8 text-brand-primary" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-base text-muted-foreground">Total Members</p>
-                <p className="text-3xl font-bold text-brand-primary">{totalMembers || 0}</p>
-              </div>
-              <Users className="h-8 w-8 text-brand-primary" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-base text-muted-foreground">Upcoming Events</p>
-                <p className="text-3xl font-bold text-brand-primary">{upcomingEvents || 0}</p>
-              </div>
-              <Calendar className="h-8 w-8 text-brand-primary" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-base text-muted-foreground">Announcements</p>
-                <p className="text-3xl font-bold text-brand-primary">{publishedAnnouncements || 0}</p>
-              </div>
-              <Megaphone className="h-8 w-8 text-brand-primary" />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <section className="mb-10">
+        <h2 className="text-2xl font-bold text-brand-primary mb-4">
+          Needs attention
+        </h2>
+        <PendingRequestsList initialRequests={pendingRequests} />
+      </section>
 
-      {/* Quick actions */}
-      <h2 className="text-2xl font-bold text-brand-primary mb-4">Quick Actions</h2>
-      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {adminLinks.map((link) => (
-          <Link key={link.href} href={link.href}>
-            <Card className="hover:shadow-md transition-shadow cursor-pointer h-full">
-              <CardHeader className="pb-2">
-                <div className="flex items-center justify-between">
-                  <link.icon className="h-6 w-6 text-brand-primary" />
-                  {link.badge && (
-                    <Badge variant="destructive" className="text-sm">
-                      {link.badge}
-                    </Badge>
-                  )}
-                </div>
-                <CardTitle className="text-xl">{link.label}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-base text-muted-foreground">{link.description}</p>
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
-      </div>
+      <section>
+        <h2 className="text-2xl font-bold text-brand-primary mb-4">
+          Quick actions
+        </h2>
+        <div className="flex flex-wrap gap-3">
+          {quickActions.map((action) => (
+            <Button
+              key={action.href}
+              size="lg"
+              variant="outline"
+              className="text-lg"
+              nativeButton={false}
+              render={<Link href={action.href} />}
+            >
+              {action.label}
+            </Button>
+          ))}
+        </div>
+      </section>
     </PageContainer>
   );
 }

--- a/components/layout/AdminSidebarNav.tsx
+++ b/components/layout/AdminSidebarNav.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Fragment, type ComponentType } from "react";
+import { ArrowLeft, LayoutDashboard } from "lucide-react";
+import { adminNavGroups } from "@/lib/admin-nav";
+import type { UserRole } from "@/lib/types";
+
+interface AdminSidebarNavProps {
+  role: UserRole;
+}
+
+const overviewItem = { href: "/admin", label: "Overview", icon: LayoutDashboard, exact: true };
+
+export function AdminSidebarNav({ role }: AdminSidebarNavProps) {
+  const pathname = usePathname();
+  const isAdmin = role === "admin";
+
+  const groups = adminNavGroups
+    .map((group) => ({
+      ...group,
+      items: isAdmin ? group.items : group.items.filter((item) => item.contentEditorVisible),
+    }))
+    .filter((group) => group.items.length > 0);
+
+  const isActive = (href: string, exact = false) =>
+    exact ? pathname === href : pathname === href || pathname.startsWith(href + "/");
+
+  // Soft-blue active state with a primary left bar, per the design system
+  const linkClass = (active: boolean) =>
+    `flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm border-l-4 transition-colors ${
+      active
+        ? "bg-brand-warm text-brand-primary font-bold border-brand-primary"
+        : "border-transparent font-medium text-slate-600 hover:text-brand-primary hover:bg-brand-warm/50"
+    }`;
+
+  const renderLink = (
+    item: { href: string; label: string; icon: ComponentType<{ className?: string }>; exact?: boolean },
+  ) => {
+    const active = isActive(item.href, item.exact);
+    return (
+      <Link
+        key={item.href}
+        href={item.href}
+        className={linkClass(active)}
+        aria-current={active ? "page" : undefined}
+      >
+        <item.icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+        <span>{item.label}</span>
+      </Link>
+    );
+  };
+
+  const backLink = (
+    <Link
+      href="/dashboard"
+      className="inline-flex min-h-11 items-center gap-2 px-3 text-base font-semibold text-brand-primary underline underline-offset-4 hover:text-brand-primary/80"
+    >
+      <ArrowLeft className="h-5 w-5" aria-hidden="true" />
+      Back to app
+    </Link>
+  );
+
+  return (
+    <>
+      {/* Desktop: persistent grouped sidebar */}
+      <nav
+        aria-label="Admin navigation"
+        className="hidden w-60 shrink-0 flex-col space-y-1 overflow-y-auto border-r border-border bg-white px-2 py-4 md:flex"
+      >
+        {backLink}
+        <div className="border-t border-border my-2" role="separator" />
+        {renderLink(overviewItem)}
+        {groups.map((group) => (
+          <Fragment key={group.key}>
+            <p className="px-3 pt-4 pb-1 text-xs font-semibold uppercase text-slate-400 tracking-wider">
+              {group.label}
+            </p>
+            {group.items.map(renderLink)}
+          </Fragment>
+        ))}
+      </nav>
+
+      {/* Mobile: horizontally scrollable bar of the same destinations */}
+      <nav
+        aria-label="Admin navigation"
+        className="flex items-center gap-2 overflow-x-auto border-b border-border bg-white px-4 py-2 md:hidden"
+      >
+        <Link
+          href="/dashboard"
+          className="inline-flex min-h-11 shrink-0 items-center gap-2 pr-1 text-base font-semibold text-brand-primary underline underline-offset-4"
+        >
+          <ArrowLeft className="h-5 w-5" aria-hidden="true" />
+          Back
+        </Link>
+        {[overviewItem, ...groups.flatMap((group) => group.items)].map((item) => {
+          const active = isActive(item.href, "exact" in item ? item.exact : undefined);
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              aria-current={active ? "page" : undefined}
+              className={`inline-flex min-h-11 shrink-0 items-center whitespace-nowrap rounded-full border px-4 text-sm transition-colors ${
+                active
+                  ? "border-brand-primary bg-brand-warm font-bold text-brand-primary"
+                  : "border-border font-medium text-slate-600 hover:text-brand-primary"
+              }`}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </>
+  );
+}

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -16,7 +16,6 @@ export const SIDEBAR_ROUTES = [
   "/announcements",
   "/lectures",
   "/pages",
-  "/admin",
   "/directory",
   "/serving",
   "/prayer",
@@ -32,7 +31,12 @@ export function AppShell({ profile, hasServingAccess, children }: AppShellProps)
     isMember && SIDEBAR_ROUTES.some((r) => pathname.startsWith(r));
 
   if (!showSidebar) {
-    return <main className="flex-1">{children}</main>;
+    // /admin/* supplies its own nav via app/admin/layout.tsx; a flex main
+    // lets that layout's sidebar stretch to full height.
+    const isAdminArea = pathname.startsWith("/admin");
+    return (
+      <main className={isAdminArea ? "flex flex-1" : "flex-1"}>{children}</main>
+    );
   }
 
   return (

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -120,7 +120,7 @@ export function Header({ profile, hasServingAccess }: HeaderProps) {
                   </div>
                   <nav
                     aria-label="Main navigation"
-                    className="flex-1 space-y-1"
+                    className="flex min-h-0 flex-1 flex-col space-y-1"
                   >
                     <SidebarNav
                       profile={profile}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -20,7 +20,7 @@ export function Sidebar({ profile, hasServingAccess }: SidebarProps) {
     >
       <nav
         aria-label="Main navigation"
-        className="flex-1 overflow-y-auto py-4 px-2 space-y-1"
+        className="flex flex-1 flex-col overflow-hidden py-4 px-2"
       >
         <SidebarNav
           profile={profile}

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -5,20 +5,17 @@ import { usePathname } from "next/navigation";
 import {
   LayoutDashboard,
   Calendar,
-  CalendarDays,
   ChevronDown,
+  Cog,
   Megaphone,
   BookOpen,
   FileText,
   Settings,
   Users,
   UserCircle,
-  Home,
-  MailPlus,
   HandHelping,
   HandCoins,
   HeartHandshake,
-  BarChart2,
   Info,
 } from "lucide-react";
 import { Fragment, useState, useEffect, type ComponentType } from "react";
@@ -53,19 +50,6 @@ const directorySubNav = [
   { href: "/directory/groups", label: "Groups" },
   { href: "/directory/birthdays", label: "Birthdays" },
   { href: "/directory/anniversaries", label: "Anniversaries" },
-];
-
-const adminNav = [
-  { href: "/admin", label: "Admin", icon: Settings, exact: true },
-  { href: "/admin/members", label: "Members", icon: Users },
-  { href: "/admin/families", label: "Families", icon: Home },
-  { href: "/admin/groups", label: "Groups", icon: Users },
-  { href: "/admin/invite", label: "Bulk Invite", icon: MailPlus },
-  { href: "/admin/calendars", label: "Calendars", icon: CalendarDays },
-  { href: "/admin/serving", label: "Serving Stats", icon: BarChart2 },
-  { href: "/admin/giving", label: "Giving", icon: HandCoins },
-  { href: "/admin/pages", label: "Manage Pages", icon: FileText },
-  { href: "/admin/about", label: "About Page", icon: Info },
 ];
 
 export function SidebarNav({
@@ -197,60 +181,49 @@ export function SidebarNav({
 
   return (
     <>
-      {memberNav
-        .filter((item) => item.href !== "/serving" || hasServingAccess)
-        .map((item) => (
-          <Fragment key={item.href}>
-            {item.href === "/directory" && !collapsed ? renderDirectoryItem() : renderLink(item)}
-            {item.href === "/directory" && renderDirectorySubNav()}
-          </Fragment>
-        ))}
+      <div className="min-h-0 flex-1 space-y-1 overflow-y-auto">
+        {memberNav
+          .filter((item) => item.href !== "/serving" || hasServingAccess)
+          .map((item) => (
+            <Fragment key={item.href}>
+              {item.href === "/directory" && !collapsed ? renderDirectoryItem() : renderLink(item)}
+              {item.href === "/directory" && renderDirectorySubNav()}
+            </Fragment>
+          ))}
 
-      {pages.length > 0 && (
-        <>
-          {!collapsed && (
-            <p className="px-3 pt-4 pb-1 text-xs font-semibold uppercase text-slate-400 tracking-wider">
-              Pages
-            </p>
-          )}
-          {collapsed && <div className="border-t border-border my-2" role="separator" />}
-          {pages.map((page) => {
-            const href = `/pages/${page.slug}`;
-            const active = isActive(href);
-            return (
-              <Link
-                key={page.slug}
-                href={href}
-                className={linkClass(active)}
-                aria-current={active ? "page" : undefined}
-                title={collapsed ? page.title : undefined}
-                onClick={onNavigate}
-              >
-                <FileText className="h-5 w-5 shrink-0" aria-hidden="true" />
-                {!collapsed && <span className="truncate">{page.title}</span>}
-              </Link>
-            );
-          })}
-        </>
-      )}
+        {pages.length > 0 && (
+          <>
+            {!collapsed && (
+              <p className="px-3 pt-4 pb-1 text-xs font-semibold uppercase text-slate-400 tracking-wider">
+                Pages
+              </p>
+            )}
+            {collapsed && <div className="border-t border-border my-2" role="separator" />}
+            {pages.map((page) => {
+              const href = `/pages/${page.slug}`;
+              const active = isActive(href);
+              return (
+                <Link
+                  key={page.slug}
+                  href={href}
+                  className={linkClass(active)}
+                  aria-current={active ? "page" : undefined}
+                  title={collapsed ? page.title : undefined}
+                  onClick={onNavigate}
+                >
+                  <FileText className="h-5 w-5 shrink-0" aria-hidden="true" />
+                  {!collapsed && <span className="truncate">{page.title}</span>}
+                </Link>
+              );
+            })}
+          </>
+        )}
+      </div>
 
       {isEditor && (
-        <>
-          {!collapsed && (
-            <p className="px-3 pt-4 pb-1 text-xs font-semibold uppercase text-slate-400 tracking-wider">
-              Admin
-            </p>
-          )}
-          {collapsed && <div className="border-t border-border my-2" role="separator" />}
-          {adminNav
-            .filter(
-              (item) =>
-                isAdmin ||
-                item.href === "/admin/pages" ||
-                item.href === "/admin/about",
-            )
-            .map(renderLink)}
-        </>
+        <div className="mt-2 shrink-0 border-t border-border pt-2">
+          {renderLink({ href: "/admin", label: "Admin", icon: Cog })}
+        </div>
       )}
     </>
   );

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -60,8 +60,7 @@ export function SidebarNav({
 }: SidebarNavProps) {
   const pathname = usePathname();
   const [pages, setPages] = useState<PageLink[]>([]);
-  const isAdmin = profile.role === "admin";
-  const isEditor = profile.role === "content_editor" || isAdmin;
+  const isEditor = profile.role === "admin" || profile.role === "content_editor";
 
   // Directory sub-menu: auto-opens while browsing the section, manually collapsible
   const inDirectory = pathname === "/directory" || pathname.startsWith("/directory/");

--- a/lib/admin-access.ts
+++ b/lib/admin-access.ts
@@ -1,0 +1,9 @@
+// content_editor may reach the admin overview plus its two content pages;
+// every other /admin/* path stays admin-only.
+export const CONTENT_EDITOR_ADMIN_PATHS = ["/admin", "/admin/pages", "/admin/about"];
+
+export function isContentEditorAllowed(pathname: string): boolean {
+  return CONTENT_EDITOR_ADMIN_PATHS.some(
+    (p) => pathname === p || (p !== "/admin" && pathname.startsWith(p + "/"))
+  );
+}

--- a/lib/admin-nav.ts
+++ b/lib/admin-nav.ts
@@ -1,0 +1,75 @@
+import type { ComponentType } from "react";
+import {
+  Users,
+  Home,
+  MailPlus,
+  CalendarDays,
+  Calendar,
+  BarChart2,
+  HandCoins,
+  FileText,
+  Info,
+  BookOpen,
+  Megaphone,
+  Settings,
+} from "lucide-react";
+
+export interface AdminNavItem {
+  href: string;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  /** Visible to content_editor as well as admin. Defaults to admin-only. */
+  contentEditorVisible?: boolean;
+}
+
+export interface AdminNavGroup {
+  key: string;
+  label: string;
+  items: AdminNavItem[];
+}
+
+/**
+ * Single source of truth for admin destinations, labels, and grouping —
+ * shared by the admin area's sub-nav and any other admin nav surface.
+ */
+export const adminNavGroups: AdminNavGroup[] = [
+  {
+    key: "people",
+    label: "People",
+    items: [
+      { href: "/admin/members", label: "Members", icon: Users },
+      { href: "/admin/families", label: "Families", icon: Home },
+      { href: "/admin/groups", label: "Groups", icon: Users },
+      { href: "/admin/invite", label: "Bulk Invite", icon: MailPlus },
+    ],
+  },
+  {
+    key: "events",
+    label: "Events",
+    items: [
+      { href: "/admin/calendars", label: "Event Calendars", icon: CalendarDays },
+      { href: "/admin/events/new", label: "Create Event", icon: Calendar },
+      { href: "/admin/serving", label: "Serving Stats", icon: BarChart2 },
+    ],
+  },
+  {
+    key: "content",
+    label: "Content",
+    items: [
+      { href: "/admin/lectures", label: "Lectures & Series", icon: BookOpen },
+      { href: "/admin/pages", label: "Pages", icon: FileText, contentEditorVisible: true },
+      { href: "/admin/about", label: "About Page", icon: Info, contentEditorVisible: true },
+      { href: "/admin/announcements/new", label: "New Announcement", icon: Megaphone },
+    ],
+  },
+  {
+    key: "giving",
+    label: "Giving",
+    items: [{ href: "/admin/giving", label: "Giving", icon: HandCoins }],
+  },
+  {
+    key: "settings",
+    label: "Settings",
+    items: [{ href: "/admin/settings", label: "Settings", icon: Settings }],
+  },
+];

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
+import { isContentEditorAllowed } from "@/lib/admin-access";
 
 const isDev = process.env.NODE_ENV === "development";
 
@@ -83,10 +84,6 @@ export async function updateSession(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  // content_editor may reach the admin overview plus its two content pages;
-  // every other /admin/* path stays admin-only.
-  const contentEditorAdminPaths = ["/admin", "/admin/pages", "/admin/about"];
-
   if (isAdmin && user) {
     const { data: profile } = await supabase
       .from("profiles")
@@ -94,13 +91,10 @@ export async function updateSession(request: NextRequest) {
       .eq("id", user.id)
       .single();
 
-    const isContentEditorAllowed =
-      profile?.role === "content_editor" &&
-      contentEditorAdminPaths.some(
-        (p) => pathname === p || (p !== "/admin" && pathname.startsWith(p + "/"))
-      );
+    const contentEditorAllowed =
+      profile?.role === "content_editor" && isContentEditorAllowed(pathname);
 
-    if (profile?.role !== "admin" && !isContentEditorAllowed) {
+    if (profile?.role !== "admin" && !contentEditorAllowed) {
       const url = request.nextUrl.clone();
       url.pathname = "/dashboard";
       return NextResponse.redirect(url);

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -83,6 +83,10 @@ export async function updateSession(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
+  // content_editor may reach the admin overview plus its two content pages;
+  // every other /admin/* path stays admin-only.
+  const contentEditorAdminPaths = ["/admin", "/admin/pages", "/admin/about"];
+
   if (isAdmin && user) {
     const { data: profile } = await supabase
       .from("profiles")
@@ -90,7 +94,13 @@ export async function updateSession(request: NextRequest) {
       .eq("id", user.id)
       .single();
 
-    if (profile?.role !== "admin") {
+    const isContentEditorAllowed =
+      profile?.role === "content_editor" &&
+      contentEditorAdminPaths.some(
+        (p) => pathname === p || (p !== "/admin" && pathname.startsWith(p + "/"))
+      );
+
+    if (profile?.role !== "admin" && !isContentEditorAllowed) {
       const url = request.nextUrl.clone();
       url.pathname = "/dashboard";
       return NextResponse.redirect(url);


### PR DESCRIPTION
Closes #277. Supersedes the direction rejected in #274 — this reworks the sidebar and adds a dedicated admin layout, not just the overview page.

## What changed

**1. Sidebar: one admin entry** (`components/layout/SidebarNav.tsx`, `Sidebar.tsx`)
- The 10-link "Admin" section is gone. A single cog-icon **Admin** link → `/admin` is pinned at the bottom of the sidebar below a divider, visible to `admin` and `content_editor`.
- The member list + Pages section now scroll independently, so the Admin link stays visible regardless of how many custom pages exist. Member nav grouping/labels are untouched (#240's scope).

**2. Dedicated `/admin` area** (`app/admin/layout.tsx`, `components/layout/AdminSidebarNav.tsx`, `lib/admin-nav.ts`)
- `/admin/*` gets its own persistent grouped sub-nav — Overview, People, Events, Content, Giving, Settings — replacing the member sidebar inside the admin area, with a "← Back to app" link.
- `lib/admin-nav.ts` is the single source of truth for admin destinations and labels (ends the "Calendars"/"Event Calendars", "Pages"/"Manage Pages" drift).
- On mobile the sub-nav renders as a horizontally scrollable bar, since the member drawer no longer lists admin sub-pages.
- `content_editor` sees only the Content group, scoped to Pages + About Page.

**3. Actionable overview** (`app/admin/page.tsx`, `app/admin/PendingRequestsList.tsx`)
- Stat tiles and the 9-card Quick Actions grid are removed.
- **Needs attention**: pending access requests as rows with inline Approve/Deny (same handlers as `/admin/members`), "All caught up." when empty.
- **Quick actions**: Invite member / Create event / Post announcement (admin); Edit pages / Edit about page (content_editor).

**Bug fix along the way** (`lib/supabase/middleware.ts`): middleware redirected *any* non-admin away from all of `/admin/*`, which made content_editor's existing Pages and About Page links silently dead. content_editor may now reach exactly `/admin`, `/admin/pages`, and `/admin/about`; every other `/admin/*` path stays admin-only (exact-path allowlist, verified in browser).

## Scope notes
- No schema or migration changes.
- content_editor's permission surface is unchanged (still exactly Pages + About Page). The issue's Content-group sketch also lists Lectures & Series / Announcements — granting those to content_editor is a permission-expansion decision left for a separate call.

## Validation
- `npx tsc --noEmit` ✅ · `npm run build` ✅ (eslint has a pre-existing repo-wide crash from the `brace-expansion` override; reproduces without this diff)
- Browser walkthrough on local Supabase, both roles: single cog entry, grouped sub-nav, queue Deny flow + empty state, quick-action navigation, content_editor scoping, route-protection matrix (`/admin/members|lectures|settings` still redirect content_editor), unauthenticated `/admin` → `/login`, mobile 375px layout.