### PR TITLE
fix(functions): resolve service key from platform-injected env vars

### DIFF
--- a/docs/security/service-role-inventory.md
+++ b/docs/security/service-role-inventory.md
@@ -31,9 +31,11 @@ PR, with the justification and the tenancy risk.**
 ## Edge Functions (2 sites)
 
 Both are cron-triggered with no session context and resolve the service key
-from platform-injected env vars (`SUPABASE_SECRET_KEY` override →
-`SUPABASE_SECRET_KEYS` map → legacy `SUPABASE_SERVICE_ROLE_KEY`; see
-`resolveServiceKey()` in each function), not `createServiceClient()`.
+from configured environment variables: a manual `SUPABASE_SECRET_KEY` override
+(local/self-host only — the hosted platform reserves the prefix), then the
+platform-injected `SUPABASE_SECRET_KEYS` map, then the legacy
+`SUPABASE_SERVICE_ROLE_KEY` (see `resolveServiceKey()` in each function), not
+`createServiceClient()`.
 
 | File | Why service-role is used | Tenancy risk once org_id lands | Mitigation |
 |------|--------------------------|--------------------------------|------------|

--- a/docs/security/service-role-inventory.md
+++ b/docs/security/service-role-inventory.md
@@ -30,8 +30,10 @@ PR, with the justification and the tenancy risk.**
 
 ## Edge Functions (2 sites)
 
-Both are cron-triggered with no session context and use the `SUPABASE_SECRET_KEY`
-env var directly (Deno pattern), not `createServiceClient()`.
+Both are cron-triggered with no session context and resolve the service key
+from platform-injected env vars (`SUPABASE_SECRET_KEY` override →
+`SUPABASE_SECRET_KEYS` map → legacy `SUPABASE_SERVICE_ROLE_KEY`; see
+`resolveServiceKey()` in each function), not `createServiceClient()`.
 
 | File | Why service-role is used | Tenancy risk once org_id lands | Mitigation |
 |------|--------------------------|--------------------------------|------------|

--- a/supabase/functions/send-event-reminders/index.ts
+++ b/supabase/functions/send-event-reminders/index.ts
@@ -18,11 +18,23 @@ function resolveServiceKey(): string {
   if (direct) return direct;
   const map = Deno.env.get("SUPABASE_SECRET_KEYS");
   if (map) {
-    const keys = JSON.parse(map) as Record<string, string>;
-    const key = keys["default"] ?? Object.values(keys)[0];
-    if (key) return key;
+    try {
+      const parsed: unknown = JSON.parse(map);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const keys = parsed as Record<string, unknown>;
+        const key = keys["default"] ?? Object.values(keys)[0];
+        if (typeof key === "string" && key) return key;
+      }
+      console.error("SUPABASE_SECRET_KEYS has no usable key; falling back");
+    } catch {
+      console.error("SUPABASE_SECRET_KEYS is not valid JSON; falling back");
+    }
   }
-  return Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const legacy = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (typeof legacy === "string" && legacy) return legacy;
+  throw new Error(
+    "No service key found: expected SUPABASE_SECRET_KEY, SUPABASE_SECRET_KEYS, or SUPABASE_SERVICE_ROLE_KEY"
+  );
 }
 const SUPABASE_SECRET_KEY = resolveServiceKey();
 const SITE_URL = Deno.env.get("SITE_URL") || "https://incouragers.org";

--- a/supabase/functions/send-event-reminders/index.ts
+++ b/supabase/functions/send-event-reminders/index.ts
@@ -7,7 +7,24 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY")!;
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
-const SUPABASE_SECRET_KEY = Deno.env.get("SUPABASE_SECRET_KEY")!;
+// Service key resolution. The platform reserves the SUPABASE_ prefix for
+// its own injected vars, so SUPABASE_SECRET_KEY can never be set manually
+// via `supabase secrets set`: on hosted projects with new-style API keys it
+// arrives as the JSON map SUPABASE_SECRET_KEYS (keyed by key name, "default"
+// unless renamed); legacy projects and the local CLI stack inject
+// SUPABASE_SERVICE_ROLE_KEY instead.
+function resolveServiceKey(): string {
+  const direct = Deno.env.get("SUPABASE_SECRET_KEY");
+  if (direct) return direct;
+  const map = Deno.env.get("SUPABASE_SECRET_KEYS");
+  if (map) {
+    const keys = JSON.parse(map) as Record<string, string>;
+    const key = keys["default"] ?? Object.values(keys)[0];
+    if (key) return key;
+  }
+  return Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+}
+const SUPABASE_SECRET_KEY = resolveServiceKey();
 const SITE_URL = Deno.env.get("SITE_URL") || "https://incouragers.org";
 const EMAIL_FROM = Deno.env.get("EMAIL_FROM") || "two42 <noreply@incouragers.org>";
 const BRAND_COLOR = Deno.env.get("BRAND_COLOR") || "#B85C38";

