### PR TITLE
chore(deps): scope brace-expansion override by major

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5532,6 +5532,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/conf": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
@@ -9128,6 +9135,24 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/minimist": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,11 @@
   "overrides": {
     "flatted": "^3.4.0",
     "serialize-javascript": "^7.0.3",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion@1": "^1.1.12",
+    "brace-expansion@2": "^2.0.2",
+    "brace-expansion@3": "^3.0.1",
+    "brace-expansion@4": "^4.0.1",
+    "brace-expansion@5": "^5.0.8",
     "fast-uri": "^4.0.0",
     "postcss": "^8.5.18",
     "sharp": "^0.35.0"


### PR DESCRIPTION
## Problem

`npm run lint` has been crashing on `main` before evaluating a single rule, which is why every recent PR review carries a "Known issue: ESLint is broken on `main`" note:

```
ESLint: 9.39.5
TypeError: expand is not a function
    at Minimatch.braceExpand (node_modules/minimatch/minimatch.js:271:10)
```

`package.json` pinned a blanket `overrides["brace-expansion"]: "^5.0.8"`, which forces v5 onto **every** consumer in the tree. `minimatch@3.1.5` (reached via `eslint` → `@eslint/config-array`) declares `^1.1.7` and does `require('brace-expansion')`, expecting a callable default export. v5 exports named bindings only, so the call blows up.

The stale `node_modules` on most machines masked this — a fresh `npm ci` reproduces it every time.

## Fix

Scope the override per major so each consumer keeps an API-compatible version, while every major stays above the CVE-2025-5889 ReDoS floor (patched in 1.1.12 / 2.0.2 / 3.0.1 / 4.0.1):

```json
"brace-expansion@1": "^1.1.12",
"brace-expansion@2": "^2.0.2",
"brace-expansion@3": "^3.0.1",
"brace-expansion@4": "^4.0.1",
"brace-expansion@5": "^5.0.8",
```

The security pin is preserved, not relaxed — no reachable version in the tree is vulnerable.

## Resulting tree

```
├─┬ eslint@9.39.5
│ └─┬ minimatch@3.1.5
│   └── brace-expansion@1.1.18 overridden
├─┬ eslint-config-next@16.2.12 → typescript-eslint → minimatch@10.2.5
│   └── brace-expansion@5.0.8 overridden
└─┬ shadcn@4.x → ts-morph → minimatch@10.2.5
    └── brace-expansion@5.0.8 deduped
```

## Verification

- Reproduced the crash from a clean `npm ci` on `main`, confirmed it is gone on this branch.
- `npm run lint` → clean, 1 pre-existing warning (`lib/org.ts:45` unused `_host`), 0 errors.
- `npm run build` → passes.
- `npm audit` → unchanged from `main` (2 pre-existing moderate, `@hono/node-server` via `@modelcontextprotocol/sdk`, unrelated).
- Lockfile diff is +25 lines, additions only, no unrelated version bumps. Regenerated with npm 11 to match the lockfile's existing metadata format.

No runtime/app code is touched — dev tooling only, so this is a `chore(deps)` and does not trigger a release.