### PR TITLE
ci(cla): enforce contributor CLA on pull requests

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,7 +19,6 @@ permissions:
   actions: write
   contents: write
   pull-requests: write
-  statuses: write
 
 jobs:
   cla-assistant:
@@ -29,8 +28,8 @@ jobs:
     # custom-pr-sign-comment input exactly; that input is deliberately left
     # unset below so this default string is the only copy to keep in sync.
     if: >
-      (github.event.comment.body == 'recheck' ||
-       github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+      github.event.comment.body == 'recheck' ||
+      github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA' ||
       github.event_name == 'pull_request_target'
     steps:
       - name: CLA Assistant

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,50 @@
+name: CLA Assistant
+
+# pull_request_target runs with base-repo permissions/secrets even for fork PRs
+# (required so the bot can comment and write the signature file on external PRs),
+# but this workflow never checks out the PR's code — the action only talks to
+# the GitHub API — so it doesn't carry the usual pull_request_target risk of
+# executing untrusted code with elevated permissions.
+#
+# No path filter, unlike the other PR workflows here: CLA coverage must apply
+# to every PR (even docs-only ones) — the legal question is about the
+# contribution, not the diff content.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, closed]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla-assistant:
+    name: CLA Assistant
+    runs-on: ubuntu-latest
+    # The second comment-body string must match the action's
+    # custom-pr-sign-comment input exactly; that input is deliberately left
+    # unset below so this default string is the only copy to keep in sync.
+    if: >
+      (github.event.comment.body == 'recheck' ||
+       github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+      github.event_name == 'pull_request_target'
+    steps:
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-document: 'https://github.com/cwaits6/two42/blob/main/CLA.md'
+          path-to-signatures: 'signatures/cla.json'
+          # Dedicated branch for signature storage. It must stay unprotected —
+          # the action commits to it via the API — and must exist before the
+          # first sign attempt (the action can update the file but cannot
+          # create the branch).
+          branch: 'cla-signatures'
+          # Renovate is the only bot that opens PRs here; without this it
+          # would be blocked on a signature a bot can never provide.
+          allowlist: renovate[bot]


### PR DESCRIPTION
## Summary

- Adds a `CLA Assistant` GitHub Actions workflow (`.github/workflows/cla.yml`) that enforces the contributor CLA (`CLA.md`, added in #287) on pull requests, using the `contributor-assistant/github-action` (CLA Assistant Lite), SHA-pinned to `v2.6.1`.
- Signatures are stored as `signatures/cla.json` on a dedicated, unprotected `cla-signatures` branch (already created on `origin` as an empty orphan branch so the action can write to it on first sign).
- `renovate[bot]` is allow-listed so dependency-update PRs aren't gated on a signature a bot can never provide.
- This is CI/config-only: no application code, dependencies, or database schema changed.

## Changes

- **`.github/workflows/cla.yml`** (new): triggers on `pull_request_target` (`opened`, `synchronize`, `closed`) and `issue_comment` (`created`), so the bot can post the sign prompt and react to the `I have read the CLA Document and I hereby sign the CLA` / `recheck` comments. Uses `pull_request_target` deliberately — the workflow never checks out PR code (the action only talks to the GitHub API), so it doesn't carry the usual risk of running untrusted code with elevated permissions. No path filter, unlike this repo's other PR workflows: CLA coverage has to apply to every PR, including docs-only ones, since the legal question is about the contribution, not the diff.
- Remote-only, non-diff change: pushed an empty orphan branch `cla-signatures` to `origin` to hold `signatures/cla.json`. The action can update the file on an existing branch but can't create the branch itself.

## Manual step required (cannot be done from this environment)

`main` currently has **no branch protection rules at all** (confirmed via `gh api repos/cwaits6/two42/branches/main/protection` → 404). This workflow makes the CLA status check *available*, but nothing will actually *block* an unsigned PR from merging until a maintainer:

1. Goes to **Settings → Branches → Add branch protection rule** for `main`.
2. Enables **Require status checks to pass before merging**.
3. Adds the **CLA Assistant** check (exact name visible in the Checks tab of the first PR this workflow runs on) to the required list.

Until that's done, treat this as "CLA prompt wired and self-service" rather than "CLA fully enforced."

## Trade-offs / notes

- `contributor-assistant/github-action` is archived upstream. It's SHA-pinned (`ca4a40a7d1004f18d9960b404b97e5f30a505a08` = `v2.6.1`, verified against the tag via `gh api`) and feature-complete for this use; swapping to a fork later is a one-line `uses:` change if needed.
- The `cla-signatures` branch must stay unprotected since the action commits to it directly via the API.

## Validation

- YAML parsed successfully (`js-yaml`); required keys (`name`, `on`, `permissions`, `jobs`) present.
- Action SHA pin verified against the `v2.6.1` tag via `gh api repos/contributor-assistant/github-action/commits/v2.6.1`.
- `cla-signatures` branch confirmed to exist on GitHub (`gh api repos/cwaits6/two42/branches/cla-signatures`).
- `npx tsc --noEmit` — pass (no app code touched).
- `npm run build` — pass, all routes compiled/prerendered.
- `npm run lint` fails, but this is a pre-existing, unrelated issue (a `brace-expansion@5.0.8` override conflicting with the transitive `minimatch@3.1.5` used by eslint), reproducible from a clean install off `main`. No workflow in this repo runs `npm run lint`, so it doesn't gate this change. Flagging as a separate follow-up for the maintainer.
- No `supabase/migrations/` changes; no application code changes.

Fixes #288


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Contributor License Agreement (CLA) checks for pull requests and CLA-related comments.
  * Contributor signatures are recorded and maintained automatically.
  * Configured trusted automated updates to pass the CLA workflow without manual intervention.

* **End-User Impact**
  * No changes to the product’s functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->