### PR TITLE
fix(supabase): capture reminder pg_cron schedules in migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ two42 was built to solve exactly that. It has since been open-sourced so other g
 | Auth + Database | Supabase (PostgreSQL, RLS, Edge Functions) |
 | Hosting | Vercel (free tier) |
 | Email | Resend (free tier: 3,000 emails/month) |
-| Scheduling | Supabase pg_cron (event reminders) |
+| Scheduling | Supabase pg_cron — schedule defined in `supabase/migrations/` (event + serving reminders) |
 
 ---
 

--- a/supabase/functions/send-event-reminders/index.ts
+++ b/supabase/functions/send-event-reminders/index.ts
@@ -1,5 +1,6 @@
 // Supabase Edge Function: send-event-reminders
-// Triggered by pg_cron daily at 8am
+// Triggered by pg_cron daily at 8am — schedule defined in
+// supabase/migrations/20260729000000_reminder_cron_schedules.sql
 // Sends email reminders to users RSVPed to events starting in the next 24 hours
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";

--- a/supabase/functions/send-serving-reminders/index.ts
+++ b/supabase/functions/send-serving-reminders/index.ts
@@ -1,32 +1,12 @@
 // Supabase Edge Function: send-serving-reminders
 //
-// Two modes, two pg_cron entries (run once in Supabase SQL editor — never CI):
+// Two modes, two pg_cron entries — schedule defined in
+// supabase/migrations/20260729000000_reminder_cron_schedules.sql (not here,
+// so it survives a point-in-time restore or self-host from this repo):
 //
-//   -- Daily: remind attendees of covered Sundays (Sat by default)
-//   select cron.schedule(
-//     'send-serving-reminders-daily',
-//     '0 8 * * *',
-//     $$
-//       select net.http_post(
-//         url := '<SUPABASE_PROJECT_URL>/functions/v1/send-serving-reminders',
-//         headers := '{"Authorization":"Bearer <SERVICE_ROLE_KEY>","Content-Type":"application/json"}'::jsonb,
-//         body := '{"mode":"daily"}'::jsonb
-//       );
-//     $$
-//   );
-//
-//   -- Monthly: broadcast open Sundays to the whole team on the 1st
-//   select cron.schedule(
-//     'send-serving-monthly-broadcast',
-//     '0 8 1 * *',
-//     $$
-//       select net.http_post(
-//         url := '<SUPABASE_PROJECT_URL>/functions/v1/send-serving-reminders',
-//         headers := '{"Authorization":"Bearer <SERVICE_ROLE_KEY>","Content-Type":"application/json"}'::jsonb,
-//         body := '{"mode":"monthly"}'::jsonb
-//       );
-//     $$
-//   );
+//   - "send-serving-reminders-daily": remind attendees of covered Sundays
+//     (per-team reminder_days, Sat by default — see serving_team_settings)
+//   - "send-serving-monthly-broadcast": broadcast open Sundays on the 1st
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 

--- a/supabase/functions/send-serving-reminders/index.ts
+++ b/supabase/functions/send-serving-reminders/index.ts
@@ -5,7 +5,7 @@
 // so it survives a point-in-time restore or self-host from this repo):
 //
 //   - "send-serving-reminders-daily": remind attendees of covered Sundays
-//     (per-team reminder_days, Sat by default — see serving_team_settings)
+//     (per-team reminder_days — see serving_team_settings)
 //   - "send-serving-monthly-broadcast": broadcast open Sundays on the 1st
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";

--- a/supabase/migrations/20260729000000_reminder_cron_schedules.sql
+++ b/supabase/migrations/20260729000000_reminder_cron_schedules.sql
@@ -13,10 +13,13 @@
 --   select vault.create_secret('https://<project-ref>.supabase.co', 'cron_project_url');
 --   select vault.create_secret('<service-role-key>', 'cron_service_role_key');
 --
--- Until both secrets exist, these jobs still run on schedule but their
--- net.http_post calls will fail (null url/Authorization) — check
--- `select * from net._http_response order by created desc limit 10;` if
--- reminders stop after a restore or fresh self-host.
+-- Until both secrets exist, these jobs still run on schedule but fail:
+-- if `cron_project_url` is missing, net.http_post raises before queuing
+-- anything (nothing shows up in net._http_response); if only
+-- `cron_service_role_key` is missing, the request goes out with a bad
+-- Authorization header and the failure shows up in net._http_response.
+-- Either way, `select * from cron.job_run_details order by start_time desc
+-- limit 10;` shows whether the job ran and why it failed.
 --
 -- The standard Supabase Postgres image (hosted, local CLI stack, and the
 -- official self-host docker-compose) already preloads pg_cron and pg_net via

