### PR TITLE
ci(security): skip ZAP, Trivy, and Semgrep for changes that cannot affect the app

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,12 +1,47 @@
 name: Semgrep
 
+# Only scan changes that touch files the scan can act on. Later patterns
+# override earlier ones; this workflow file re-triggers itself so changes
+# to the scan setup are tested on their own PR.
 on:
   push:
     branches:
       - main
+    paths:
+      - '**'
+      - '!**.md'
+      - '!docs/**'
+      - '!LICENSE'
+      - '!.github/**'
+      - '.github/workflows/semgrep.yml'
+      - '!.claude/**'
+      - '!.agents/**'
+      - '!.archon/**'
+      - '!.zap/**'
+      - '!.coderabbit.yaml'
+      - '!renovate.json5'
+      - '!.releaserc.json'
+      - '!.gitignore'
+      - '!.env.example'
   pull_request:
     branches:
       - main
+    paths:
+      - '**'
+      - '!**.md'
+      - '!docs/**'
+      - '!LICENSE'
+      - '!.github/**'
+      - '.github/workflows/semgrep.yml'
+      - '!.claude/**'
+      - '!.agents/**'
+      - '!.archon/**'
+      - '!.zap/**'
+      - '!.coderabbit.yaml'
+      - '!renovate.json5'
+      - '!.releaserc.json'
+      - '!.gitignore'
+      - '!.env.example'
 
 permissions:
   contents: write

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,8 +1,8 @@
 name: Semgrep
 
 # Only scan changes that touch files the scan can act on. Later patterns
-# override earlier ones; this workflow file re-triggers itself so changes
-# to the scan setup are tested on their own PR.
+# override earlier ones. .github/ is not excluded — semgrep's auto config
+# includes GitHub Actions security rules.
 on:
   push:
     branches:
@@ -12,8 +12,6 @@ on:
       - '!**.md'
       - '!docs/**'
       - '!LICENSE'
-      - '!.github/**'
-      - '.github/workflows/semgrep.yml'
       - '!.claude/**'
       - '!.agents/**'
       - '!.archon/**'
@@ -31,8 +29,6 @@ on:
       - '!**.md'
       - '!docs/**'
       - '!LICENSE'
-      - '!.github/**'
-      - '.github/workflows/semgrep.yml'
       - '!.claude/**'
       - '!.agents/**'
       - '!.archon/**'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -4,6 +4,25 @@ on:
   pull_request:
     branches:
       - main
+    # Only scan PRs that touch files the scan can act on. Later patterns
+    # override earlier ones; this workflow file re-triggers itself so
+    # changes to the scan setup are tested on their own PR.
+    paths:
+      - '**'
+      - '!**.md'
+      - '!docs/**'
+      - '!LICENSE'
+      - '!.github/**'
+      - '.github/workflows/trivy.yml'
+      - '!.claude/**'
+      - '!.agents/**'
+      - '!.archon/**'
+      - '!.zap/**'
+      - '!.coderabbit.yaml'
+      - '!renovate.json5'
+      - '!.releaserc.json'
+      - '!.gitignore'
+      - '!.env.example'
 
 permissions:
   contents: read

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -5,15 +5,14 @@ on:
     branches:
       - main
     # Only scan PRs that touch files the scan can act on. Later patterns
-    # override earlier ones; this workflow file re-triggers itself so
-    # changes to the scan setup are tested on their own PR.
+    # override earlier ones: README.md is re-included so Trivy's secret
+    # detection still covers it. .github/ is not excluded.
     paths:
       - '**'
       - '!**.md'
+      - 'README.md'
       - '!docs/**'
       - '!LICENSE'
-      - '!.github/**'
-      - '.github/workflows/trivy.yml'
       - '!.claude/**'
       - '!.agents/**'
       - '!.archon/**'

--- a/.github/workflows/zap-pr.yml
+++ b/.github/workflows/zap-pr.yml
@@ -4,6 +4,26 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
+    # Only scan PRs that can affect the deployed app. Later patterns override
+    # earlier ones: .github/** is excluded as a whole, but this workflow and its
+    # comment script are re-included so changes to the scan itself still run it.
+    # .zap/ (suppression rules) is intentionally NOT excluded.
+    paths:
+      - '**'
+      - '!**.md'
+      - '!docs/**'
+      - '!LICENSE'
+      - '!.github/**'
+      - '.github/workflows/zap-pr.yml'
+      - '.github/scripts/zap_pr_comment.py'
+      - '!.claude/**'
+      - '!.agents/**'
+      - '!.archon/**'
+      - '!.coderabbit.yaml'
+      - '!renovate.json5'
+      - '!.releaserc.json'
+      - '!.gitignore'
+      - '!.env.example'
   workflow_dispatch:
     inputs:
       target_url:


### PR DESCRIPTION
## Summary

The ZAP baseline, Trivy, and Semgrep scans currently run on every push to every non-draft PR targeting `main` (and Semgrep on every push to `main`), including README updates and CI-only changes. This adds `paths` filters so each scan only runs when the change can actually affect what it scans.

**Skipped for all three:** `docs/`, `LICENSE`, `.claude/`, `.agents/`, `.archon/`, `renovate.json5`, `.coderabbit.yaml`, `.releaserc.json`, `.gitignore`, `.env.example`, and markdown files (with the Trivy exception below). Semgrep's push-to-`main` trigger gets the same filter, so doc-only merges skip it too.

**Per-scan differences:**
- **ZAP** additionally skips `.github/` (CI changes can't affect the deployed app), but re-includes its own workflow file and `.github/scripts/zap_pr_comment.py` so scan changes are tested on their own PR. `.zap/rules.tsv` is never excluded — suppression rules change what counts as a finding.
- **Trivy and Semgrep** keep `.github/` in scope: semgrep's `auto` config includes GitHub Actions security rules (e.g. workflow command injection), and trivy's secret detection covers workflow files.
- **Trivy** re-includes `README.md` so its secret detection still covers it.

## Notes

- Safe as plain filters because the `main` ruleset has no required status checks — a skipped scan simply doesn't appear on the PR.
- Filters evaluate the full PR diff, so mixed PRs (app code + docs) still scan on every push.
- The ZAP Vercel `CANCELED` fallback stays in place for mixed PRs; it's just rarely hit now.
- `zap-weekly.yml` is untouched (cron-only).