### PR TITLE
fix: redirect signed-in members away from public landing and join pages

### DIFF
--- a/app/join/JoinForm.tsx
+++ b/app/join/JoinForm.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent } from "@/components/ui/card";
+import { createClient } from "@/lib/supabase/client";
+import { toast } from "sonner";
+import { useSearchParams } from "next/navigation";
+import { AuthShell } from "@/app/(auth)/_components/AuthShell";
+
+function JoinFormFields() {
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const supabase = createClient();
+  const searchParams = useSearchParams();
+
+  // Pre-fill when coming from a family invite link
+  const prefilledEmail = searchParams.get("email") ?? "";
+  const inviteToken = searchParams.get("invite_token") ?? "";
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setLoading(true);
+
+    const formData = new FormData(e.currentTarget);
+    const name = formData.get("name") as string;
+    const email = formData.get("email") as string;
+    const message = formData.get("message") as string;
+
+    const { error } = await supabase.from("access_requests").insert({
+      name,
+      email,
+      message: message || null,
+      // Store the family invite token on the access request so that when
+      // the user creates their account the family link can be established.
+      ...(inviteToken ? { invite_token: inviteToken } : {}),
+    });
+
+    setLoading(false);
+
+    if (error) {
+      toast.error("Something went wrong. Please try again.");
+      return;
+    }
+
+    setSubmitted(true);
+  };
+
+  if (submitted) {
+    return (
+      <div className="container mx-auto px-4 py-20 max-w-lg text-center">
+        <Card className="p-8">
+          <CardContent className="pt-6">
+            <h1 className="text-3xl font-bold text-brand-primary mb-4">Request Submitted!</h1>
+            <p className="text-lg text-muted-foreground">
+              Thank you for your interest in joining us. An admin will review your
+              request and you&apos;ll receive an email once approved.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <AuthShell
+      eyebrow="REQUEST ACCESS"
+      title="Join"
+      em="our group"
+      kicker="Fill out the form below and an admin will review your request."
+    >
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="space-y-2">
+          <Label htmlFor="name" className="text-lg">Full Name</Label>
+          <Input
+            id="name"
+            name="name"
+            required
+            placeholder="Your full name"
+            className="text-lg py-6"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="email" className="text-lg">Email</Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            required
+            defaultValue={prefilledEmail}
+            readOnly={!!prefilledEmail}
+            placeholder="your@email.com"
+            className={`text-lg py-6${prefilledEmail ? " bg-muted" : ""}`}
+          />
+          {prefilledEmail && (
+            <p className="text-lg text-muted-foreground">
+              Your invite was sent to this email address — please use it to sign up.
+            </p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="message" className="text-lg">
+            Message <span className="text-muted-foreground">(optional)</span>
+          </Label>
+          <Textarea
+            id="message"
+            name="message"
+            placeholder="Tell us a little about yourself..."
+            rows={4}
+            className="text-lg"
+          />
+        </div>
+        <Button
+          type="submit"
+          size="lg"
+          className="w-full text-lg py-6 bg-brand-primary hover:bg-brand-primary/90 text-white"
+          disabled={loading}
+        >
+          {loading ? "Submitting..." : "Submit Request"}
+        </Button>
+      </form>
+    </AuthShell>
+  );
+}
+
+export function JoinForm() {
+  return (
+    <Suspense fallback={
+      <div className="container mx-auto px-4 py-12 max-w-lg">
+        <Card>
+          <CardContent className="py-12 text-center text-muted-foreground text-lg">
+            Loading...
+          </CardContent>
+        </Card>
+      </div>
+    }>
+      <JoinFormFields />
+    </Suspense>
+  );
+}

--- a/app/join/JoinForm.tsx
+++ b/app/join/JoinForm.tsx
@@ -30,23 +30,28 @@ function JoinFormFields() {
     const email = formData.get("email") as string;
     const message = formData.get("message") as string;
 
-    const { error } = await supabase.from("access_requests").insert({
-      name,
-      email,
-      message: message || null,
-      // Store the family invite token on the access request so that when
-      // the user creates their account the family link can be established.
-      ...(inviteToken ? { invite_token: inviteToken } : {}),
-    });
+    try {
+      const { error } = await supabase.from("access_requests").insert({
+        name,
+        email,
+        message: message || null,
+        // Store the family invite token on the access request so that when
+        // the user creates their account the family link can be established.
+        ...(inviteToken ? { invite_token: inviteToken } : {}),
+      });
 
-    setLoading(false);
+      if (error) {
+        toast.error("Something went wrong. Please try again.");
+        return;
+      }
 
-    if (error) {
+      setSubmitted(true);
+    } catch {
+      // Network failure or an unexpected throw from the client.
       toast.error("Something went wrong. Please try again.");
-      return;
+    } finally {
+      setLoading(false);
     }
-
-    setSubmitted(true);
   };
 
   if (submitted) {

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -1,25 +1,12 @@
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
+import { getOptionalUser } from "@/lib/supabase/current-user";
 import { JoinForm } from "./JoinForm";
 
 export default async function JoinPage() {
   // Signed-in members are already in the group — there's nothing to request, so
   // send them to the app rather than showing the access-request form.
-  // Mirror the root layout: skip the getUser() call entirely when there are no
-  // auth cookies, so anonymous visitors don't trigger refresh-token errors.
-  const cookieStore = await cookies();
-  const hasAuthCookie = cookieStore
-    .getAll()
-    .some((c) => c.name.includes("auth-token"));
-  if (hasAuthCookie) {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (user) {
-      redirect("/dashboard");
-    }
+  if (await getOptionalUser()) {
+    redirect("/dashboard");
   }
 
   return <JoinForm />;

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -1,143 +1,26 @@
-"use client";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { JoinForm } from "./JoinForm";
 
-import { Suspense, useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Label } from "@/components/ui/label";
-import { Card, CardContent } from "@/components/ui/card";
-import { createClient } from "@/lib/supabase/client";
-import { toast } from "sonner";
-import { useSearchParams } from "next/navigation";
-import { AuthShell } from "@/app/(auth)/_components/AuthShell";
-
-function JoinForm() {
-  const [loading, setLoading] = useState(false);
-  const [submitted, setSubmitted] = useState(false);
-  const supabase = createClient();
-  const searchParams = useSearchParams();
-
-  // Pre-fill when coming from a family invite link
-  const prefilledEmail = searchParams.get("email") ?? "";
-  const inviteToken = searchParams.get("invite_token") ?? "";
-
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setLoading(true);
-
-    const formData = new FormData(e.currentTarget);
-    const name = formData.get("name") as string;
-    const email = formData.get("email") as string;
-    const message = formData.get("message") as string;
-
-    const { error } = await supabase.from("access_requests").insert({
-      name,
-      email,
-      message: message || null,
-      // Store the family invite token on the access request so that when
-      // the user creates their account the family link can be established.
-      ...(inviteToken ? { invite_token: inviteToken } : {}),
-    });
-
-    setLoading(false);
-
-    if (error) {
-      toast.error("Something went wrong. Please try again.");
-      return;
+export default async function JoinPage() {
+  // Signed-in members are already in the group — there's nothing to request, so
+  // send them to the app rather than showing the access-request form.
+  // Mirror the root layout: skip the getUser() call entirely when there are no
+  // auth cookies, so anonymous visitors don't trigger refresh-token errors.
+  const cookieStore = await cookies();
+  const hasAuthCookie = cookieStore
+    .getAll()
+    .some((c) => c.name.includes("auth-token"));
+  if (hasAuthCookie) {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (user) {
+      redirect("/dashboard");
     }
-
-    setSubmitted(true);
-  };
-
-  if (submitted) {
-    return (
-      <div className="container mx-auto px-4 py-20 max-w-lg text-center">
-        <Card className="p-8">
-          <CardContent className="pt-6">
-            <h1 className="text-3xl font-bold text-brand-primary mb-4">Request Submitted!</h1>
-            <p className="text-lg text-muted-foreground">
-              Thank you for your interest in joining us. An admin will review your
-              request and you&apos;ll receive an email once approved.
-            </p>
-          </CardContent>
-        </Card>
-      </div>
-    );
   }
 
-  return (
-    <AuthShell
-      eyebrow="REQUEST ACCESS"
-      title="Join"
-      em="our group"
-      kicker="Fill out the form below and an admin will review your request."
-    >
-      <form onSubmit={handleSubmit} className="space-y-6">
-        <div className="space-y-2">
-          <Label htmlFor="name" className="text-lg">Full Name</Label>
-          <Input
-            id="name"
-            name="name"
-            required
-            placeholder="Your full name"
-            className="text-lg py-6"
-          />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="email" className="text-lg">Email</Label>
-          <Input
-            id="email"
-            name="email"
-            type="email"
-            required
-            defaultValue={prefilledEmail}
-            readOnly={!!prefilledEmail}
-            placeholder="your@email.com"
-            className={`text-lg py-6${prefilledEmail ? " bg-muted" : ""}`}
-          />
-          {prefilledEmail && (
-            <p className="text-lg text-muted-foreground">
-              Your invite was sent to this email address — please use it to sign up.
-            </p>
-          )}
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="message" className="text-lg">
-            Message <span className="text-muted-foreground">(optional)</span>
-          </Label>
-          <Textarea
-            id="message"
-            name="message"
-            placeholder="Tell us a little about yourself..."
-            rows={4}
-            className="text-lg"
-          />
-        </div>
-        <Button
-          type="submit"
-          size="lg"
-          className="w-full text-lg py-6 bg-brand-primary hover:bg-brand-primary/90 text-white"
-          disabled={loading}
-        >
-          {loading ? "Submitting..." : "Submit Request"}
-        </Button>
-      </form>
-    </AuthShell>
-  );
-}
-
-export default function JoinPage() {
-  return (
-    <Suspense fallback={
-      <div className="container mx-auto px-4 py-12 max-w-lg">
-        <Card>
-          <CardContent className="py-12 text-center text-muted-foreground text-lg">
-            Loading...
-          </CardContent>
-        </Card>
-      </div>
-    }>
-      <JoinForm />
-    </Suspense>
-  );
+  return <JoinForm />;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,30 +1,17 @@
 import Link from "next/link";
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import { Christicon } from "@christicons/react";
 import { siteConfig } from "@/lib/config";
-import { createClient } from "@/lib/supabase/server";
+import { getOptionalUser } from "@/lib/supabase/current-user";
 
 export default async function HomePage() {
   // Signed-in members have no use for the public marketing hero — send them to
   // the app. Without this, an authenticated visitor to "/" sees the logged-out
   // hero under a member header (with "Sign Out"), which reads as a bug.
-  // Mirror the root layout: skip the getUser() call entirely when there are no
-  // auth cookies, so anonymous visitors don't trigger refresh-token errors.
-  const cookieStore = await cookies();
-  const hasAuthCookie = cookieStore
-    .getAll()
-    .some((c) => c.name.includes("auth-token"));
-  if (hasAuthCookie) {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (user) {
-      redirect("/dashboard");
-    }
+  if (await getOptionalUser()) {
+    redirect("/dashboard");
   }
 
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,32 @@
 import Link from "next/link";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import { Christicon } from "@christicons/react";
 import { siteConfig } from "@/lib/config";
+import { createClient } from "@/lib/supabase/server";
 
-export default function HomePage() {
+export default async function HomePage() {
+  // Signed-in members have no use for the public marketing hero — send them to
+  // the app. Without this, an authenticated visitor to "/" sees the logged-out
+  // hero under a member header (with "Sign Out"), which reads as a bug.
+  // Mirror the root layout: skip the getUser() call entirely when there are no
+  // auth cookies, so anonymous visitors don't trigger refresh-token errors.
+  const cookieStore = await cookies();
+  const hasAuthCookie = cookieStore
+    .getAll()
+    .some((c) => c.name.includes("auth-token"));
+  if (hasAuthCookie) {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (user) {
+      redirect("/dashboard");
+    }
+  }
+
   return (
     <div>
       {/* ── Hero ── */}

--- a/lib/supabase/current-user.ts
+++ b/lib/supabase/current-user.ts
@@ -1,0 +1,20 @@
+import { cookies } from "next/headers";
+import type { User } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/server";
+
+// Resolve the authenticated user for a server render, or null when anonymous.
+// Skips the getUser() call entirely when there are no auth cookies, so
+// anonymous visitors don't trigger "Invalid Refresh Token" lookups.
+export async function getOptionalUser(): Promise<User | null> {
+  const cookieStore = await cookies();
+  const hasAuthCookie = cookieStore
+    .getAll()
+    .some((c) => c.name.includes("auth-token"));
+  if (!hasAuthCookie) return null;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return user;
+}


### PR DESCRIPTION
## Problem

A signed-in member visiting `/` saw the logged-out marketing hero ("Request to Join" / "Sign In") **underneath** the member header — which renders a "Sign Out" button. The result reads as a bug: the page looks logged-out while the header says you're logged in. The `/join` access-request form had the same issue: it rendered for authenticated members who have no reason to request access.

## Fix

Redirect authenticated users to `/dashboard` from both public-only pages, using the same `hasAuthCookie` short-circuit the root layout already uses (so anonymous visitors don't trigger refresh-token lookups):

- **`/` (`app/page.tsx`)** — made the server component `async` and added the auth check + `redirect("/dashboard")`.
- **`/join`** — split into a server `page.tsx` (auth check + redirect) and a client `JoinForm.tsx` (unchanged form logic), since the original page was entirely `"use client"` and couldn't do a server redirect.

## Result

- Logged out → hero + "Sign In" (consistent).
- Logged in → straight to the dashboard; no more contradictory "Sign Out" over a logged-out-looking page.

## Verification

- `tsc --noEmit` passes clean.
- No behavior change to the join form itself — only the surrounding server wrapper is new.

https://claude.ai/code/session_018uY4rtawjGZX8iieSfxcMP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Join/Request Access form for submitting email addresses and optional invitation tokens.
  - Invitation links can prefill the email field and lock it for editing.
  - Added submission progress feedback and a confirmation screen after successful requests.
- **Bug Fixes**
  - Authenticated visitors are now redirected to the dashboard from the home and join pages.
  - Anonymous visitors can access these pages without unnecessary authentication errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->