### PR TITLE
fix(serving): honor email_announcements opt-out in broadcasts

### DIFF
--- a/app/api/serving/broadcast/route.ts
+++ b/app/api/serving/broadcast/route.ts
@@ -88,7 +88,9 @@ export async function POST(request: Request) {
 
   const { data: memberRows } = await service
     .from("profile_groups")
-    .select("profiles(id, first_name, last_name, preferred_name, email, role)")
+    .select(
+      "profiles(id, first_name, last_name, preferred_name, email, role, email_announcements)"
+    )
     .eq("group_id", groupId);
 
   const members = (memberRows ?? [])
@@ -101,9 +103,13 @@ export async function POST(request: Request) {
           preferred_name: string | null;
           email: string | null;
           role: string;
+          email_announcements: boolean;
         } | null
     )
-    .filter((p): p is NonNullable<typeof p> => !!p?.email && p.role !== "pending");
+    .filter(
+      (p): p is NonNullable<typeof p> =>
+        !!p?.email && p.role !== "pending" && p.email_announcements !== false
+    );
 
   if (members.length === 0) {
     return NextResponse.json(

--- a/supabase/functions/send-serving-reminders/index.ts
+++ b/supabase/functions/send-serving-reminders/index.ts
@@ -301,12 +301,18 @@ async function runMonthly(
     // Get all team members
     const { data: members } = await supabase
       .from("profile_groups")
-      .select("profiles(id, first_name, preferred_name, email)")
+      .select("profiles(id, first_name, preferred_name, email, email_announcements)")
       .eq("group_id", group_id);
 
     for (const row of members ?? []) {
-      const m = row.profiles as { id: string; first_name: string | null; preferred_name: string | null; email: string | null } | null;
-      if (!m?.email) continue;
+      const m = row.profiles as {
+        id: string;
+        first_name: string | null;
+        preferred_name: string | null;
+        email: string | null;
+        email_announcements: boolean;
+      } | null;
+      if (!m?.email || m.email_announcements === false) continue;
 
       const name = escapeHtml(m.preferred_name || m.first_name || "Friend");
       const safeTeam = escapeHtml(teamName);


### PR DESCRIPTION
## Summary

- `profiles.email_announcements` is stored and toggled from Settings, but no send path checked it — opted-out members still received serving-team broadcast emails.
- Both broadcast send paths now select `email_announcements` and exclude opted-out members from the recipient list.

## Changes

- **`app/api/serving/broadcast/route.ts`** (leader-triggered broadcast): added `email_announcements` to the embedded `profiles(...)` select and row-shape cast, and excluded opted-out members in the existing recipient `.filter()` (`p.email_announcements !== false`).
- **`supabase/functions/send-serving-reminders/index.ts`** (`runMonthly`, automated monthly broadcast): added `email_announcements` to the `profiles(...)` select and row-shape cast, and skip opted-out members via an early `continue` (`m.email_announcements === false`).

Out of scope (per investigation): `runDaily()` in `send-serving-reminders` and the reminders in `send-event-reminders` are transactional reminders, not announcements, and remain intentionally unfiltered.

## Validation

- `npx tsc --noEmit` — 0 errors (repo has no `type-check` script)
- `npm run build` — compiled successfully
- `npm run lint` — pre-existing crash (`brace-expansion@5.0.8` / `minimatch@3.1.5` incompatibility in ESLint's config loading), reproduced identically on `main` with changes stashed; unrelated to this fix
- `deno check` on the edge function — 13 pre-existing errors, same count/kind on `main`; caused by missing generated DB types, unrelated to this fix
- No test runner exists in this repo (no vitest/jest, no `test` script, no `*.test.*` files anywhere), so the planned regression test for the route filter was not added. Recommend a follow-up to introduce a test framework and add coverage for this filter.
- Manual verification (toggling a real member's flag and observing sends) was not performed in this run, per repo rules against touching remote Supabase or the shared local stack.

Fixes #218


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email announcement preferences to broadcast and monthly reminder delivery.
  * Recipients who disable email announcements will no longer receive these emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->