--- a/supabase/functions/send-serving-reminders/index.ts
+++ b/supabase/functions/send-serving-reminders/index.ts
@@ -12,7 +12,24 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY")!;
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
-const SUPABASE_SECRET_KEY = Deno.env.get("SUPABASE_SECRET_KEY")!;
+// Service key resolution. The platform reserves the SUPABASE_ prefix for
+// its own injected vars, so SUPABASE_SECRET_KEY can never be set manually
+// via `supabase secrets set`: on hosted projects with new-style API keys it
+// arrives as the JSON map SUPABASE_SECRET_KEYS (keyed by key name, "default"
+// unless renamed); legacy projects and the local CLI stack inject
+// SUPABASE_SERVICE_ROLE_KEY instead.
+function resolveServiceKey(): string {
+  const direct = Deno.env.get("SUPABASE_SECRET_KEY");
+  if (direct) return direct;
+  const map = Deno.env.get("SUPABASE_SECRET_KEYS");
+  if (map) {
+    const keys = JSON.parse(map) as Record<string, string>;
+    const key = keys["default"] ?? Object.values(keys)[0];
+    if (key) return key;
+  }
+  return Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+}
+const SUPABASE_SECRET_KEY = resolveServiceKey();
 const SITE_URL = Deno.env.get("SITE_URL") || "https://incouragers.org";
 const EMAIL_FROM = Deno.env.get("EMAIL_FROM") || "two42 <noreply@incouragers.org>";
 const APP_NAME = Deno.env.get("APP_NAME") || "two42";

--- a/supabase/functions/send-serving-reminders/index.ts
+++ b/supabase/functions/send-serving-reminders/index.ts
@@ -23,11 +23,23 @@ function resolveServiceKey(): string {
   if (direct) return direct;
   const map = Deno.env.get("SUPABASE_SECRET_KEYS");
   if (map) {
-    const keys = JSON.parse(map) as Record<string, string>;
-    const key = keys["default"] ?? Object.values(keys)[0];
-    if (key) return key;
+    try {
+      const parsed: unknown = JSON.parse(map);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const keys = parsed as Record<string, unknown>;
+        const key = keys["default"] ?? Object.values(keys)[0];
+        if (typeof key === "string" && key) return key;
+      }
+      console.error("SUPABASE_SECRET_KEYS has no usable key; falling back");
+    } catch {
+      console.error("SUPABASE_SECRET_KEYS is not valid JSON; falling back");
+    }
   }
-  return Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const legacy = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (typeof legacy === "string" && legacy) return legacy;
+  throw new Error(
+    "No service key found: expected SUPABASE_SECRET_KEY, SUPABASE_SECRET_KEYS, or SUPABASE_SERVICE_ROLE_KEY"
+  );
 }
 const SUPABASE_SECRET_KEY = resolveServiceKey();
 const SITE_URL = Deno.env.get("SITE_URL") || "https://incouragers.org";


### PR DESCRIPTION
## Summary

Discovered while wiring up the reminder pipeline (CWA-41): `supabase secrets set SUPABASE_SECRET_KEY=…` is rejected by the platform (`Env name cannot start with SUPABASE_`), and the runtime never injects that singular name — so both edge functions would crash with an undefined key on their first real invocation.

Per the [edge function secrets docs](https://supabase.com/docs/guides/functions/secrets), the platform injects:
- `SUPABASE_SECRET_KEYS` — a JSON map keyed by API-key name (projects on new-style keys)
- `SUPABASE_SERVICE_ROLE_KEY` — legacy projects and the local CLI stack

Both functions now resolve the service key through all three forms: direct env override → `SUPABASE_SECRET_KEYS` map (preferring the `default`-named key) → `SUPABASE_SERVICE_ROLE_KEY`. The resolver tolerates malformed or non-map `SUPABASE_SECRET_KEYS` values (falling through to the legacy key) and throws a clear configuration error at boot when no key is found. The edge-function section of `docs/security/service-role-inventory.md` is updated to match.

## Validation

- `deno check` reports the identical 13 pre-existing errors on this branch and on unmodified `main` (untyped supabase-js client generics) — no new errors introduced.
- Resolver logic unit-tested against 9 scenarios (valid map, renamed key, malformed JSON, JSON array, empty/non-string entries, direct-override precedence, both no-key throw paths).
- No schema, migration, or app changes.

## Post-merge

Nothing to do — since #301, CI deploys both functions on merge to `main` (`.github/workflows/supabase.yml`), and the hosted platform injects `SUPABASE_SECRET_KEYS` automatically, so no secrets need to be set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event and serving reminder delivery reliability by supporting multiple credential configurations.
  * Added fallback handling for direct, hosted, and legacy service credentials.
  * Added clearer error handling when credentials are invalid or unavailable.
  * Reminder services now select available credentials in a consistent order, reducing setup-related failures.

* **Documentation**
  * Documented the supported credential resolution order for reminder services.
  * Clarified supported configuration options and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
