### PR TITLE
fix: give the admin area a single nav system

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -58,6 +58,11 @@ export function Header({ profile, hasServingAccess }: HeaderProps) {
   const hasDesktopSidebar =
     isMember && SIDEBAR_ROUTES.some((r) => pathname.startsWith(r));
 
+  // The admin area supplies its own nav (AdminSidebarNav: a persistent rail on
+  // desktop, a horizontal bar on mobile) plus a "Back to app" link. Swap, don't
+  // stack: suppress the member-nav drawer here so admin has one nav system.
+  const isAdminArea = pathname.startsWith("/admin");
+
   return (
     <header
       className={`sticky top-0 z-50 w-full border-b border-border transition-all duration-300 ${
@@ -82,8 +87,9 @@ export function Header({ profile, hasServingAccess }: HeaderProps) {
               <Menu className="h-6 w-6" aria-hidden="true" />
             </Button>
           )}
-          {/* Mobile (or no sidebar): menu button opens the nav drawer */}
-          {profile && isMember && (
+          {/* Mobile (or no sidebar): menu button opens the nav drawer.
+              Hidden in the admin area, which supplies its own nav. */}
+          {profile && isMember && !isAdminArea && (
             <Sheet open={open} onOpenChange={setOpen}>
               <SheetTrigger
                 render={
@@ -166,7 +172,7 @@ export function Header({ profile, hasServingAccess }: HeaderProps) {
               size="lg"
               onClick={handleSignOut}
               className={`text-base border-slate-200 hover:border-destructive/30 hover:text-destructive hover:bg-destructive/10 ${
-                isMember ? "hidden md:inline-flex" : ""
+                isMember && !isAdminArea ? "hidden md:inline-flex" : ""
               }`}
             >
               <LogOut className="mr-2 h-4 w-4" aria-hidden="true" />

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -254,13 +254,13 @@ export function SidebarNav({
             })}
           </>
         )}
-      </div>
 
-      {isEditor && (
-        <div className="mt-2 shrink-0 border-t border-border pt-2">
-          {renderLink({ href: "/admin", label: "Admin", icon: Cog })}
-        </div>
-      )}
+        {isEditor && (
+          <div className="mt-2 border-t border-border pt-2">
+            {renderLink({ href: "/admin", label: "Admin", icon: Cog })}
+          </div>
+        )}
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary

Restores a fix that was authored alongside #280 but was **left uncommitted in the branch worktree**, so it never made it into PR #280 and never reached `main`. Two symptoms on the live app:

1. Inside `/admin`, the `Header` still rendered the **member-nav hamburger drawer** — a second, competing nav stacked on top of the admin rail/bar (and, because `hasDesktopSidebar` is false in `/admin`, that hamburger was even visible on desktop).
2. The member sidebar's **"Admin" link was pinned to the very bottom** of the sidebar (`shrink-0`, outside the scroll area), floating away from the rest of the nav.

## Changes

- **`components/layout/Header.tsx`** — add `isAdminArea = pathname.startsWith("/admin")`; hide the member-nav drawer when `isAdminArea` so the admin area has exactly one nav system (its own rail on desktop / horizontal bar on mobile + "Back to app"). Keep the top-right Sign Out visible at all breakpoints in `/admin` so mobile admin still has sign-out (it previously lived only in the now-suppressed drawer).
- **`components/layout/SidebarNav.tsx`** — move the "Admin" cog link *inside* the scrolling nav container and drop `shrink-0`, so it flows directly after the member nav instead of being pinned to the bottom. Re-applied on top of #281's grouped-nav structure.

## Validation

- `npx tsc --noEmit` — pass
- `npm run build` — pass, all routes generated
- UI-layer only; no schema/migration changes.

Follow-up to #280 (#277).