### PR TITLE
Group sidebar nav, fix New Fund casing, drop dashboard tiles

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
-import { Calendar, Play, Users, Bell, Heart, HandHelping } from "lucide-react";
+import { Calendar, HandHelping } from "lucide-react";
 import Link from "next/link";
 import { siteConfig } from "@/lib/config";
 import { formatServiceDate, toDateString } from "@/lib/serving/sundays";
@@ -121,22 +121,12 @@ export default async function DashboardPage() {
   const windowStart = new Date(nowDate.getTime() - 24 * 60 * 60 * 1000);
   const windowStartISO = windowStart.toISOString();
 
-  // Give tile — live funds, gated by the admin toggle. UTC date to match
-  // the retirement filtering on /give and /admin/giving.
-  const today = new Date().toISOString().slice(0, 10);
-  const thirtyDaysAgo = new Date(new Date(now).getTime() - 30 * 86400000).toISOString();
-
   // Phase A — every query below is independent of `nextEvent`; fire them
   // together instead of awaiting one at a time.
   const [
     { data: rawEvents },
     { data: rsvps },
     { data: announcements },
-    { data: giveTileSetting },
-    { data: liveFunds, count: liveFundCount },
-    { count: eventCount },
-    { count: memberCount },
-    { count: announcementCount },
     { count: lectureCount },
     { data: lectures },
     { data: myServings },
@@ -163,34 +153,6 @@ export default async function DashboardPage() {
       .lte("published_at", now)
       .order("published_at", { ascending: false })
       .limit(3),
-    supabase
-      .from("site_settings")
-      .select("value")
-      .eq("key", "giving_dashboard_tile")
-      .maybeSingle(),
-    supabase
-      .from("giving_funds")
-      .select("name", { count: "exact" })
-      .eq("is_active", true)
-      .or(`retire_on.is.null,retire_on.gte.${today}`)
-      .order("display_order")
-      .order("created_at")
-      .limit(1),
-    // Counts for quick-actions
-    supabase
-      .from("events")
-      .select("id", { count: "exact", head: true })
-      .gte("start_time", now),
-    supabase
-      .from("profiles")
-      .select("id", { count: "exact", head: true })
-      .neq("role", "pending"),
-    supabase
-      .from("announcements")
-      .select("id", { count: "exact", head: true })
-      .eq("is_published", true)
-      .lte("published_at", now)
-      .gte("published_at", thirtyDaysAgo),
     supabase
       .from("lectures")
       .select("id", { count: "exact", head: true }),
@@ -223,14 +185,6 @@ export default async function DashboardPage() {
   if (rsvps) {
     userRsvps = Object.fromEntries(rsvps.map((r) => [r.event_id, r]));
   }
-
-  const showGiveTile =
-    (giveTileSetting?.value ?? "on") === "on" &&
-    (liveFundCount ?? 0) > 0;
-  const giveTileSubtitle =
-    liveFundCount === 1 && liveFunds?.[0]
-      ? liveFunds[0].name
-      : `${liveFundCount} funds collecting`;
 
   const hasLectures = lectures && lectures.length > 0;
 
@@ -451,108 +405,6 @@ export default async function DashboardPage() {
               </div>
             </div>
           )}
-      </section>
-
-      {/* ── Quick Actions ─────────────────────────────────────────────────── */}
-      <section className="px-4 pb-6 md:px-14">
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
-
-          {/* All Events */}
-          <Link
-            href="/events"
-            className="flex items-center gap-3.5 bg-card border border-border rounded-2xl p-4 hover:bg-muted/40 transition-colors"
-          >
-            <div className="w-[42px] h-[42px] rounded-xl bg-brand-warm flex items-center justify-center flex-shrink-0">
-              <Calendar className="h-5 w-5 text-brand-primary" />
-            </div>
-            <div>
-              <div className="font-sans text-sm font-semibold text-foreground">
-                All events
-              </div>
-              <div className="font-sans text-xs text-muted-foreground mt-0.5">
-                {eventCount != null ? `${eventCount} upcoming` : "View calendar"}
-              </div>
-            </div>
-          </Link>
-
-          {/* Lectures */}
-          {lectureCount != null && lectureCount > 0 && (
-            <Link
-              href="/lectures"
-              className="flex items-center gap-3.5 bg-card border border-border rounded-2xl p-4 hover:bg-muted/40 transition-colors"
-            >
-              <div className="w-[42px] h-[42px] rounded-xl bg-brand-warm flex items-center justify-center flex-shrink-0">
-                <Play className="h-5 w-5 text-brand-primary" />
-              </div>
-              <div>
-                <div className="font-sans text-sm font-semibold text-foreground">
-                  Lectures
-                </div>
-                <div className="font-sans text-xs text-muted-foreground mt-0.5">
-                  {lectureCount} in library
-                </div>
-              </div>
-            </Link>
-          )}
-
-          {/* Directory */}
-          <Link
-            href="/directory"
-            className="flex items-center gap-3.5 bg-card border border-border rounded-2xl p-4 hover:bg-muted/40 transition-colors"
-          >
-            <div className="w-[42px] h-[42px] rounded-xl bg-brand-warm flex items-center justify-center flex-shrink-0">
-              <Users className="h-5 w-5 text-brand-primary" />
-            </div>
-            <div>
-              <div className="font-sans text-sm font-semibold text-foreground">
-                Directory
-              </div>
-              <div className="font-sans text-xs text-muted-foreground mt-0.5">
-                {memberCount != null ? `${memberCount} members` : "View all"}
-              </div>
-            </div>
-          </Link>
-
-          {/* Announcements */}
-          <Link
-            href="/announcements"
-            className="flex items-center gap-3.5 bg-card border border-border rounded-2xl p-4 hover:bg-muted/40 transition-colors"
-          >
-            <div className="w-[42px] h-[42px] rounded-xl bg-brand-warm flex items-center justify-center flex-shrink-0">
-              <Bell className="h-5 w-5 text-brand-primary" />
-            </div>
-            <div>
-              <div className="font-sans text-sm font-semibold text-foreground">
-                Announcements
-              </div>
-              <div className="font-sans text-xs text-muted-foreground mt-0.5">
-                {announcementCount != null && announcementCount > 0
-                  ? `${announcementCount} new`
-                  : "See all"}
-              </div>
-            </div>
-          </Link>
-
-          {/* Give — only when funds are collecting and the admin tile is on */}
-          {showGiveTile && (
-            <Link
-              href="/give"
-              className="flex items-center gap-3.5 bg-card border border-border rounded-2xl p-4 hover:bg-muted/40 transition-colors"
-            >
-              <div className="w-[42px] h-[42px] rounded-xl bg-brand-warm flex items-center justify-center flex-shrink-0">
-                <Heart className="h-5 w-5 text-brand-primary" />
-              </div>
-              <div className="min-w-0">
-                <div className="font-sans text-sm font-semibold text-foreground">
-                  Give
-                </div>
-                <div className="font-sans text-xs text-muted-foreground mt-0.5 truncate">
-                  {giveTileSubtitle}
-                </div>
-              </div>
-            </Link>
-          )}
-        </div>
       </section>
 
       {/* ── Your turn to serve ───────────────────────────────────────────── */}

--- a/app/give/new/page.tsx
+++ b/app/give/new/page.tsx
@@ -32,7 +32,7 @@ export default async function NewFundPage() {
   return (
     <div className="container mx-auto px-4 py-12 max-w-5xl">
       <h1 className="text-3xl md:text-4xl font-bold text-brand-primary mb-10">
-        New fund
+        New Fund
       </h1>
       <FundForm
         fund={null}

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -31,18 +31,39 @@ interface SidebarNavProps {
   onNavigate?: () => void;
 }
 
-const memberNav = [
-  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { href: "/events", label: "Calendar", icon: Calendar },
-  { href: "/announcements", label: "Announcements", icon: Megaphone },
-  { href: "/lectures", label: "Lectures", icon: BookOpen },
-  { href: "/directory", label: "Directory", icon: Users },
-  { href: "/serving", label: "Serving", icon: HandHelping },
-  { href: "/prayer", label: "Prayer", icon: HeartHandshake },
-  { href: "/give", label: "Give", icon: HandCoins },
-  { href: "/about", label: "About", icon: Info },
-  { href: "/profile", label: "My Profile", icon: UserCircle },
-  { href: "/settings", label: "Settings", icon: Settings },
+const memberNavGroups: {
+  label: string | null;
+  items: { href: string; label: string; icon: ComponentType<{ className?: string }> }[];
+}[] = [
+  {
+    label: null,
+    items: [{ href: "/dashboard", label: "Dashboard", icon: LayoutDashboard }],
+  },
+  {
+    label: "Content",
+    items: [
+      { href: "/events", label: "Calendar", icon: Calendar },
+      { href: "/announcements", label: "Announcements", icon: Megaphone },
+      { href: "/lectures", label: "Lectures", icon: BookOpen },
+      { href: "/about", label: "About", icon: Info },
+    ],
+  },
+  {
+    label: "Community",
+    items: [
+      { href: "/directory", label: "Directory", icon: Users },
+      { href: "/serving", label: "Serving", icon: HandHelping },
+      { href: "/prayer", label: "Prayer", icon: HeartHandshake },
+      { href: "/give", label: "Give", icon: HandCoins },
+    ],
+  },
+  {
+    label: "Account",
+    items: [
+      { href: "/profile", label: "My Profile", icon: UserCircle },
+      { href: "/settings", label: "Settings", icon: Settings },
+    ],
+  },
 ];
 
 const directorySubNav = [
@@ -181,19 +202,31 @@ export function SidebarNav({
   return (
     <>
       <div className="min-h-0 flex-1 space-y-1 overflow-y-auto">
-        {memberNav
-          .filter((item) => item.href !== "/serving" || hasServingAccess)
-          .map((item) => (
-            <Fragment key={item.href}>
-              {item.href === "/directory" && !collapsed ? renderDirectoryItem() : renderLink(item)}
-              {item.href === "/directory" && renderDirectorySubNav()}
-            </Fragment>
-          ))}
+        {memberNavGroups.map((group) => (
+          <Fragment key={group.label ?? "top"}>
+            {group.label && !collapsed && (
+              <p className="px-3 pt-4 pb-1 text-sm font-bold uppercase text-muted-foreground tracking-wider">
+                {group.label}
+              </p>
+            )}
+            {group.label && collapsed && (
+              <div className="border-t border-border my-2" role="separator" />
+            )}
+            {group.items
+              .filter((item) => item.href !== "/serving" || hasServingAccess)
+              .map((item) => (
+                <Fragment key={item.href}>
+                  {item.href === "/directory" && !collapsed ? renderDirectoryItem() : renderLink(item)}
+                  {item.href === "/directory" && renderDirectorySubNav()}
+                </Fragment>
+              ))}
+          </Fragment>
+        ))}
 
         {pages.length > 0 && (
           <>
             {!collapsed && (
-              <p className="px-3 pt-4 pb-1 text-xs font-semibold uppercase text-slate-400 tracking-wider">
+              <p className="px-3 pt-4 pb-1 text-sm font-bold uppercase text-muted-foreground tracking-wider">
                 Pages
               </p>
             )}

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -31,10 +31,16 @@ interface SidebarNavProps {
   onNavigate?: () => void;
 }
 
-const memberNavGroups: {
-  label: string | null;
-  items: { href: string; label: string; icon: ComponentType<{ className?: string }> }[];
-}[] = [
+type NavItem = {
+  href: string;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  exact?: boolean;
+};
+
+type NavGroup = { label: string | null; items: NavItem[] };
+
+const memberNavGroups: NavGroup[] = [
   {
     label: null,
     items: [{ href: "/dashboard", label: "Dashboard", icon: LayoutDashboard }],
@@ -116,9 +122,7 @@ export function SidebarNav({
         : "border-transparent font-medium text-slate-600 hover:text-brand-primary hover:bg-brand-warm/50"
     }`;
 
-  const renderLink = (
-    item: { href: string; label: string; icon: ComponentType<{ className?: string }>; exact?: boolean },
-  ) => {
+  const renderLink = (item: NavItem) => {
     const active = isActive(item.href, item.exact);
     return (
       <Link


### PR DESCRIPTION
## Summary

- Groups the member sidebar nav (`components/layout/SidebarNav.tsx`) into scannable sections — **Content** (Calendar, Announcements, Lectures, About), **Community** (Directory, Serving, Prayer, Give), **Account** (My Profile, Settings) — with Dashboard left ungrouped at top.
- Upgrades the section-label style from `text-xs font-semibold text-slate-400` (12px, ~2.7:1 contrast) to `text-sm font-bold text-muted-foreground` for the new group labels and the existing "Pages" label, matching the senior-friendly legibility bar in `CLAUDE.md` and mirroring `app/serving/page.tsx`'s existing section-label style.
- Fixes a real casing bug: `app/give/new/page.tsx` had `<title>New Fund</title>` but an `<h1>` of "New fund" — now both read "New Fund", matching the Title Case convention used elsewhere (e.g. "Bulk Invite Members").
- Removes the dashboard's 5-up quick-action tile grid (`app/dashboard/page.tsx`, previously ~lines 456-556) since it just re-navigated to destinations already one tap away in the sidebar (desktop) and nav drawer (mobile) — confirmed via `AppShell.tsx`/`Header.tsx` that the same `SidebarNav` renders in both. Pruned the now-dead queries/variables that existed solely to feed it (`eventCount`, `memberCount`, `announcementCount`, `giveTileSetting`, `liveFunds`/`liveFundCount`, `showGiveTile`, `giveTileSubtitle`, `today`, `thirtyDaysAgo`) and unused icon imports (`Play`, `Users`, `Bell`, `Heart`), while keeping `lectureCount` (still used by "Continue Listening"/`recordingsHref`).

## Scope boundary with #280

This PR does **not** touch the `adminNav` array or the "Admin" section render block in `SidebarNav.tsx` — that block is owned by #280 (issue #277), which replaces the 10-link admin section with a single cog entry. The "Admin" label intentionally keeps its old `text-xs text-slate-400` styling for now; that inconsistency will resolve itself once #280 lands.

## Naming items addressed via documentation, not code

The issue also flagged `Calendar`/`Calendars`, `Give`/`Giving`, and `Serving`/`Serving Stats` as inconsistent nouns. Investigation found these are not naming bugs:

- **Calendar vs Calendars** — `/admin/calendars` manages the `event_calendars` table (named calendar categories), a genuinely distinct, plural concept from the member-facing single "Calendar" (events) view.
- **Give vs Giving** — `/give` (member donation action) vs `/admin/giving` (fund management section) is a verb-for-action vs noun-for-domain split, an intentional and common convention, not a bug.
- **Serving vs Serving Stats** — "Serving Stats" already correctly signals a distinct admin reporting concept, not a mislabeled duplicate of the member-facing "Serving" sign-up page.

No code changes were made for these; they're called out here per the issue's "decide and document" option.

## Validation

- `npx tsc --noEmit` — pass, no errors.
- `npm run build` — pass, compiled successfully, all 64 routes generated.
- `npm run lint` — could not run: pre-existing, repo-wide crash (`brace-expansion`/`minimatch` version mismatch in `package-lock.json`) unrelated to this diff. Reproduces identically on `main` and in every other active worktree; confirmed via lockfile history that the incompatible bump landed in #255, before this branch existed. Recommend a separate `chore(deps):` fix.
- Manual/visual verification of `/dashboard`, `/give/new`, and the sidebar (desktop + mobile drawer, member + admin) is still recommended before merge — not performed in this session (no browser available).

No schema or migration changes — UI layer only.

Fixes #240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Simplified the dashboard by removing the Quick Actions tiles.
  * Improved sidebar navigation with grouped sections, headings, and separators for collapsed views.
  * The Serving navigation option remains visible only when access is available.

* **Style**
  * Updated the New Fund page heading capitalization for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->