### PR TITLE
feat(tenancy): Phase 1 org spine — organizations, platform_admins, org_id (#210)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - main
-    paths:
+    paths: &semgrep_paths
       - '**'
       - '!**.md'
       - '!docs/**'
@@ -24,20 +24,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '**'
-      - '!**.md'
-      - '!docs/**'
-      - '!LICENSE'
-      - '!.claude/**'
-      - '!.agents/**'
-      - '!.archon/**'
-      - '!.zap/**'
-      - '!.coderabbit.yaml'
-      - '!renovate.json5'
-      - '!.releaserc.json'
-      - '!.gitignore'
-      - '!.env.example'
+    paths: *semgrep_paths
 
 permissions:
   contents: write

--- a/app/api/serving/broadcast/route.ts
+++ b/app/api/serving/broadcast/route.ts
@@ -6,6 +6,7 @@ import { getServingLinkMode } from "@/lib/serving/config";
 import { createServingToken } from "@/lib/serving/links";
 import { upcomingSundays } from "@/lib/serving/sundays";
 import { sendServingBroadcastEmail } from "@/lib/email/serving";
+import type { Profile } from "@/lib/types";
 
 /**
  * Leader "Email the team" broadcast: emails every team member the Sundays
@@ -96,15 +97,10 @@ export async function POST(request: Request) {
   const members = (memberRows ?? [])
     .map(
       (r) =>
-        r.profiles as unknown as {
-          id: string;
-          first_name: string | null;
-          last_name: string | null;
-          preferred_name: string | null;
-          email: string | null;
-          role: string;
-          email_announcements: boolean;
-        } | null
+        r.profiles as unknown as Pick<
+          Profile,
+          "id" | "first_name" | "last_name" | "preferred_name" | "email" | "role" | "email_announcements"
+        > | null
     )
     .filter(
       (p): p is NonNullable<typeof p> =>

--- a/app/api/serving/link-action/route.ts
+++ b/app/api/serving/link-action/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/server";
 import { displayName } from "@/lib/names";
+import { DEFAULT_ORG_ID } from "@/lib/org";
 import { getServingLinkMode } from "@/lib/serving/config";
 import { verifyServingToken } from "@/lib/serving/links";
 import { isValidServiceDate } from "@/lib/serving/sundays";
@@ -108,6 +109,10 @@ export async function POST(request: Request) {
         service_date: payload.d,
         family_id: profile.family_id,
         created_by: profile.id,
+        // Service-role insert: the fail-closed org_id DEFAULT resolves to
+        // NULL without a session, so the org is passed explicitly (Phase 1
+        // interim — see lib/org.ts).
+        org_id: DEFAULT_ORG_ID,
       })
       .select()
       .single();
@@ -125,7 +130,13 @@ export async function POST(request: Request) {
 
     const { error: attendeeError } = await service
       .from("serving_signup_attendees")
-      .insert(attendees.map((a) => ({ signup_id: signup.id, profile_id: a.id })));
+      .insert(
+        attendees.map((a) => ({
+          signup_id: signup.id,
+          profile_id: a.id,
+          org_id: DEFAULT_ORG_ID,
+        }))
+      );
     if (attendeeError) {
       console.error("Signed-link attendee insert failed:", attendeeError);
       await service.from("serving_signups").delete().eq("id", signup.id);

--- a/app/join/JoinForm.tsx
+++ b/app/join/JoinForm.tsx
@@ -7,6 +7,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent } from "@/components/ui/card";
 import { createClient } from "@/lib/supabase/client";
+import { DEFAULT_ORG_ID } from "@/lib/org";
 import { toast } from "sonner";
 import { useSearchParams } from "next/navigation";
 import { AuthShell } from "@/app/(auth)/_components/AuthShell";
@@ -35,6 +36,10 @@ function JoinFormFields() {
         name,
         email,
         message: message || null,
+        // Anon insert: the fail-closed org_id DEFAULT resolves to NULL
+        // without a session, so the org is passed explicitly (Phase 1
+        // interim — see lib/org.ts).
+        org_id: DEFAULT_ORG_ID,
         // Store the family invite token on the access request so that when
         // the user creates their account the family link can be established.
         ...(inviteToken ? { invite_token: inviteToken } : {}),

--- a/docs/design/DESIGN.md
+++ b/docs/design/DESIGN.md
@@ -71,7 +71,7 @@ Tokens come in two layers.
 
 **1. Product tokens — fixed.** Defined as CSS custom properties in `app/globals.css` (`@theme`): the Fraunces wordmark, shell chrome, structural neutrals, spacing, radii, and semantic colors. Not overridable by a tenant.
 
-**2. Tenant tokens — per-org (planned).** Not yet implemented — the schema/API and runtime below describe the intended design, not current behavior. The plan is to store these on an **`organizations.branding`** (jsonb) column:
+**2. Tenant tokens — per-org (planned).** The **`organizations.branding`** (jsonb) column exists in the schema (Phase 1, #210) but nothing reads or applies it yet — the API and runtime below describe the intended design, not current behavior:
 
 | Key | Meaning |
 |---|---|

--- a/lib/org.ts
+++ b/lib/org.ts
@@ -1,0 +1,12 @@
+/**
+ * Phase 1 interim (org spine, #210): the fixed UUID of the default
+ * organization all existing rows were backfilled to.
+ *
+ * The schema's fail-closed `org_id DEFAULT app_current_org_id()` resolves
+ * through auth.uid(), so write paths with no authenticated user — the anon
+ * join form and token-authenticated service-role flows — must pass this
+ * explicitly or their inserts violate NOT NULL. Phase 3 replaces these call
+ * sites with real org derivation from the validated token/row; this
+ * constant is deleted then.
+ */
+export const DEFAULT_ORG_ID = "00000000-0000-0000-0000-000000000001";

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -13,22 +13,33 @@ export type Database = {
         Row: {
           body: string
           id: boolean
+          org_id: string
           updated_at: string
           updated_by: string | null
         }
         Insert: {
           body?: string
           id?: boolean
+          org_id?: string
           updated_at?: string
           updated_by?: string | null
         }
         Update: {
           body?: string
           id?: boolean
+          org_id?: string
           updated_at?: string
           updated_by?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "about_page_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       access_requests: {
         Row: {
@@ -38,6 +49,7 @@ export type Database = {
           invite_token: string | null
           message: string | null
           name: string
+          org_id: string
           reviewed_at: string | null
           reviewed_by: string | null
           signup_token: string | null
@@ -51,6 +63,7 @@ export type Database = {
           invite_token?: string | null
           message?: string | null
           name: string
+          org_id?: string
           reviewed_at?: string | null
           reviewed_by?: string | null
           signup_token?: string | null
@@ -64,6 +77,7 @@ export type Database = {
           invite_token?: string | null
           message?: string | null
           name?: string
+          org_id?: string
           reviewed_at?: string | null
           reviewed_by?: string | null
           signup_token?: string | null
@@ -78,6 +92,13 @@ export type Database = {
             referencedRelation: "family_invites"
             referencedColumns: ["token"]
           },
+          {
+            foreignKeyName: "access_requests_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
         ]
       }
       announcements: {
@@ -87,6 +108,7 @@ export type Database = {
           created_at: string
           id: string
           is_published: boolean
+          org_id: string
           published_at: string | null
           title: string
         }
@@ -96,6 +118,7 @@ export type Database = {
           created_at?: string
           id?: string
           is_published?: boolean
+          org_id?: string
           published_at?: string | null
           title: string
         }
@@ -105,6 +128,7 @@ export type Database = {
           created_at?: string
           id?: string
           is_published?: boolean
+          org_id?: string
           published_at?: string | null
           title?: string
         }
@@ -123,6 +147,13 @@ export type Database = {
             referencedRelation: "profiles_directory"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "announcements_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
         ]
       }
       calendar_subscription_tokens: {
@@ -130,6 +161,7 @@ export type Database = {
           created_at: string
           expires_at: string
           id: string
+          org_id: string
           token_hash: string
           user_id: string
         }
@@ -137,6 +169,7 @@ export type Database = {
           created_at?: string
           expires_at: string
           id?: string
+          org_id?: string
           token_hash: string
           user_id: string
         }
@@ -144,10 +177,18 @@ export type Database = {
           created_at?: string
           expires_at?: string
           id?: string
+          org_id?: string
           token_hash?: string
           user_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "calendar_subscription_tokens_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "calendar_subscription_tokens_user_id_fkey"
             columns: ["user_id"]
@@ -169,6 +210,7 @@ export type Database = {
           bio: string
           created_at: string
           id: string
+          org_id: string
           profile_id: string
           sort_order: number
           title: string
@@ -177,6 +219,7 @@ export type Database = {
           bio?: string
           created_at?: string
           id?: string
+          org_id?: string
           profile_id: string
           sort_order?: number
           title?: string
@@ -185,11 +228,19 @@ export type Database = {
           bio?: string
           created_at?: string
           id?: string
+          org_id?: string
           profile_id?: string
           sort_order?: number
           title?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "class_teachers_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "class_teachers_profile_id_fkey"
             columns: ["profile_id"]
@@ -213,6 +264,7 @@ export type Database = {
           created_by: string | null
           id: string
           name: string
+          org_id: string
         }
         Insert: {
           color?: string | null
@@ -220,6 +272,7 @@ export type Database = {
           created_by?: string | null
           id?: string
           name: string
+          org_id?: string
         }
         Update: {
           color?: string | null
@@ -227,6 +280,7 @@ export type Database = {
           created_by?: string | null
           id?: string
           name?: string
+          org_id?: string
         }
         Relationships: [
           {
@@ -241,6 +295,13 @@ export type Database = {
             columns: ["created_by"]
             isOneToOne: false
             referencedRelation: "profiles_directory"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "event_calendars_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
             referencedColumns: ["id"]
           },
         ]
@@ -260,6 +321,7 @@ export type Database = {
           meeting_passcode: string | null
           meeting_show_on_dashboard: boolean
           meeting_url: string | null
+          org_id: string
           recurrence_count: number | null
           recurrence_end_mode: string | null
           recurrence_frequency: string | null
@@ -284,6 +346,7 @@ export type Database = {
           meeting_passcode?: string | null
           meeting_show_on_dashboard?: boolean
           meeting_url?: string | null
+          org_id?: string
           recurrence_count?: number | null
           recurrence_end_mode?: string | null
           recurrence_frequency?: string | null
@@ -308,6 +371,7 @@ export type Database = {
           meeting_passcode?: string | null
           meeting_show_on_dashboard?: boolean
           meeting_url?: string | null
+          org_id?: string
           recurrence_count?: number | null
           recurrence_end_mode?: string | null
           recurrence_frequency?: string | null
@@ -341,6 +405,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "events_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "events_series_id_fkey"
             columns: ["series_id"]
             isOneToOne: false
@@ -358,6 +429,7 @@ export type Database = {
           family_member_id: string
           id: string
           invite_email: string
+          org_id: string
           sent_at: string | null
           token: string
         }
@@ -369,6 +441,7 @@ export type Database = {
           family_member_id: string
           id?: string
           invite_email: string
+          org_id?: string
           sent_at?: string | null
           token?: string
         }
@@ -380,6 +453,7 @@ export type Database = {
           family_member_id?: string
           id?: string
           invite_email?: string
+          org_id?: string
           sent_at?: string | null
           token?: string
         }
@@ -412,6 +486,13 @@ export type Database = {
             referencedRelation: "family_members"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "family_invites_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
         ]
       }
       family_members: {
@@ -427,6 +508,7 @@ export type Database = {
           id: string
           is_class_member: boolean
           last_name: string | null
+          org_id: string
           preferred_name: string | null
           relationship: string
           updated_at: string
@@ -443,6 +525,7 @@ export type Database = {
           id?: string
           is_class_member?: boolean
           last_name?: string | null
+          org_id?: string
           preferred_name?: string | null
           relationship: string
           updated_at?: string
@@ -459,6 +542,7 @@ export type Database = {
           id?: string
           is_class_member?: boolean
           last_name?: string | null
+          org_id?: string
           preferred_name?: string | null
           relationship?: string
           updated_at?: string
@@ -485,6 +569,13 @@ export type Database = {
             referencedRelation: "family_units"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "family_members_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
         ]
       }
       family_units: {
@@ -498,6 +589,7 @@ export type Database = {
           hide_address: boolean
           hide_phone_home: boolean
           id: string
+          org_id: string
           phone_home: string | null
           photo_url: string | null
           postal_code: string | null
@@ -514,6 +606,7 @@ export type Database = {
           hide_address?: boolean
           hide_phone_home?: boolean
           id?: string
+          org_id?: string
           phone_home?: string | null
           photo_url?: string | null
           postal_code?: string | null
@@ -530,19 +623,29 @@ export type Database = {
           hide_address?: boolean
           hide_phone_home?: boolean
           id?: string
+          org_id?: string
           phone_home?: string | null
           photo_url?: string | null
           postal_code?: string | null
           state?: string | null
           updated_at?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "family_units_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       feedback: {
         Row: {
           created_at: string
           id: string
           message: string
+          org_id: string
           profile_id: string | null
           type: string
         }
@@ -550,6 +653,7 @@ export type Database = {
           created_at?: string
           id?: string
           message: string
+          org_id?: string
           profile_id?: string | null
           type: string
         }
@@ -557,10 +661,18 @@ export type Database = {
           created_at?: string
           id?: string
           message?: string
+          org_id?: string
           profile_id?: string | null
           type?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "feedback_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "feedback_profile_id_fkey"
             columns: ["profile_id"]
@@ -583,18 +695,21 @@ export type Database = {
           display_order: number
           fund_id: string
           method: string
+          org_id: string
         }
         Insert: {
           custom_handle: string
           display_order?: number
           fund_id: string
           method: string
+          org_id?: string
         }
         Update: {
           custom_handle?: string
           display_order?: number
           fund_id?: string
           method?: string
+          org_id?: string
         }
         Relationships: [
           {
@@ -602,6 +717,13 @@ export type Database = {
             columns: ["fund_id"]
             isOneToOne: false
             referencedRelation: "giving_funds"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "giving_fund_methods_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
             referencedColumns: ["id"]
           },
         ]
@@ -616,6 +738,7 @@ export type Database = {
           id: string
           is_active: boolean
           name: string
+          org_id: string
           retire_on: string | null
           steward_id: string
           steward_role: string | null
@@ -630,6 +753,7 @@ export type Database = {
           id?: string
           is_active?: boolean
           name: string
+          org_id?: string
           retire_on?: string | null
           steward_id: string
           steward_role?: string | null
@@ -644,6 +768,7 @@ export type Database = {
           id?: string
           is_active?: boolean
           name?: string
+          org_id?: string
           retire_on?: string | null
           steward_id?: string
           steward_role?: string | null
@@ -679,6 +804,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "giving_funds_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "giving_funds_steward_id_fkey"
             columns: ["steward_id"]
             isOneToOne: false
@@ -700,6 +832,7 @@ export type Database = {
           id: string
           is_archived: boolean
           name: string
+          org_id: string
           teacher: string | null
         }
         Insert: {
@@ -707,6 +840,7 @@ export type Database = {
           id?: string
           is_archived?: boolean
           name: string
+          org_id?: string
           teacher?: string | null
         }
         Update: {
@@ -714,9 +848,18 @@ export type Database = {
           id?: string
           is_archived?: boolean
           name?: string
+          org_id?: string
           teacher?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "lecture_series_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       lectures: {
         Row: {
@@ -725,6 +868,7 @@ export type Database = {
           description: string | null
           id: string
           lecture_date: string | null
+          org_id: string
           scripture_reference: string | null
           series_id: string | null
           summary: string | null
@@ -739,6 +883,7 @@ export type Database = {
           description?: string | null
           id?: string
           lecture_date?: string | null
+          org_id?: string
           scripture_reference?: string | null
           series_id?: string | null
           summary?: string | null
@@ -753,6 +898,7 @@ export type Database = {
           description?: string | null
           id?: string
           lecture_date?: string | null
+          org_id?: string
           scripture_reference?: string | null
           series_id?: string | null
           summary?: string | null
@@ -777,6 +923,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "lectures_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "lectures_series_id_fkey"
             columns: ["series_id"]
             isOneToOne: false
@@ -792,11 +945,13 @@ export type Database = {
           created_by: string | null
           description: string | null
           display_order: number
+          functional_role: string | null
           grants_prayer_access: boolean
           icon: string | null
           id: string
           is_serving_role: boolean
           name: string
+          org_id: string
           show_in_directory_filter: boolean
           updated_at: string
         }
@@ -806,11 +961,13 @@ export type Database = {
           created_by?: string | null
           description?: string | null
           display_order?: number
+          functional_role?: string | null
           grants_prayer_access?: boolean
           icon?: string | null
           id?: string
           is_serving_role?: boolean
           name: string
+          org_id?: string
           show_in_directory_filter?: boolean
           updated_at?: string
         }
@@ -820,15 +977,25 @@ export type Database = {
           created_by?: string | null
           description?: string | null
           display_order?: number
+          functional_role?: string | null
           grants_prayer_access?: boolean
           icon?: string | null
           id?: string
           is_serving_role?: boolean
           name?: string
+          org_id?: string
           show_in_directory_filter?: boolean
           updated_at?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "member_groups_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       organization_members: {
         Row: {
@@ -872,25 +1039,35 @@ export type Database = {
       }
       organizations: {
         Row: {
+          branding: Json
           created_at: string
           id: string
           name: string
+          slug: string
+          status: string
         }
         Insert: {
+          branding?: Json
           created_at?: string
           id?: string
           name: string
+          slug: string
+          status?: string
         }
         Update: {
+          branding?: Json
           created_at?: string
           id?: string
           name?: string
+          slug?: string
+          status?: string
         }
         Relationships: []
       }
       page_content: {
         Row: {
           body: string
+          org_id: string
           slug: string
           title: string
           updated_at: string
@@ -898,6 +1075,7 @@ export type Database = {
         }
         Insert: {
           body?: string
+          org_id?: string
           slug: string
           title: string
           updated_at?: string
@@ -905,10 +1083,34 @@ export type Database = {
         }
         Update: {
           body?: string
+          org_id?: string
           slug?: string
           title?: string
           updated_at?: string
           updated_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "page_content_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      platform_admins: {
+        Row: {
+          created_at: string
+          profile_id: string
+        }
+        Insert: {
+          created_at?: string
+          profile_id: string
+        }
+        Update: {
+          created_at?: string
+          profile_id?: string
         }
         Relationships: []
       }
@@ -922,6 +1124,7 @@ export type Database = {
           id: string
           join_url: string | null
           leader_id: string | null
+          org_id: string
           pin: string | null
           start_time: string
           updated_at: string
@@ -936,6 +1139,7 @@ export type Database = {
           id?: string
           join_url?: string | null
           leader_id?: string | null
+          org_id?: string
           pin?: string | null
           start_time: string
           updated_at?: string
@@ -950,6 +1154,7 @@ export type Database = {
           id?: string
           join_url?: string | null
           leader_id?: string | null
+          org_id?: string
           pin?: string | null
           start_time?: string
           updated_at?: string
@@ -977,6 +1182,13 @@ export type Database = {
             referencedRelation: "profiles_directory"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "prayer_call_sessions_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
         ]
       }
       prayer_requests: {
@@ -988,6 +1200,7 @@ export type Database = {
           id: string
           is_anonymous: boolean
           is_answered: boolean
+          org_id: string
           updated_at: string
           visible_to_warriors: boolean
         }
@@ -999,6 +1212,7 @@ export type Database = {
           id?: string
           is_anonymous?: boolean
           is_answered?: boolean
+          org_id?: string
           updated_at?: string
           visible_to_warriors?: boolean
         }
@@ -1010,6 +1224,7 @@ export type Database = {
           id?: string
           is_anonymous?: boolean
           is_answered?: boolean
+          org_id?: string
           updated_at?: string
           visible_to_warriors?: boolean
         }
@@ -1028,25 +1243,42 @@ export type Database = {
             referencedRelation: "profiles_directory"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "prayer_requests_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
         ]
       }
       prayer_responses: {
         Row: {
           created_at: string
+          org_id: string
           profile_id: string
           request_id: string
         }
         Insert: {
           created_at?: string
+          org_id?: string
           profile_id: string
           request_id: string
         }
         Update: {
           created_at?: string
+          org_id?: string
           profile_id?: string
           request_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "prayer_responses_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "prayer_responses_profile_id_fkey"
             columns: ["profile_id"]
@@ -1083,6 +1315,7 @@ export type Database = {
           assigned_by: string | null
           group_id: string
           is_leader: boolean
+          org_id: string
           profile_id: string
         }
         Insert: {
@@ -1090,6 +1323,7 @@ export type Database = {
           assigned_by?: string | null
           group_id: string
           is_leader?: boolean
+          org_id?: string
           profile_id: string
         }
         Update: {
@@ -1097,6 +1331,7 @@ export type Database = {
           assigned_by?: string | null
           group_id?: string
           is_leader?: boolean
+          org_id?: string
           profile_id?: string
         }
         Relationships: [
@@ -1105,6 +1340,13 @@ export type Database = {
             columns: ["group_id"]
             isOneToOne: false
             referencedRelation: "member_groups"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "profile_groups_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
             referencedColumns: ["id"]
           },
           {
@@ -1156,6 +1398,7 @@ export type Database = {
           is_unlisted: boolean
           last_name: string | null
           occupation: string | null
+          org_id: string
           phone: string | null
           phone_home: string | null
           phone_mobile: string | null
@@ -1200,6 +1443,7 @@ export type Database = {
           is_unlisted?: boolean
           last_name?: string | null
           occupation?: string | null
+          org_id?: string
           phone?: string | null
           phone_home?: string | null
           phone_mobile?: string | null
@@ -1244,6 +1488,7 @@ export type Database = {
           is_unlisted?: boolean
           last_name?: string | null
           occupation?: string | null
+          org_id?: string
           phone?: string | null
           phone_home?: string | null
           phone_mobile?: string | null
@@ -1278,6 +1523,13 @@ export type Database = {
             referencedRelation: "family_units"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "profiles_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
         ]
       }
       rsvps: {
@@ -1285,6 +1537,7 @@ export type Database = {
           created_at: string
           event_id: string
           id: string
+          org_id: string
           status: string
           user_id: string
         }
@@ -1292,6 +1545,7 @@ export type Database = {
           created_at?: string
           event_id: string
           id?: string
+          org_id?: string
           status: string
           user_id: string
         }
@@ -1299,6 +1553,7 @@ export type Database = {
           created_at?: string
           event_id?: string
           id?: string
+          org_id?: string
           status?: string
           user_id?: string
         }
@@ -1308,6 +1563,13 @@ export type Database = {
             columns: ["event_id"]
             isOneToOne: false
             referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rsvps_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
             referencedColumns: ["id"]
           },
           {
@@ -1332,6 +1594,7 @@ export type Database = {
           group_id: string
           id: string
           open_dates: string[]
+          org_id: string
           recipient_count: number
           sent_by: string | null
           subject: string
@@ -1341,6 +1604,7 @@ export type Database = {
           group_id: string
           id?: string
           open_dates?: string[]
+          org_id?: string
           recipient_count?: number
           sent_by?: string | null
           subject: string
@@ -1350,6 +1614,7 @@ export type Database = {
           group_id?: string
           id?: string
           open_dates?: string[]
+          org_id?: string
           recipient_count?: number
           sent_by?: string | null
           subject?: string
@@ -1360,6 +1625,13 @@ export type Database = {
             columns: ["group_id"]
             isOneToOne: false
             referencedRelation: "member_groups"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "serving_broadcasts_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
             referencedColumns: ["id"]
           },
           {
@@ -1380,18 +1652,28 @@ export type Database = {
       }
       serving_signup_attendees: {
         Row: {
+          org_id: string
           profile_id: string
           signup_id: string
         }
         Insert: {
+          org_id?: string
           profile_id: string
           signup_id: string
         }
         Update: {
+          org_id?: string
           profile_id?: string
           signup_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "serving_signup_attendees_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "serving_signup_attendees_profile_id_fkey"
             columns: ["profile_id"]
@@ -1422,6 +1704,7 @@ export type Database = {
           family_id: string | null
           group_id: string
           id: string
+          org_id: string
           service_date: string
         }
         Insert: {
@@ -1430,6 +1713,7 @@ export type Database = {
           family_id?: string | null
           group_id: string
           id?: string
+          org_id?: string
           service_date: string
         }
         Update: {
@@ -1438,6 +1722,7 @@ export type Database = {
           family_id?: string | null
           group_id?: string
           id?: string
+          org_id?: string
           service_date?: string
         }
         Relationships: [
@@ -1483,12 +1768,20 @@ export type Database = {
             referencedRelation: "member_groups"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "serving_signups_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
         ]
       }
       serving_team_settings: {
         Row: {
           enabled: boolean
           group_id: string
+          org_id: string
           reminder_days: number[]
           reminder_method: string
           updated_at: string
@@ -1498,6 +1791,7 @@ export type Database = {
         Insert: {
           enabled?: boolean
           group_id: string
+          org_id?: string
           reminder_days?: number[]
           reminder_method?: string
           updated_at?: string
@@ -1507,6 +1801,7 @@ export type Database = {
         Update: {
           enabled?: boolean
           group_id?: string
+          org_id?: string
           reminder_days?: number[]
           reminder_method?: string
           updated_at?: string
@@ -1521,12 +1816,20 @@ export type Database = {
             referencedRelation: "member_groups"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "serving_team_settings_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
         ]
       }
       site_settings: {
         Row: {
           is_public: boolean
           key: string
+          org_id: string
           updated_at: string | null
           updated_by: string | null
           value: string | null
@@ -1534,6 +1837,7 @@ export type Database = {
         Insert: {
           is_public?: boolean
           key: string
+          org_id?: string
           updated_at?: string | null
           updated_by?: string | null
           value?: string | null
@@ -1541,11 +1845,20 @@ export type Database = {
         Update: {
           is_public?: boolean
           key?: string
+          org_id?: string
           updated_at?: string | null
           updated_by?: string | null
           value?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "site_settings_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
       }
     }
     Views: {
@@ -1719,6 +2032,7 @@ export type Database = {
       }
     }
     Functions: {
+      app_current_org_id: { Args: never; Returns: string }
       current_family_id: { Args: never; Returns: string }
       get_own_email: { Args: never; Returns: string }
       get_own_role: { Args: never; Returns: string }
@@ -1732,6 +2046,7 @@ export type Database = {
       is_household_manager: { Args: never; Returns: boolean }
       is_member: { Args: never; Returns: boolean }
       is_org_member: { Args: { _org_id: string }; Returns: boolean }
+      is_platform_admin: { Args: never; Returns: boolean }
       is_prayer_warrior: { Args: never; Returns: boolean }
       provision_organization: {
         Args: { _name: string; _owner_id: string }

--- a/supabase/functions/send-serving-reminders/index.ts
+++ b/supabase/functions/send-serving-reminders/index.ts
@@ -19,6 +19,10 @@ const APP_NAME = Deno.env.get("APP_NAME") || "two42";
 const BRAND_COLOR = Deno.env.get("BRAND_COLOR") || "#B85C38";
 const SERVING_LINK_SECRET = Deno.env.get("SERVING_LINK_SECRET");
 const SERVING_LINK_MODE = Deno.env.get("SERVING_LINK_MODE") || "signed";
+// Phase 1 interim (org spine, #210): service-role inserts get NULL from the
+// fail-closed org_id DEFAULT, so the default org is passed explicitly.
+// Mirrors lib/org.ts; Phase 3 makes this function org-iterating.
+const DEFAULT_ORG_ID = "00000000-0000-0000-0000-000000000001";
 
 // ── HMAC token (same format as lib/serving/links.ts) ─────────────────────────
 
@@ -343,6 +347,7 @@ async function runMonthly(
     await supabase.from("serving_broadcasts").insert({
       group_id,
       sent_by: null,
+      org_id: DEFAULT_ORG_ID,
       subject: `${teamName}: monthly open-Sunday broadcast`,
       open_dates: openDates,
       recipient_count: teamSent,

--- a/supabase/migrations/20260730010000_org_spine.sql
+++ b/supabase/migrations/20260730010000_org_spine.sql
@@ -70,6 +70,8 @@ $$;
 
 grant execute on function public.app_current_org_id() to anon, authenticated, service_role;
 
+set check_function_bodies = on;  -- re-enable: the only forward-reference is above
+
 -- 4. org_id rollout. Per table: add nullable column, backfill to the
 -- default org, set the fail-closed default, set NOT NULL, FK, index.
 -- Never ADD COLUMN with the function default directly — the migration
@@ -258,8 +260,9 @@ alter table public.page_content add constraint page_content_pkey primary key (or
 -- code relying on slug alone being unique keeps working. Only one org
 -- exists today, so this is not yet a real restriction. Phase 2 drops it.
 alter table public.page_content add constraint page_content_slug_legacy_key unique (slug);
-
-create index page_content_org_id_idx on public.page_content (org_id);
+-- No standalone org_id index: page_content_pkey (org_id, slug) already
+-- serves org_id-only lookups via the leftmost-prefix rule (same treatment
+-- as profiles above).
 
 -- site_settings: PK key → (org_id, key).
 alter table public.site_settings add column org_id uuid;
@@ -271,8 +274,8 @@ alter table public.site_settings add constraint site_settings_org_id_fkey foreig
 alter table public.site_settings drop constraint site_settings_pkey;
 alter table public.site_settings add constraint site_settings_pkey primary key (org_id, key);
 alter table public.site_settings add constraint site_settings_key_legacy_key unique (key);
-
-create index site_settings_org_id_idx on public.site_settings (org_id);
+-- No standalone org_id index: site_settings_pkey (org_id, key) already
+-- serves org_id-only lookups via the leftmost-prefix rule.
 
 -- class_teachers: PK stays id; UNIQUE(profile_id) → UNIQUE(org_id, profile_id),
 -- old one kept (renamed) as the temporary legacy unique.
@@ -284,8 +287,9 @@ alter table public.class_teachers add constraint class_teachers_org_id_fkey fore
 
 alter table public.class_teachers rename constraint class_teachers_profile_id_key to class_teachers_profile_id_legacy_key;
 alter table public.class_teachers add constraint class_teachers_org_id_profile_id_key unique (org_id, profile_id);
-
-create index class_teachers_org_id_idx on public.class_teachers (org_id);
+-- No standalone org_id index: class_teachers_org_id_profile_id_key
+-- (org_id, profile_id) already serves org_id-only lookups via the
+-- leftmost-prefix rule.
 
 -- about_page: singleton; PK id (boolean CHECKed true) → (org_id, id).
 alter table public.about_page add column org_id uuid;
@@ -299,8 +303,8 @@ alter table public.about_page add constraint about_page_pkey primary key (org_id
 -- Legacy: id stays boolean CHECKed true, so this trivially still means
 -- "at most one about_page row in the whole table" until Phase 2 drops it.
 alter table public.about_page add constraint about_page_id_legacy_key unique (id);
-
-create index about_page_org_id_idx on public.about_page (org_id);
+-- No standalone org_id index: about_page_pkey (org_id, id) already serves
+-- org_id-only lookups via the leftmost-prefix rule.
 
 -- member_groups: plain org_id rollout plus re-adding functional_role.
 alter table public.member_groups add column org_id uuid;

--- a/supabase/migrations/20260730010000_org_spine.sql
+++ b/supabase/migrations/20260730010000_org_spine.sql
@@ -1,0 +1,400 @@
+-- Phase 1 tenancy org spine (CWA-8 / #210, decisions amended by #221;
+-- design pinned by .agents/plans/phase-2-rls-rewrite.md's Task 0 gate).
+-- Adds organizations columns + platform_admins, tags all 28 tenant tables
+-- with org_id (fail-closed default, backfilled to one synthetic org),
+-- re-scopes 4 tables' PK/uniques, re-adds member_groups.functional_role.
+-- No real church/member data is seeded — the default org below is
+-- synthetic per #221. Production behavior is unchanged: existing RLS
+-- policies are not modified in this phase (that's Phase 2).
+
+-- app_current_org_id() below reads profiles.org_id, a column this same
+-- migration adds later (the function must exist first so the org_id
+-- columns can reference it as their DEFAULT). Skip body validation at
+-- CREATE time; the body is exercised by the pgTAP suite and the
+-- fail-closed smoke check.
+set check_function_bodies = off;
+
+-- 1. Extend the Phase 0 organizations table (do NOT re-create it).
+alter table public.organizations
+  add column slug text,
+  add column branding jsonb not null default '{}'::jsonb,
+  add column status text not null default 'active';
+
+alter table public.organizations
+  add constraint organizations_status_check check (status in ('active', 'suspended'));
+
+update public.organizations set slug = 'default' where slug is null;
+alter table public.organizations alter column slug set not null;
+alter table public.organizations add constraint organizations_slug_key unique (slug);
+
+-- Synthetic default org. NEVER a real church/member identity (#221).
+-- Constant id referenced by every table's backfill below.
+insert into public.organizations (id, slug, name, branding, status)
+values ('00000000-0000-0000-0000-000000000001', 'default', 'Default Organization', '{}'::jsonb, 'active')
+on conflict (id) do nothing;
+
+-- 2. platform_admins: Two42-operator superusers, orthogonal to any org.
+-- References auth.users directly (not profiles) since profiles is now
+-- org-pinned and a platform admin isn't necessarily a member of any org.
+create table public.platform_admins (
+  profile_id uuid primary key references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now()
+);
+
+alter table public.platform_admins enable row level security;
+
+create or replace function public.is_platform_admin() returns boolean
+  language sql stable security definer set search_path = ''
+as $$
+  select exists (select 1 from public.platform_admins where profile_id = (select auth.uid()));
+$$;
+
+grant execute on function public.is_platform_admin() to anon, authenticated, service_role;
+
+create policy "platform admins can view platform admins" on public.platform_admins
+  for select using (( select public.is_platform_admin() ));
+-- No insert/update/delete policy: bootstrapping a platform admin is a
+-- migration/service-role-only operation, same treatment as
+-- provision_organization() in the Phase 0 scaffold.
+
+-- 3. app_current_org_id(): resolves via profiles.org_id (per the Phase 2
+-- plan's §3.1 — NOT organization_members). NULL when the caller has no
+-- profile row (service-role, or the instant before handle_new_user()'s
+-- own insert completes), which is exactly what makes
+-- org_id NOT NULL DEFAULT this function fail-closed.
+create or replace function public.app_current_org_id() returns uuid
+  language sql stable security definer set search_path = ''
+as $$
+  select org_id from public.profiles where id = (select auth.uid());
+$$;
+
+grant execute on function public.app_current_org_id() to anon, authenticated, service_role;
+
+-- 4. org_id rollout. Per table: add nullable column, backfill to the
+-- default org, set the fail-closed default, set NOT NULL, FK, index.
+-- Never ADD COLUMN with the function default directly — the migration
+-- role has no auth.uid(), so that would backfill every row to NULL and
+-- fail the NOT NULL step.
+
+alter table public.access_requests add column org_id uuid;
+update public.access_requests set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.access_requests alter column org_id set default public.app_current_org_id();
+alter table public.access_requests alter column org_id set not null;
+alter table public.access_requests add constraint access_requests_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index access_requests_org_id_idx on public.access_requests (org_id);
+
+alter table public.announcements add column org_id uuid;
+update public.announcements set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.announcements alter column org_id set default public.app_current_org_id();
+alter table public.announcements alter column org_id set not null;
+alter table public.announcements add constraint announcements_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index announcements_org_id_idx on public.announcements (org_id);
+
+alter table public.calendar_subscription_tokens add column org_id uuid;
+update public.calendar_subscription_tokens set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.calendar_subscription_tokens alter column org_id set default public.app_current_org_id();
+alter table public.calendar_subscription_tokens alter column org_id set not null;
+alter table public.calendar_subscription_tokens add constraint calendar_subscription_tokens_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index calendar_subscription_tokens_org_id_idx on public.calendar_subscription_tokens (org_id);
+
+alter table public.event_calendars add column org_id uuid;
+update public.event_calendars set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.event_calendars alter column org_id set default public.app_current_org_id();
+alter table public.event_calendars alter column org_id set not null;
+alter table public.event_calendars add constraint event_calendars_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index event_calendars_org_id_idx on public.event_calendars (org_id);
+
+alter table public.events add column org_id uuid;
+update public.events set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.events alter column org_id set default public.app_current_org_id();
+alter table public.events alter column org_id set not null;
+alter table public.events add constraint events_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index events_org_id_idx on public.events (org_id);
+
+alter table public.family_units add column org_id uuid;
+update public.family_units set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.family_units alter column org_id set default public.app_current_org_id();
+alter table public.family_units alter column org_id set not null;
+alter table public.family_units add constraint family_units_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index family_units_org_id_idx on public.family_units (org_id);
+
+alter table public.family_members add column org_id uuid;
+update public.family_members set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.family_members alter column org_id set default public.app_current_org_id();
+alter table public.family_members alter column org_id set not null;
+alter table public.family_members add constraint family_members_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index family_members_org_id_idx on public.family_members (org_id);
+
+alter table public.family_invites add column org_id uuid;
+update public.family_invites set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.family_invites alter column org_id set default public.app_current_org_id();
+alter table public.family_invites alter column org_id set not null;
+alter table public.family_invites add constraint family_invites_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index family_invites_org_id_idx on public.family_invites (org_id);
+
+alter table public.feedback add column org_id uuid;
+update public.feedback set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.feedback alter column org_id set default public.app_current_org_id();
+alter table public.feedback alter column org_id set not null;
+alter table public.feedback add constraint feedback_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index feedback_org_id_idx on public.feedback (org_id);
+
+alter table public.giving_fund_methods add column org_id uuid;
+update public.giving_fund_methods set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.giving_fund_methods alter column org_id set default public.app_current_org_id();
+alter table public.giving_fund_methods alter column org_id set not null;
+alter table public.giving_fund_methods add constraint giving_fund_methods_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index giving_fund_methods_org_id_idx on public.giving_fund_methods (org_id);
+
+alter table public.giving_funds add column org_id uuid;
+update public.giving_funds set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.giving_funds alter column org_id set default public.app_current_org_id();
+alter table public.giving_funds alter column org_id set not null;
+alter table public.giving_funds add constraint giving_funds_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index giving_funds_org_id_idx on public.giving_funds (org_id);
+
+alter table public.lecture_series add column org_id uuid;
+update public.lecture_series set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.lecture_series alter column org_id set default public.app_current_org_id();
+alter table public.lecture_series alter column org_id set not null;
+alter table public.lecture_series add constraint lecture_series_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index lecture_series_org_id_idx on public.lecture_series (org_id);
+
+alter table public.lectures add column org_id uuid;
+update public.lectures set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.lectures alter column org_id set default public.app_current_org_id();
+alter table public.lectures alter column org_id set not null;
+alter table public.lectures add constraint lectures_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index lectures_org_id_idx on public.lectures (org_id);
+
+alter table public.prayer_call_sessions add column org_id uuid;
+update public.prayer_call_sessions set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.prayer_call_sessions alter column org_id set default public.app_current_org_id();
+alter table public.prayer_call_sessions alter column org_id set not null;
+alter table public.prayer_call_sessions add constraint prayer_call_sessions_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index prayer_call_sessions_org_id_idx on public.prayer_call_sessions (org_id);
+
+alter table public.prayer_requests add column org_id uuid;
+update public.prayer_requests set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.prayer_requests alter column org_id set default public.app_current_org_id();
+alter table public.prayer_requests alter column org_id set not null;
+alter table public.prayer_requests add constraint prayer_requests_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index prayer_requests_org_id_idx on public.prayer_requests (org_id);
+
+alter table public.prayer_responses add column org_id uuid;
+update public.prayer_responses set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.prayer_responses alter column org_id set default public.app_current_org_id();
+alter table public.prayer_responses alter column org_id set not null;
+alter table public.prayer_responses add constraint prayer_responses_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index prayer_responses_org_id_idx on public.prayer_responses (org_id);
+
+alter table public.profile_groups add column org_id uuid;
+update public.profile_groups set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.profile_groups alter column org_id set default public.app_current_org_id();
+alter table public.profile_groups alter column org_id set not null;
+alter table public.profile_groups add constraint profile_groups_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index profile_groups_org_id_idx on public.profile_groups (org_id);
+
+alter table public.rsvps add column org_id uuid;
+update public.rsvps set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.rsvps alter column org_id set default public.app_current_org_id();
+alter table public.rsvps alter column org_id set not null;
+alter table public.rsvps add constraint rsvps_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index rsvps_org_id_idx on public.rsvps (org_id);
+
+alter table public.serving_broadcasts add column org_id uuid;
+update public.serving_broadcasts set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.serving_broadcasts alter column org_id set default public.app_current_org_id();
+alter table public.serving_broadcasts alter column org_id set not null;
+alter table public.serving_broadcasts add constraint serving_broadcasts_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index serving_broadcasts_org_id_idx on public.serving_broadcasts (org_id);
+
+alter table public.serving_signup_attendees add column org_id uuid;
+update public.serving_signup_attendees set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.serving_signup_attendees alter column org_id set default public.app_current_org_id();
+alter table public.serving_signup_attendees alter column org_id set not null;
+alter table public.serving_signup_attendees add constraint serving_signup_attendees_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index serving_signup_attendees_org_id_idx on public.serving_signup_attendees (org_id);
+
+alter table public.serving_signups add column org_id uuid;
+update public.serving_signups set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.serving_signups alter column org_id set default public.app_current_org_id();
+alter table public.serving_signups alter column org_id set not null;
+alter table public.serving_signups add constraint serving_signups_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index serving_signups_org_id_idx on public.serving_signups (org_id);
+
+alter table public.serving_team_settings add column org_id uuid;
+update public.serving_team_settings set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.serving_team_settings alter column org_id set default public.app_current_org_id();
+alter table public.serving_team_settings alter column org_id set not null;
+alter table public.serving_team_settings add constraint serving_team_settings_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+create index serving_team_settings_org_id_idx on public.serving_team_settings (org_id);
+
+-- profiles: same rollout, but upgrade the existing directory-listing index
+-- to be org_id-leading rather than adding a redundant plain org_id index.
+alter table public.profiles add column org_id uuid;
+update public.profiles set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.profiles alter column org_id set default public.app_current_org_id();
+alter table public.profiles alter column org_id set not null;
+alter table public.profiles add constraint profiles_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+
+drop index if exists public.profiles_last_first_idx;
+create index profiles_org_id_last_first_idx on public.profiles (org_id, last_name, first_name);
+
+-- 5. PK/unique re-scoping. Each keeps a temporary legacy global unique so
+-- current app onConflict targets keep working while only one org exists;
+-- Phase 2 (§3.5 / Task 9) drops them alongside the app upsert updates.
+
+-- page_content: PK slug → (org_id, slug).
+alter table public.page_content add column org_id uuid;
+update public.page_content set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.page_content alter column org_id set default public.app_current_org_id();
+alter table public.page_content alter column org_id set not null;
+alter table public.page_content add constraint page_content_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+
+alter table public.page_content drop constraint page_content_pkey;
+alter table public.page_content add constraint page_content_pkey primary key (org_id, slug);
+-- Temporary: preserves the pre-Phase-1 single-column uniqueness so any
+-- code relying on slug alone being unique keeps working. Only one org
+-- exists today, so this is not yet a real restriction. Phase 2 drops it.
+alter table public.page_content add constraint page_content_slug_legacy_key unique (slug);
+
+create index page_content_org_id_idx on public.page_content (org_id);
+
+-- site_settings: PK key → (org_id, key).
+alter table public.site_settings add column org_id uuid;
+update public.site_settings set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.site_settings alter column org_id set default public.app_current_org_id();
+alter table public.site_settings alter column org_id set not null;
+alter table public.site_settings add constraint site_settings_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+
+alter table public.site_settings drop constraint site_settings_pkey;
+alter table public.site_settings add constraint site_settings_pkey primary key (org_id, key);
+alter table public.site_settings add constraint site_settings_key_legacy_key unique (key);
+
+create index site_settings_org_id_idx on public.site_settings (org_id);
+
+-- class_teachers: PK stays id; UNIQUE(profile_id) → UNIQUE(org_id, profile_id),
+-- old one kept (renamed) as the temporary legacy unique.
+alter table public.class_teachers add column org_id uuid;
+update public.class_teachers set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.class_teachers alter column org_id set default public.app_current_org_id();
+alter table public.class_teachers alter column org_id set not null;
+alter table public.class_teachers add constraint class_teachers_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+
+alter table public.class_teachers rename constraint class_teachers_profile_id_key to class_teachers_profile_id_legacy_key;
+alter table public.class_teachers add constraint class_teachers_org_id_profile_id_key unique (org_id, profile_id);
+
+create index class_teachers_org_id_idx on public.class_teachers (org_id);
+
+-- about_page: singleton; PK id (boolean CHECKed true) → (org_id, id).
+alter table public.about_page add column org_id uuid;
+update public.about_page set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.about_page alter column org_id set default public.app_current_org_id();
+alter table public.about_page alter column org_id set not null;
+alter table public.about_page add constraint about_page_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+
+alter table public.about_page drop constraint about_page_pkey;
+alter table public.about_page add constraint about_page_pkey primary key (org_id, id);
+-- Legacy: id stays boolean CHECKed true, so this trivially still means
+-- "at most one about_page row in the whole table" until Phase 2 drops it.
+alter table public.about_page add constraint about_page_id_legacy_key unique (id);
+
+create index about_page_org_id_idx on public.about_page (org_id);
+
+-- member_groups: plain org_id rollout plus re-adding functional_role.
+alter table public.member_groups add column org_id uuid;
+update public.member_groups set org_id = '00000000-0000-0000-0000-000000000001' where org_id is null;
+alter table public.member_groups alter column org_id set default public.app_current_org_id();
+alter table public.member_groups alter column org_id set not null;
+alter table public.member_groups add constraint member_groups_org_id_fkey foreign key (org_id) references public.organizations(id) on delete cascade;
+
+create index member_groups_org_id_idx on public.member_groups (org_id);
+
+-- Re-added per .agents/plans/phase-2-rls-rewrite.md §6.2 — Phase 2's
+-- provision_organization() looks up specific groups by this key. No
+-- CHECK enum: the actual role names (prayer_warriors/serving_team/
+-- leaders proposed) are an open item for the maintainer, not decided
+-- here. Left NULL on all existing rows — assigning values is Phase 2's job.
+alter table public.member_groups add column functional_role text;
+
+create unique index member_groups_org_id_functional_role_key
+  on public.member_groups (org_id, functional_role)
+  where functional_role is not null;
+
+-- 6. provision_organization(): the Phase 0 stub inserts organizations
+-- rows with only a name, which now violates slug's NOT NULL. Still a
+-- test/seed-only stub (EXECUTE stays revoked from anon/authenticated per
+-- Phase 0); Phase 2 replaces it with real provisioning. Slug is derived
+-- from the name with a random suffix — fixture orgs only, never a real
+-- identity (#221).
+create or replace function public.provision_organization(_name text, _owner_id uuid)
+returns uuid
+language plpgsql security definer set search_path = ''
+as $$
+declare
+  _org_id uuid;
+begin
+  insert into public.organizations (name, slug)
+  values (
+    _name,
+    lower(regexp_replace(_name, '[^a-zA-Z0-9]+', '-', 'g'))
+      || '-' || left(gen_random_uuid()::text, 8)
+  )
+  returning id into _org_id;
+  insert into public.organization_members (org_id, profile_id) values (_org_id, _owner_id);
+  return _org_id;
+end;
+$$;
+
+-- 7. handle_new_user(): stamp new signups into the default org explicitly.
+-- The explicit org_id on the profiles INSERT bypasses the column DEFAULT,
+-- breaking the app_current_org_id() chicken-and-egg for a user's own first
+-- profile row. Interim, Phase-1-only version — Phase 2 (§5) replaces it
+-- with a fail-closed version that resolves org from approved
+-- access_requests/family_invites.
+create or replace function public.handle_new_user() returns trigger
+  language plpgsql security definer set search_path = ''
+as $$
+declare
+  _role text := 'pending';
+  _full_name text := new.raw_user_meta_data->>'full_name';
+  _first text;
+  _last text;
+  _default_org_id uuid := '00000000-0000-0000-0000-000000000001';
+begin
+  if exists (
+    select 1 from public.access_requests
+    where email = new.email
+      and status = 'approved'
+  ) then
+    _role := 'member';
+  end if;
+
+  if _full_name is not null and btrim(_full_name) <> '' then
+    if position(' ' in btrim(_full_name)) = 0 then
+      _first := btrim(_full_name);
+      _last := null;
+    else
+      _first := btrim(substring(btrim(_full_name) from 1 for (length(btrim(_full_name)) - position(' ' in reverse(btrim(_full_name))))));
+      _last := btrim(substring(btrim(_full_name) from (length(btrim(_full_name)) - position(' ' in reverse(btrim(_full_name))) + 2)));
+    end if;
+  end if;
+
+  insert into public.profiles (id, first_name, last_name, email, role, relationship, org_id)
+  values (new.id, _first, _last, new.email, _role, 'primary', _default_org_id);
+
+  insert into public.organization_members (org_id, profile_id)
+  values (_default_org_id, new.id)
+  on conflict do nothing;
+
+  return new;
+end;
+$$;
+
+-- Fail-closed verification (run manually after applying, not part of this
+-- migration): as the postgres/service-role role (no auth.uid()), attempt
+--   insert into public.event_calendars (name, color) values (...);
+-- without an explicit org_id. app_current_org_id() resolves to NULL
+-- (auth.uid() is NULL, so no profiles row matches), so the NOT NULL
+-- constraint on org_id must reject the insert.

--- a/supabase/migrations/20260730010000_org_spine.sql
+++ b/supabase/migrations/20260730010000_org_spine.sql
@@ -332,6 +332,12 @@ create unique index member_groups_org_id_functional_role_key
 -- Phase 0); Phase 2 replaces it with real provisioning. Slug is derived
 -- from the name with a random suffix — fixture orgs only, never a real
 -- identity (#221).
+-- Known limitation, intentional: this stub does NOT re-pin the owner's
+-- profiles.org_id, so app_current_org_id() for the owner keeps resolving
+-- to the org handle_new_user() stamped (the default org) — the leak suite
+-- asserts exactly that. Fixture org membership flows through
+-- organization_members / is_org_member() instead. Owner pinning belongs
+-- to Phase 2's real provisioning (CWA-9 §provision_organization).
 create or replace function public.provision_organization(_name text, _owner_id uuid)
 returns uuid
 language plpgsql security definer set search_path = ''

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -52,6 +52,6 @@ UPDATE public.profiles SET role = 'admin' WHERE id = 'a0000000-0000-0000-0000-00
 -- Dev-only starter group so the prayer wall's restricted-visibility flow is
 -- testable locally. Production deployments create their own groups at
 -- /admin/groups.
-INSERT INTO public.member_groups (id, name, description, color, icon, display_order, grants_prayer_access, is_serving_role)
-VALUES ('b0000000-0000-0000-0000-000000000001', 'Prayer Warriors', 'Sees prayer requests shared with prayer warriors', '#8A6BB5', 'shield', 0, true, true)
+INSERT INTO public.member_groups (id, org_id, name, description, color, icon, display_order, grants_prayer_access, is_serving_role)
+VALUES ('b0000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000001', 'Prayer Warriors', 'Sees prayer requests shared with prayer warriors', '#8A6BB5', 'shield', 0, true, true)
 ON CONFLICT (id) DO NOTHING;

--- a/supabase/tests/schema_tenancy_lint.sql
+++ b/supabase/tests/schema_tenancy_lint.sql
@@ -181,7 +181,11 @@ create temporary table org_id_wrong_default on commit drop as
       join pg_catalog.pg_namespace n on n.oid = c.relnamespace
       where n.nspname = 'public' and c.relname = t.table_name
         and a.attname = 'org_id'
-        and pg_get_expr(d.adbin, d.adrelid) <> 'app_current_org_id()'
+        -- pg_get_expr renders the call schema-qualified or not depending on
+        -- the session search_path; both spellings are the same function and
+        -- ONLY these two exact renderings are valid.
+        and pg_get_expr(d.adbin, d.adrelid) not in
+          ('app_current_org_id()', 'public.app_current_org_id()')
     );
 
 select is(
@@ -220,13 +224,34 @@ select throws_ok(
 -- the legacy unique (which current app onConflict targets still depend on)
 -- or lose the composite PK without a test catching it.
 select col_is_pk('public', 'page_content', array['org_id', 'slug'], 'page_content PK is (org_id, slug)');
-select has_unique('public', 'page_content', 'page_content retains a slug-only unique for legacy onConflict targets');
+select ok(
+  exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.page_content'::regclass
+      and conname = 'page_content_slug_legacy_key' and contype = 'u'
+  ),
+  'page_content retains the slug-only legacy unique for legacy onConflict targets'
+);
 
 select col_is_pk('public', 'site_settings', array['org_id', 'key'], 'site_settings PK is (org_id, key)');
-select has_unique('public', 'site_settings', 'site_settings retains a key-only unique for legacy onConflict targets');
+select ok(
+  exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.site_settings'::regclass
+      and conname = 'site_settings_key_legacy_key' and contype = 'u'
+  ),
+  'site_settings retains the key-only legacy unique for legacy onConflict targets'
+);
 
 select col_is_pk('public', 'about_page', array['org_id', 'id'], 'about_page PK is (org_id, id)');
-select has_unique('public', 'about_page', 'about_page retains an id-only unique (singleton guard)');
+select ok(
+  exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.about_page'::regclass
+      and conname = 'about_page_id_legacy_key' and contype = 'u'
+  ),
+  'about_page retains the id-only legacy unique (singleton guard)'
+);
 
 select col_is_pk('public', 'class_teachers', array['id'], 'class_teachers PK stays plain id');
 select ok(

--- a/supabase/tests/schema_tenancy_lint.sql
+++ b/supabase/tests/schema_tenancy_lint.sql
@@ -13,7 +13,7 @@
 
 begin;
 create extension if not exists pgtap with schema extensions;
-select plan(8);
+select plan(22);
 
 create temporary table tenancy_allowlist (table_name text primary key) on commit drop;
 insert into tenancy_allowlist (table_name) values
@@ -50,6 +50,16 @@ create table public.tenancy_probe_no_default (
 -- RLS enabled so this probe only trips the NOT NULL/DEFAULT checks it
 -- exists to exercise, not the unrelated RLS check above.
 alter table public.tenancy_probe_no_default enable row level security;
+
+-- Third negative-test probe (Phase 1): org_id is NOT NULL and HAS a
+-- default, so it passes the two checks above, but the default isn't
+-- app_current_org_id() — proving the wrong-default check below isn't
+-- vacuous.
+create table public.tenancy_probe_wrong_default (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null default gen_random_uuid()  -- deliberately wrong default
+);
+alter table public.tenancy_probe_wrong_default enable row level security;
 
 -- Each catalog scan is computed once here and reused by both the "clean"
 -- assertion (excludes the probe table) and the "lint actually flags
@@ -151,6 +161,125 @@ select isnt(
   (select count(*)::int from org_id_no_default),
   0,
   'lint DOES flag the injected no-default probe table when not excluded'
+);
+
+-- Phase 1 gate (tighter): org_id's DEFAULT must be app_current_org_id()
+-- specifically, not just "any non-null default" — org_id_no_default above
+-- would pass for a hardcoded UUID, gen_random_uuid(), or a copy-pasted
+-- wrong function just as easily.
+create temporary table org_id_wrong_default on commit drop as
+  select t.table_name
+  from information_schema.tables t
+  where t.table_schema = 'public' and t.table_type = 'BASE TABLE'
+    and t.table_name not in (select table_name from tenancy_allowlist)
+    and t.table_name <> 'organization_members'
+    and exists (
+      select 1
+      from pg_catalog.pg_attrdef d
+      join pg_catalog.pg_attribute a on a.attrelid = d.adrelid and a.attnum = d.adnum
+      join pg_catalog.pg_class c on c.oid = d.adrelid
+      join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+      where n.nspname = 'public' and c.relname = t.table_name
+        and a.attname = 'org_id'
+        and pg_get_expr(d.adbin, d.adrelid) <> 'app_current_org_id()'
+    );
+
+select is(
+  (select count(*)::int from org_id_wrong_default where table_name <> 'tenancy_probe_wrong_default'),
+  0,
+  'every non-allowlisted table''s org_id DEFAULT is app_current_org_id() specifically'
+);
+
+select isnt(
+  (select count(*)::int from org_id_wrong_default),
+  0,
+  'lint DOES flag the injected wrong-default probe table when not excluded'
+);
+
+-- Fail-closed runtime check: as the postgres/service-role role (no
+-- auth.uid(), matching this file's own execution context), an org_id-less
+-- insert on a representative plain-rollout table and a representative
+-- PK-rescoped table must both be rejected, not silently misrouted.
+select throws_ok(
+  $$ insert into public.event_calendars (name) values ('tenancy-lint-probe') $$,
+  '23502',
+  null,
+  'service-role insert into a plain org_id-rollout table is rejected without explicit org_id'
+);
+
+select throws_ok(
+  $$ insert into public.page_content (slug, title, body) values ('tenancy-lint-probe-slug', 'Probe', 'x') $$,
+  '23502',
+  null,
+  'service-role insert into a PK-rescoped table is rejected without explicit org_id'
+);
+
+-- PK/unique re-scoping (Review Focus Area #2): confirm the new composite
+-- PK and the retained legacy single-column unique both actually exist for
+-- each of the 4 re-scoped tables, so a later migration can't silently drop
+-- the legacy unique (which current app onConflict targets still depend on)
+-- or lose the composite PK without a test catching it.
+select col_is_pk('public', 'page_content', array['org_id', 'slug'], 'page_content PK is (org_id, slug)');
+select has_unique('public', 'page_content', 'page_content retains a slug-only unique for legacy onConflict targets');
+
+select col_is_pk('public', 'site_settings', array['org_id', 'key'], 'site_settings PK is (org_id, key)');
+select has_unique('public', 'site_settings', 'site_settings retains a key-only unique for legacy onConflict targets');
+
+select col_is_pk('public', 'about_page', array['org_id', 'id'], 'about_page PK is (org_id, id)');
+select has_unique('public', 'about_page', 'about_page retains an id-only unique (singleton guard)');
+
+select col_is_pk('public', 'class_teachers', array['id'], 'class_teachers PK stays plain id');
+select ok(
+  exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.class_teachers'::regclass
+      and conname = 'class_teachers_org_id_profile_id_key' and contype = 'u'
+  ),
+  'class_teachers has (org_id, profile_id) unique'
+);
+select ok(
+  exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.class_teachers'::regclass
+      and conname = 'class_teachers_profile_id_legacy_key' and contype = 'u'
+  ),
+  'class_teachers retains the renamed legacy profile_id-only unique'
+);
+
+-- Backfill correctness (Review Focus Area #3), data level: every existing
+-- row on every org_id-bearing, non-allowlisted table must have landed on
+-- the constant default-org UUID, not just "non-null" (which the earlier
+-- checks already cover). Requires dynamic SQL since this inspects row
+-- data, not catalog metadata, per table.
+create temporary table org_id_bad_backfill (table_name text) on commit drop;
+do $$
+declare
+  t text;
+  bad_count bigint;
+begin
+  for t in
+    select ts.table_name from information_schema.tables ts
+    where ts.table_schema = 'public' and ts.table_type = 'BASE TABLE'
+      and ts.table_name not in (select table_name from tenancy_allowlist)
+      and exists (
+        select 1 from information_schema.columns c
+        where c.table_schema = 'public' and c.table_name = ts.table_name
+          and c.column_name = 'org_id'
+      )
+  loop
+    execute format(
+      'select count(*) from public.%I where org_id <> %L::uuid', t, '00000000-0000-0000-0000-000000000001'
+    ) into bad_count;
+    if bad_count > 0 then
+      insert into org_id_bad_backfill values (t);
+    end if;
+  end loop;
+end $$;
+
+select is(
+  (select count(*)::int from org_id_bad_backfill),
+  0,
+  'every org_id-bearing, non-allowlisted table has all existing rows backfilled to the default org'
 );
 
 select * from finish();

--- a/supabase/tests/schema_tenancy_lint.sql
+++ b/supabase/tests/schema_tenancy_lint.sql
@@ -1,8 +1,8 @@
--- CI schema lint (CWA-7 / #209, Phase 0): every public base table must have
--- RLS enabled AND an org_id column, unless explicitly allowlisted below.
--- The allowlist covers every table that predates multi-tenancy and has not
--- yet been migrated to carry org_id. Remove entries as each table gains
--- org_id in later CWA-7 phases — an empty allowlist is the end goal.
+-- CI schema lint (CWA-7 / #209, Phase 0; extended for CWA-8 / #210, Phase 1):
+-- every public base table must have RLS enabled AND an org_id column that is
+-- NOT NULL with a DEFAULT, unless explicitly allowlisted below.
+-- Remove entries as each table gains org_id in later CWA-7 phases — an empty
+-- allowlist is the end goal.
 --
 -- Run locally (rollback-safe, never mutates the shared local stack):
 --
@@ -13,25 +13,19 @@
 
 begin;
 create extension if not exists pgtap with schema extensions;
-select plan(4);
+select plan(8);
 
 create temporary table tenancy_allowlist (table_name text primary key) on commit drop;
 insert into tenancy_allowlist (table_name) values
-  ('about_page'), ('access_requests'), ('announcements'),
-  ('calendar_subscription_tokens'), ('class_teachers'), ('event_calendars'),
-  ('events'), ('family_units'), ('family_members'), ('profiles'),
-  ('family_invites'), ('feedback'), ('giving_fund_methods'), ('giving_funds'),
-  ('lecture_series'), ('lectures'), ('member_groups'), ('page_content'),
-  ('prayer_call_sessions'), ('prayer_requests'), ('prayer_responses'),
-  ('profile_groups'), ('rsvps'), ('serving_broadcasts'),
-  ('serving_signup_attendees'), ('serving_signups'), ('serving_team_settings'),
-  ('site_settings'),
   -- Phase 0 scaffold: organizations is the tenant root table, so it has no
   -- org_id column by design (RLS is already enabled, so only the org_id
   -- check needs this exemption). organization_members already carries both
   -- org_id and RLS, so it's deliberately NOT allowlisted — it's the working
-  -- example of the target end state and should stay under lint coverage:
+  -- example of the target end state and should stay under lint coverage.
+  -- platform_admins is likewise org-orthogonal by design (Phase 1): it holds
+  -- Two42-operator superusers who aren't pinned to any org:
   ('organizations'),
+  ('platform_admins'),
   -- In-flight on another branch, present on the shared local stack only;
   -- does not exist in CI's ephemeral database built from this branch:
   ('payment_handles');
@@ -45,6 +39,17 @@ insert into tenancy_allowlist (table_name) values
 create table public.tenancy_probe_violation (
   id uuid primary key default gen_random_uuid()
 );
+
+-- Second negative-test probe (Phase 1): HAS an org_id column, so it passes
+-- the presence check above, but the column is deliberately nullable with no
+-- default — proving the NOT NULL and DEFAULT checks below aren't vacuous.
+create table public.tenancy_probe_no_default (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid  -- deliberately nullable, no default
+);
+-- RLS enabled so this probe only trips the NOT NULL/DEFAULT checks it
+-- exists to exercise, not the unrelated RLS check above.
+alter table public.tenancy_probe_no_default enable row level security;
 
 -- Each catalog scan is computed once here and reused by both the "clean"
 -- assertion (excludes the probe table) and the "lint actually flags
@@ -93,6 +98,59 @@ select isnt(
   (select count(*)::int from org_id_missing),
   0,
   'lint DOES flag the injected no-org_id probe table when not excluded'
+);
+
+-- Phase 1 gate: org_id must be NOT NULL and carry a DEFAULT (fail-closed
+-- app_current_org_id()) on every non-allowlisted table that has the column.
+create temporary table org_id_nullable on commit drop as
+  select t.table_name
+  from information_schema.tables t
+  where t.table_schema = 'public' and t.table_type = 'BASE TABLE'
+    and t.table_name not in (select table_name from tenancy_allowlist)
+    and exists (
+      select 1 from information_schema.columns c
+      where c.table_schema = 'public' and c.table_name = t.table_name
+        and c.column_name = 'org_id' and c.is_nullable = 'YES'
+    );
+
+create temporary table org_id_no_default on commit drop as
+  select t.table_name
+  from information_schema.tables t
+  where t.table_schema = 'public' and t.table_type = 'BASE TABLE'
+    and t.table_name not in (select table_name from tenancy_allowlist)
+    -- organization_members is a membership join table: org_id is half its
+    -- natural key and must always be named explicitly by the caller
+    -- (provision_organization, handle_new_user) — a fail-closed DEFAULT
+    -- makes no sense there. It stays covered by every other check.
+    and t.table_name <> 'organization_members'
+    and exists (
+      select 1 from information_schema.columns c
+      where c.table_schema = 'public' and c.table_name = t.table_name
+        and c.column_name = 'org_id' and c.column_default is null
+    );
+
+select is(
+  (select count(*)::int from org_id_nullable where table_name <> 'tenancy_probe_no_default'),
+  0,
+  'every non-allowlisted table''s org_id column is NOT NULL'
+);
+
+select isnt(
+  (select count(*)::int from org_id_nullable),
+  0,
+  'lint DOES flag the injected nullable-org_id probe table when not excluded'
+);
+
+select is(
+  (select count(*)::int from org_id_no_default where table_name <> 'tenancy_probe_no_default'),
+  0,
+  'every non-allowlisted table''s org_id column has a DEFAULT'
+);
+
+select isnt(
+  (select count(*)::int from org_id_no_default),
+  0,
+  'lint DOES flag the injected no-default probe table when not excluded'
 );
 
 select * from finish();

--- a/supabase/tests/tenancy_leak_suite.sql
+++ b/supabase/tests/tenancy_leak_suite.sql
@@ -118,6 +118,54 @@ begin
     select ok(is_member_own, 'is_org_member() is true for org A member''s own org');
   insert into tenancy_leak_results
     select ok(not is_member_other, 'is_org_member() is false for org A member checking org B');
+
+  insert into tenancy_leak_results
+    select is(
+      (select org_id from public.profiles where id = user_a),
+      '00000000-0000-0000-0000-000000000001'::uuid,
+      'handle_new_user() stamps new signups into the default org'
+    );
+
+  insert into tenancy_leak_results
+    select ok(
+      exists (
+        select 1 from public.organization_members
+        where org_id = '00000000-0000-0000-0000-000000000001'::uuid and profile_id = user_a
+      ),
+      'handle_new_user() inserts the matching organization_members row'
+    );
+end $$;
+
+-- platform_admins RLS (new Phase 1 primitive): a platform admin can see
+-- their own roster row; a non-admin (including a regular org member) can
+-- see none. No bootstrap path exists yet to populate this table in normal
+-- operation, but the policy is reachable the moment a row is seeded.
+do $$
+declare
+  admin_user uuid := gen_random_uuid();
+  plain_user uuid := gen_random_uuid();
+  admin_visible_count int;
+  plain_visible_count int;
+begin
+  insert into auth.users (id, email) values
+    (admin_user, 'platform-admin-fixture@example.test'),
+    (plain_user, 'plain-fixture@example.test');
+  insert into public.platform_admins (profile_id) values (admin_user);
+
+  set local role authenticated;
+
+  perform set_config('request.jwt.claims', json_build_object('sub', admin_user)::text, true);
+  select count(*) into admin_visible_count from public.platform_admins;
+
+  perform set_config('request.jwt.claims', json_build_object('sub', plain_user)::text, true);
+  select count(*) into plain_visible_count from public.platform_admins;
+
+  reset role;
+
+  insert into tenancy_leak_results
+    select ok(admin_visible_count = 1, 'a platform admin can see platform_admins rows');
+  insert into tenancy_leak_results
+    select ok(plain_visible_count = 0, 'a non-admin cannot see platform_admins rows');
 end $$;
 
 select line from tenancy_leak_results;


### PR DESCRIPTION
## Summary

Phase 1 of the multi-tenancy rearchitecture (#210, decisions amended by #221; Linear CWA-8). Database-only — zero app-code changes.

- **`organizations`** (Phase 0 scaffold) gains `slug` (UNIQUE, NOT NULL), `branding jsonb`, `status` (`active`/`suspended`), plus exactly one synthetic `'default'` org at the fixed constant UUID `00000000-0000-0000-0000-000000000001`. No real church/member identity is seeded, per #221.
- **`platform_admins`** + `is_platform_admin()` — org-orthogonal operator table, RLS-enabled, no self-service write path (bootstrap is migration/service-role-only, same treatment as `provision_organization()`).
- **`app_current_org_id()`** — resolves via `profiles.org_id`, `SECURITY DEFINER`, `search_path = ''`. Returns NULL for service-role/no-profile callers.
- **`org_id uuid NOT NULL DEFAULT app_current_org_id()`** on all 28 tenant tables, backfilled to the default org, FK'd to `organizations(id) on delete cascade`, org_id-leading indexed (`profiles` upgrades its directory index to `(org_id, last_name, first_name)` instead of adding a redundant one).
- **Fail-closed**: service-role inserts without an explicit `org_id` violate NOT NULL (verified manually — see below).
- **Re-scoped keys** with temporary legacy global uniques kept so current app `onConflict` targets keep working (dropped later per the Phase 2 plan §3.5/Task 9):
  - `page_content`: PK `(org_id, slug)` + legacy `UNIQUE(slug)`
  - `site_settings`: PK `(org_id, key)` + legacy `UNIQUE(key)`
  - `about_page`: PK `(org_id, id)` + legacy `UNIQUE(id)` (preserves the global singleton)
  - `class_teachers`: `UNIQUE(org_id, profile_id)` + legacy `UNIQUE(profile_id)` (renamed)
- **`member_groups.functional_role` re-added** (text, nullable, deliberately no CHECK enum — the role names are an open item for the maintainer) with partial unique `(org_id, functional_role) WHERE functional_role IS NOT NULL`. Left NULL on all existing rows; assigning values is Phase 2's `provision_organization()` job.
- **`handle_new_user()`** stamps new signups into the default org (`profiles.org_id` set explicitly, bypassing the column default, breaking the chicken-and-egg) and inserts the matching `organization_members` row. Interim, Phase-1-only version.
- **`provision_organization()`** (Phase 0 test stub) updated to generate a slug — the new `slug NOT NULL` otherwise breaks the leak suite's fixtures.
- **`schema_tenancy_lint.sql`** extended to the Phase 1 gate: allowlist shrunk to `organizations`/`platform_admins`/`payment_handles`, new NOT NULL + DEFAULT assertions with a second negative probe (8 assertions total).

## Reviewer notes

1. **The `app_current_org_id()` / `handle_new_user()` design intentionally matches what `.agents/plans/phase-2-rls-rewrite.md`'s Task 0 gate assumes** (function body per that plan's §3.1, `member_groups.functional_role` present, legacy uniques per §3.5). That plan lives on the `archon/task-assist-cwa-9-phase-2-plan` branch (commit 50732a1).
2. **`tenancy_leak_suite.sql` remains intentionally vacuous**: it now auto-discovers all 28 org_id tables and passes 32/32, but org B holds zero rows in tenant tables, so it doesn't yet prove isolation. Real RLS org-scoping and fixture completeness are Phase 2 (its plan's §9.1 owns this).
3. `organization_members.org_id` is carved out of the lint's DEFAULT check (not the others): it's half the natural PK of a membership join table and is always set explicitly — a fail-closed default there makes no sense.
4. `supabase/schema.sql` is deliberately not regenerated here — the shared local stack carries another in-flight branch's objects (`payment_handles`, an altered `giving_fund_methods.custom_handle`), and CI refreshes the dump post-merge. The committed `database.types.ts` was pruned of those same two shared-stack artifacts so it matches what CI generates from this branch's migrations.
5. Pre-existing, unrelated: `npm run lint` currently crashes on every file (`TypeError: expand is not a function`) because the committed lockfile pairs `minimatch@3.1.5` with only a hoisted `brace-expansion@5.0.8` (likely from deps PR #294). Not introduced by this PR.

## Verification (local shared stack, per CLAUDE.md rules)

- `supabase migration up --db-url …54322…` applies cleanly; 28 tables carry `org_id`
- `schema_tenancy_lint.sql`: **8/8 ok**
- `tenancy_leak_suite.sql`: **32/32 ok** (see note 2)
- Fail-closed: `insert into public.event_calendars (name, color) values (…)` as the `postgres` role → `null value in column "org_id" … violates not-null constraint` ✅
- Signup smoke test (rollback-safe): new `auth.users` row → profile with `org_id = …0001`, role `pending`, matching `organization_members` row ✅
- `npx tsc --noEmit` ✅, `npm run build` ✅
- No remote Supabase commands were run at any point

Fixes #210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added foundational organization-based data separation across content, events, profiles, giving, serving, and other areas.
  * Added organization details including slugs, branding, and active or suspended status.
  * Added platform administrator support and automatic assignment of new accounts to the default organization.

* **Bug Fixes**
  * Improved safeguards to prevent data from being accessed across organizations.

* **Documentation**
  * Clarified that organization branding integration remains planned and inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->