--- a/supabase/migrations/20260729000000_reminder_cron_schedules.sql
+++ b/supabase/migrations/20260729000000_reminder_cron_schedules.sql
@@ -1,0 +1,76 @@
+-- Captures the pg_cron schedules that drive send-event-reminders and
+-- send-serving-reminders. Previously these existed only as manually-run SQL
+-- in the remote project (see git history on the edge function files) — a
+-- point-in-time restore or self-hoster had no way to reproduce them.
+--
+-- These jobs call out to Edge Functions over pg_net, which needs a project
+-- URL and a service-role key. Those must NEVER be committed to this public
+-- repo, so they're read from Supabase Vault by name instead. Populate them
+-- once per environment (this is a data operation via the SQL editor / CLI,
+-- not a schema change — it does not conflict with "never touch remote
+-- schema outside CI"):
+--
+--   select vault.create_secret('https://<project-ref>.supabase.co', 'cron_project_url');
+--   select vault.create_secret('<service-role-key>', 'cron_service_role_key');
+--
+-- Until both secrets exist, these jobs still run on schedule but their
+-- net.http_post calls will fail (null url/Authorization) — check
+-- `select * from net._http_response order by created desc limit 10;` if
+-- reminders stop after a restore or fresh self-host.
+--
+-- The standard Supabase Postgres image (hosted, local CLI stack, and the
+-- official self-host docker-compose) already preloads pg_cron and pg_net via
+-- shared_preload_libraries. A non-standard Postgres install must add them to
+-- shared_preload_libraries manually — that can't be done from a SQL migration.
+
+create extension if not exists pg_cron with schema pg_catalog;
+create extension if not exists pg_net with schema extensions;
+
+-- cron.schedule() upserts by job name (pg_cron >= 1.4), so re-applying this
+-- migration — or applying it over jobs created by the original manual setup —
+-- converges each job to the definition below rather than duplicating it.
+
+select cron.schedule(
+  'send-event-reminders-daily',
+  '0 8 * * *',
+  $$
+  select net.http_post(
+    url := (select decrypted_secret from vault.decrypted_secrets where name = 'cron_project_url') || '/functions/v1/send-event-reminders',
+    headers := jsonb_build_object(
+      'Authorization', 'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'cron_service_role_key'),
+      'Content-Type', 'application/json'
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);
+
+select cron.schedule(
+  'send-serving-reminders-daily',
+  '0 8 * * *',
+  $$
+  select net.http_post(
+    url := (select decrypted_secret from vault.decrypted_secrets where name = 'cron_project_url') || '/functions/v1/send-serving-reminders',
+    headers := jsonb_build_object(
+      'Authorization', 'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'cron_service_role_key'),
+      'Content-Type', 'application/json'
+    ),
+    body := '{"mode":"daily"}'::jsonb
+  );
+  $$
+);
+
+select cron.schedule(
+  'send-serving-monthly-broadcast',
+  '0 8 1 * *',
+  $$
+  select net.http_post(
+    url := (select decrypted_secret from vault.decrypted_secrets where name = 'cron_project_url') || '/functions/v1/send-serving-reminders',
+    headers := jsonb_build_object(
+      'Authorization', 'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'cron_service_role_key'),
+      'Content-Type', 'application/json'
+    ),
+    body := '{"mode":"monthly"}'::jsonb
+  );
+  $$
+);

--- a/supabase/migrations/20260729000000_reminder_cron_schedules.sql
+++ b/supabase/migrations/20260729000000_reminder_cron_schedules.sql
@@ -29,51 +29,74 @@
 create extension if not exists pg_cron with schema pg_catalog;
 create extension if not exists pg_net with schema extensions;
 
+-- `private` is not in the API-exposed schema list (see supabase/config.toml),
+-- so this helper is reachable only from SQL (migrations, pg_cron), never via
+-- PostgREST — it builds requests authenticated with the service-role key.
+create schema if not exists private;
+
+-- Shared by every reminder job below: look up both vault secrets once, then
+-- POST to the given Edge Function path with the given body. Parameterizing
+-- job_name/schedule/function_path/body keeps that shape defined in one place
+-- instead of once per cron.schedule() call.
+create or replace function private.schedule_edge_reminder(
+  job_name text,
+  schedule text,
+  function_path text,
+  body jsonb
+) returns void
+language plpgsql
+set search_path = ''
+as $$
+begin
+  perform cron.schedule(
+    job_name,
+    schedule,
+    format(
+      $sql$
+      with secrets as (
+        select name, decrypted_secret
+        from vault.decrypted_secrets
+        where name in ('cron_project_url', 'cron_service_role_key')
+      )
+      select net.http_post(
+        url := (select decrypted_secret from secrets where name = 'cron_project_url') || %L,
+        headers := jsonb_build_object(
+          'Authorization', 'Bearer ' || (select decrypted_secret from secrets where name = 'cron_service_role_key'),
+          'Content-Type', 'application/json'
+        ),
+        body := %L::jsonb
+      );
+      $sql$,
+      function_path,
+      body::text
+    )
+  );
+end;
+$$;
+
+revoke all on function private.schedule_edge_reminder(text, text, text, jsonb) from public;
+
 -- cron.schedule() upserts by job name (pg_cron >= 1.4), so re-applying this
 -- migration — or applying it over jobs created by the original manual setup —
 -- converges each job to the definition below rather than duplicating it.
 
-select cron.schedule(
+select private.schedule_edge_reminder(
   'send-event-reminders-daily',
   '0 8 * * *',
-  $$
-  select net.http_post(
-    url := (select decrypted_secret from vault.decrypted_secrets where name = 'cron_project_url') || '/functions/v1/send-event-reminders',
-    headers := jsonb_build_object(
-      'Authorization', 'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'cron_service_role_key'),
-      'Content-Type', 'application/json'
-    ),
-    body := '{}'::jsonb
-  );
-  $$
+  '/functions/v1/send-event-reminders',
+  '{}'::jsonb
 );
 
-select cron.schedule(
+select private.schedule_edge_reminder(
   'send-serving-reminders-daily',
   '0 8 * * *',
-  $$
-  select net.http_post(
-    url := (select decrypted_secret from vault.decrypted_secrets where name = 'cron_project_url') || '/functions/v1/send-serving-reminders',
-    headers := jsonb_build_object(
-      'Authorization', 'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'cron_service_role_key'),
-      'Content-Type', 'application/json'
-    ),
-    body := '{"mode":"daily"}'::jsonb
-  );
-  $$
+  '/functions/v1/send-serving-reminders',
+  '{"mode":"daily"}'::jsonb
 );
 
-select cron.schedule(
+select private.schedule_edge_reminder(
   'send-serving-monthly-broadcast',
   '0 8 1 * *',
-  $$
-  select net.http_post(
-    url := (select decrypted_secret from vault.decrypted_secrets where name = 'cron_project_url') || '/functions/v1/send-serving-reminders',
-    headers := jsonb_build_object(
-      'Authorization', 'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'cron_service_role_key'),
-      'Content-Type', 'application/json'
-    ),
-    body := '{"mode":"monthly"}'::jsonb
-  );
-  $$
+  '/functions/v1/send-serving-reminders',
+  '{"mode":"monthly"}'::jsonb
 );


### PR DESCRIPTION
## Summary

pg_cron schedules driving the reminder edge functions (`send-event-reminders`, `send-serving-reminders`) existed only as manually-run SQL against the remote Supabase project — not in migrations or `config.toml`. A point-in-time restore or a self-hoster standing the repo up fresh would silently lose all reminders, with no error and no indication anything was missing.

This adds an additive migration that captures the three cron schedules so they're reproducible from the repo.

## Changes

- **`supabase/migrations/20260729000000_reminder_cron_schedules.sql`** (new) — enables `pg_cron`/`pg_net` and schedules the three reminder jobs via Vault-backed `net.http_post` calls:
  - `send-event-reminders-daily` — `0 8 * * *`
  - `send-serving-reminders-daily` — `0 8 * * *`
  - `send-serving-monthly-broadcast` — `0 8 1 * *`
  
  Uses `cron.schedule` upsert-by-jobname (pg_cron ≥1.4) so re-running the migration is idempotent. No secrets are stored in the repo — the Vault entries (`cron_project_url`, `cron_service_role_key`) are populated separately, once, directly on the remote project.
- **`supabase/functions/send-event-reminders/index.ts`** — stale "triggered by pg_cron" comment now points at the migration instead of implying an undocumented external schedule.
- **`supabase/functions/send-serving-reminders/index.ts`** — replaced "paste this into the SQL editor" setup instructions with a pointer to the migration.
- **`README.md`** — scheduling row updated to reference the migration as the source of truth.

## Validation

- `supabase migration up --db-url postgresql://postgres:postgres@127.0.0.1:54322/postgres` applied the new migration cleanly against the shared local stack.
- `cron.job` on local shows all 3 jobs active with the expected schedules; `pg_cron` 1.6.4 and `pg_net` 0.19.5 extensions installed.
- `npx tsc --noEmit` — no errors.
- `npm run build` — passes.
- `npm run lint` — fails, but this is a **pre-existing, unrelated** break on `main` (confirmed via `git stash`): an `overrides` pin of `brace-expansion@^5.0.8` is incompatible with ESLint 9's bundled `minimatch@3.1.5`. No CI workflow runs lint, so it doesn't surface there. Flagging separately for the maintainer; out of scope for this fix.

## Operational follow-ups (not part of this PR)

This migration makes the schedule reproducible, but reminders aren't fully live in prod from this change alone — two one-time, human-run actions remain against the remote project (intentionally not done by an agent, per repo rules against touching remote Supabase state):

1. Deploy the edge functions: `supabase functions deploy send-event-reminders send-serving-reminders`
2. Populate the two Vault secrets once via the SQL editor:
   - `select vault.create_secret('https://<project-ref>.supabase.co', 'cron_project_url');`
   - `select vault.create_secret('<service-role-key>', 'cron_service_role_key');`

Fixes #220
