### PR TITLE
feat(tenancy): app-layer org resolution + public per-org join route

### DIFF
--- a/app/[orgSlug]/join/page.tsx
+++ b/app/[orgSlug]/join/page.tsx
@@ -1,0 +1,53 @@
+import { redirect } from "next/navigation";
+import { siteConfig } from "@/lib/config";
+import { isValidOrgSlug, resolveRequestOrgId } from "@/lib/org";
+import { getOptionalUser } from "@/lib/supabase/current-user";
+import { createClient } from "@/lib/supabase/server";
+import { JoinForm } from "@/app/join/JoinForm";
+import { JoinUnavailable } from "@/app/join/JoinUnavailable";
+
+interface PageProps {
+  params: Promise<{ orgSlug: string }>;
+}
+
+export const metadata = { title: `Request Access | ${siteConfig.name}` };
+
+export default async function OrgJoinPage({ params }: PageProps) {
+  const { orgSlug } = await params;
+
+  // Signed-in members are already in an org — there's nothing to request, and
+  // app_request_org_id() would ignore the slug and return their own org
+  // anyway. Send them to the app before any resolution happens.
+  if (await getOptionalUser()) {
+    redirect("/dashboard");
+  }
+
+  // Shape-check before the slug reaches an HTTP header. Route params arrive
+  // URL-decoded, so a %0d%0a payload would otherwise reach undici as a raw
+  // header value and throw a 500 instead of taking the fail-closed path.
+  // The pattern is the DB's own (provision_organization()), so anything it
+  // rejects could never have been minted as an org slug.
+  if (!isValidOrgSlug(orgSlug)) {
+    console.error("Org join page: rejected malformed org slug %s", orgSlug);
+    return <JoinUnavailable />;
+  }
+
+  // The URL slug — not the host/env slug — is the org this request is about.
+  // app_request_org_id() validates it against a real organizations row and
+  // returns NULL otherwise, which is the fail-closed path below. It grants
+  // nothing: the header only ever selects among orgs' already-public content.
+  const supabase = await createClient(orgSlug);
+  const orgId = await resolveRequestOrgId(supabase, {
+    label: "Org join page",
+    orgSlug,
+  });
+
+  // Both failure modes (RPC error, NULL result) land here. Never a fallback
+  // org. The render is identical to the unresolvable-org case on purpose —
+  // a distinct message would be an org-existence oracle.
+  if (!orgId) {
+    return <JoinUnavailable />;
+  }
+
+  return <JoinForm orgId={orgId} orgSlug={orgSlug} />;
+}

--- a/app/join/JoinForm.tsx
+++ b/app/join/JoinForm.tsx
@@ -11,10 +11,10 @@ import { toast } from "sonner";
 import { useSearchParams } from "next/navigation";
 import { AuthShell } from "@/app/(auth)/_components/AuthShell";
 
-function JoinFormFields({ orgId }: { orgId: string }) {
+function JoinFormFields({ orgId, orgSlug }: { orgId: string; orgSlug?: string }) {
   const [loading, setLoading] = useState(false);
   const [submitted, setSubmitted] = useState(false);
-  const supabase = createClient();
+  const supabase = createClient(orgSlug);
   const searchParams = useSearchParams();
 
   // Pre-fill when coming from a family invite link
@@ -38,7 +38,10 @@ function JoinFormFields({ orgId }: { orgId: string }) {
         // Anon insert: the fail-closed org_id DEFAULT resolves to NULL
         // without a session, so the org is passed explicitly — resolved
         // server-side from the same app_request_org_id() the RLS WITH CHECK
-        // evaluates (see app/join/page.tsx).
+        // evaluates (see app/join/page.tsx). The browser client above sends
+        // the same x-two42-org the page resolved from, so this org_id and
+        // the WITH CHECK cannot disagree — on /join that's the env slug, on
+        // /[orgSlug]/join the URL slug.
         org_id: orgId,
         // Store the family invite token on the access request so that when
         // the user creates their account the family link can be established.
@@ -143,7 +146,7 @@ function JoinFormFields({ orgId }: { orgId: string }) {
   );
 }
 
-export function JoinForm({ orgId }: { orgId: string }) {
+export function JoinForm({ orgId, orgSlug }: { orgId: string; orgSlug?: string }) {
   return (
     <Suspense fallback={
       <div className="container mx-auto px-4 py-12 max-w-lg">
@@ -154,7 +157,7 @@ export function JoinForm({ orgId }: { orgId: string }) {
         </Card>
       </div>
     }>
-      <JoinFormFields orgId={orgId} />
+      <JoinFormFields orgId={orgId} orgSlug={orgSlug} />
     </Suspense>
   );
 }

--- a/app/join/JoinUnavailable.tsx
+++ b/app/join/JoinUnavailable.tsx
@@ -1,0 +1,25 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+/**
+ * The fail-closed render for both `/join` and `/[orgSlug]/join`. It is
+ * deliberately identical for "org exists but is unresolvable" and "slug
+ * matches no org" — a distinguishing message would be an org-existence
+ * oracle (same reasoning as app/serving/go/page.tsx).
+ */
+export function JoinUnavailable() {
+  return (
+    <div className="container mx-auto px-4 py-20 max-w-lg text-center">
+      <Card className="p-8">
+        <CardContent className="pt-6">
+          <h1 className="text-3xl font-bold text-brand-primary mb-4">
+            Join requests unavailable
+          </h1>
+          <p className="text-lg text-muted-foreground">
+            This site isn&apos;t accepting join requests right now — please
+            contact your group admin.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/join/family/[token]/page.tsx
+++ b/app/join/family/[token]/page.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import { siteConfig } from "@/lib/config";
-import { resolveOrgSlug } from "@/lib/org";
+import { resolveOrgSlug, resolveRequestOrgId } from "@/lib/org";
 import { AuthShell } from "@/app/(auth)/_components/AuthShell";
 
 interface PageProps {
@@ -24,19 +24,10 @@ export default async function FamilyJoinPage({ params }: PageProps) {
   // way it is the same value the downstream access_requests RLS WITH CHECK
   // compares against, and NULL fails closed below.
   const requestClient = await createClient();
-  const { data: resolvedOrg, error: orgError } = await requestClient.rpc("app_request_org_id");
-  const requestOrgId = typeof resolvedOrg === "string" ? resolvedOrg : null;
-  if (orgError) {
-    console.error("Family join page: org resolution failed:", orgError);
-  } else if (!requestOrgId) {
-    // The RPC succeeded but returned NULL — the resolved slug matches no
-    // organization row. orgError stays null in this path, so without this
-    // log this redirect is indistinguishable from an ordinary invalid token.
-    console.error(
-      "Family join page: org resolution returned NULL for slug %s",
-      resolveOrgSlug()
-    );
-  }
+  const requestOrgId = await resolveRequestOrgId(requestClient, {
+    label: "Family join page",
+    orgSlug: resolveOrgSlug(),
+  });
 
   // Fail closed — same destination the invalid-token branch uses.
   if (!requestOrgId) {

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -1,9 +1,9 @@
 import { redirect } from "next/navigation";
-import { Card, CardContent } from "@/components/ui/card";
-import { resolveOrgSlug } from "@/lib/org";
+import { resolveOrgSlug, resolveRequestOrgId } from "@/lib/org";
 import { getOptionalUser } from "@/lib/supabase/current-user";
 import { createClient } from "@/lib/supabase/server";
 import { JoinForm } from "./JoinForm";
+import { JoinUnavailable } from "./JoinUnavailable";
 
 export default async function JoinPage() {
   // Signed-in members are already in the group — there's nothing to request, so
@@ -15,40 +15,19 @@ export default async function JoinPage() {
   // Resolve the request's org through the same app_request_org_id() the
   // access_requests RLS WITH CHECK evaluates — the server client sends the
   // x-two42-org header that the helper reads, so the value the form inserts
-  // is by construction the value the policy compares against.
+  // is by construction the value the policy compares against. The slug here
+  // is for the log message only; the client keeps its own host/env mapping.
+  const orgSlug = resolveOrgSlug();
   const supabase = await createClient();
-  const { data: resolvedOrg, error: orgError } = await supabase.rpc("app_request_org_id");
-  const orgId = typeof resolvedOrg === "string" ? resolvedOrg : null;
-  if (orgError) {
-    console.error("Join page: org resolution failed:", orgError);
-  } else if (!orgId) {
-    // The RPC succeeded but returned NULL — the resolved slug matches no
-    // organization row. orgError stays null in this path, so without this
-    // log the entire public join funnel goes down with zero operator signal.
-    console.error(
-      "Join page: org resolution returned NULL for slug %s",
-      resolveOrgSlug()
-    );
-  }
+  const orgId = await resolveRequestOrgId(supabase, {
+    label: "Join page",
+    orgSlug,
+  });
 
   // Without a resolvable org every submission would fail closed with a bare
   // 42501 — show a real message instead of a form that can only error.
   if (!orgId) {
-    return (
-      <div className="container mx-auto px-4 py-20 max-w-lg text-center">
-        <Card className="p-8">
-          <CardContent className="pt-6">
-            <h1 className="text-3xl font-bold text-brand-primary mb-4">
-              Join requests unavailable
-            </h1>
-            <p className="text-lg text-muted-foreground">
-              This site isn&apos;t accepting join requests right now — please
-              contact your group admin.
-            </p>
-          </CardContent>
-        </Card>
-      </div>
-    );
+    return <JoinUnavailable />;
   }
 
   return <JoinForm orgId={orgId} />;

--- a/docs/security/service-role-inventory.md
+++ b/docs/security/service-role-inventory.md
@@ -34,6 +34,12 @@ error and a NULL result (a slug matching no organization row) are each
 logged, then the family-invite page redirects to `/join` and the join form
 renders a "Join requests unavailable" notice instead of a form whose every
 submission would die on a bare `42501`. Neither falls back to an org.
+Since Phase 4b (CWA-48 / #314) that fail-closed resolution is the single
+`resolveRequestOrgId()` in `lib/org.ts` — the RPC call, the NULL narrowing,
+and the dual fail-closed logging live in one place. The public per-org route
+`app/[orgSlug]/join` uses the same helper (with the URL slug overriding the
+`x-two42-org` header on both the request and browser clients) and adds
+**no** service-role client, so it needs no row in the tables below.
 
 One lookup is deliberately unscoped: the initial `signup_token` read in
 `app/api/auth/consume-token/route.ts` and `app/api/auth/verify-token/route.ts`,

--- a/docs/security/tenancy-model.md
+++ b/docs/security/tenancy-model.md
@@ -40,7 +40,13 @@ Rules that make these safe:
   to Phase 3 and must be gated on `auth.role() = 'service_role'`.
 - Every app Supabase client (server, browser, middleware) sends
   `x-two42-org` from `resolveOrgSlug()` in `lib/org.ts` — a trivial
-  host-independent mapping until Phase 5 custom domains.
+  host-independent mapping until Phase 5 custom domains. The one exception:
+  the public per-org routes (`app/[orgSlug]/join`) pass the URL slug
+  explicitly to `createClient(orgSlug)` on **both** the server and browser
+  clients. The DB still validates that slug against a real `organizations`
+  row and still ignores it for authenticated principals, so the trust model
+  is unchanged — the header grants nothing, it only selects which org's
+  already-public surface an anonymous request is about.
 
 Also, `org_id` on every org-owned table is `NOT NULL DEFAULT
 app_current_org_id()`: a write with no session and no explicit org violates

--- a/lib/org.ts
+++ b/lib/org.ts
@@ -1,3 +1,12 @@
+// Type-only import — erased at compile time. resolveRequestOrgId() takes the
+// client as a PARAMETER, never constructs one: this module is reachable from
+// the client bundle (lib/supabase/client.ts → app/join/JoinForm.tsx, a
+// "use client" module). Importing @/lib/supabase/server here — statically or
+// via await import() — would pull next/headers into the client graph and
+// break `npm run build`, and would close an import cycle
+// (lib/supabase/server.ts already imports this file).
+import type { SupabaseClient } from "@supabase/supabase-js";
+
 /**
  * Phase 2 (CWA-9 / #211): slug sent as the `x-two42-org` header on every
  * Supabase client, so anonymous requests resolve an org via
@@ -24,4 +33,49 @@ export const DEFAULT_ORG_SLUG = "default";
  */
 export function resolveOrgSlug(_host?: string | null): string {
   return process.env.NEXT_PUBLIC_ORG_SLUG || DEFAULT_ORG_SLUG;
+}
+
+/**
+ * Mirrors the regex provision_organization() enforces on the DB side, so the
+ * app can never route to a slug the DB would refuse to mint. `{1,62}` means
+ * minimum TWO characters total — that is the DB's rule, not a typo.
+ */
+export const ORG_SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{1,62}$/;
+
+export function isValidOrgSlug(slug: string): boolean {
+  return ORG_SLUG_PATTERN.test(slug);
+}
+
+/**
+ * Phase 4b (CWA-48 / #314): the single implementation of the fail-closed
+ * org-resolution guard both anonymous entry points (`/join`,
+ * `/join/family/[token]`) and the per-org route (`/[orgSlug]/join`) rely on.
+ * Resolves the request's org via app_request_org_id() — the same value the
+ * access_requests RLS WITH CHECK evaluates — and returns NULL on either
+ * failure mode (RPC error, or a slug matching no organization row), logging
+ * both so the public funnel never goes down with zero operator signal.
+ */
+export async function resolveRequestOrgId(
+  client: SupabaseClient,
+  opts: { label: string; orgSlug: string }
+): Promise<string | null> {
+  const { data, error } = await client.rpc("app_request_org_id");
+  // The generated type claims Returns: string, but the SQL function
+  // returns NULL whenever neither a principal nor the header resolves.
+  // This narrowing is the only thing catching that lying type — do not
+  // replace it with a non-null assertion.
+  const orgId = typeof data === "string" ? data : null;
+  if (error) {
+    console.error("%s: org resolution failed:", opts.label, error);
+  } else if (!orgId) {
+    // The RPC succeeded but returned NULL — the resolved slug matches no
+    // organization row. `error` stays null in this path, so without this
+    // log the public funnel goes down with zero operator signal.
+    console.error(
+      "%s: org resolution returned NULL for slug %s",
+      opts.label,
+      opts.orgSlug
+    );
+  }
+  return orgId;
 }

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,7 +1,7 @@
 import { createBrowserClient } from "@supabase/ssr";
 import { resolveOrgSlug } from "@/lib/org";
 
-export function createClient() {
+export function createClient(orgSlug?: string) {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
@@ -10,11 +10,17 @@ export function createClient() {
       // this header the anon join form's insert would fail closed —
       // app_request_org_id() would resolve no org. Authenticated sessions
       // ignore it (the principal's own org always wins).
+      // `orgSlug` is the explicit override used by the public per-org routes
+      // (app/[orgSlug]/join): the anon insert goes browser → PostgREST
+      // directly, so the browser client must send the same URL slug the page
+      // resolved server-side or the RLS WITH CHECK rejects every submit.
       global: {
         headers: {
-          "x-two42-org": resolveOrgSlug(
-            typeof window !== "undefined" ? window.location.host : null
-          ),
+          "x-two42-org":
+            orgSlug ??
+            resolveOrgSlug(
+              typeof window !== "undefined" ? window.location.host : null
+            ),
         },
       },
     }

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -2,7 +2,7 @@ import { createServerClient } from "@supabase/ssr";
 import { cookies, headers } from "next/headers";
 import { resolveOrgSlug } from "@/lib/org";
 
-export async function createClient() {
+export async function createClient(orgSlug?: string) {
   const cookieStore = await cookies();
   const headerStore = await headers();
 
@@ -13,8 +13,13 @@ export async function createClient() {
       // Org resolution for anonymous reads (Phase 2, CWA-9): the DB's
       // app_request_org_id() reads this header only when there is no
       // authenticated principal, and only to select among public content.
+      // `orgSlug` is the explicit override used by the public per-org routes
+      // (app/[orgSlug]/join): there the org is addressed by URL, not by host.
+      // Everything else keeps the host-derived (today: env-pinned) mapping.
       global: {
-        headers: { "x-two42-org": resolveOrgSlug(headerStore.get("host")) },
+        headers: {
+          "x-two42-org": orgSlug ?? resolveOrgSlug(headerStore.get("host")),
+        },
       },
       cookies: {
         getAll() {


### PR DESCRIPTION
## Summary

Phase 4b of the multi-tenancy work, in three parts:

1. **`refactor`** — Extract the duplicated fail-closed org-resolution guard out of the two `app/join/**` pages into a single `resolveRequestOrgId()` in `lib/org.ts`.
2. **`feat`** — Add the public per-org join route `app/[orgSlug]/join`, so an anonymous visitor can reach a specific org's access-request form by URL instead of relying on the host/env slug mapping.
3. **Verification only** — Confirm the signed-link cancel path already derives `org_id` from validated context (see "About `Closes #312`" below).

No migrations, no new `createServiceClient()` sites, no test files.

Closes #314
Closes #312

### About `Closes #312`

**This PR contains no code change for #312.** The issue was already fixed by `5e11b44` — *fix(tenancy): derive org_id from validated context at every app service-role call site* (#306). `app/api/serving/link-action/route.ts` already passes `orgId: group.org_id` to `notifyLeadersOfCancel` and `group.org_id` to `resolveSignupLabel`, and `notifyLeadersOfCancel` now requires `orgId: string`, so omitting it is a type error. The marker comment the issue describes does not exist in the tree (`grep -rn "CWA-46\|#312" app lib` → no matches). `git diff --stat main -- app/api/serving/link-action/route.ts` is empty, deliberately — a fabricated no-op diff would make the issue look fixed by the wrong PR.

### #213 / CWA-11 is only partially advanced — leave it open

This delivers the **join half** of the public-routes checkbox. Published per-org public pages (`/{orgSlug}/pages/[slug]`), the anon tightening of `site_settings.is_public` / announcements to member-only, and the CWA-11 hard gate (leak + IDOR suites in CI, storage verification) are all still outstanding. #213 should stay open.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `lib/org.ts` | UPDATE | Adds `ORG_SLUG_PATTERN`, `isValidOrgSlug()`, and `resolveRequestOrgId()` — the single implementation of the RPC call, the NULL narrowing, and the dual fail-closed logging |
| `app/join/JoinUnavailable.tsx` | CREATE | The shared "Join requests unavailable" render, extracted verbatim from `app/join/page.tsx` |
| `app/join/page.tsx` | UPDATE | Consumes the helper and the shared component |
| `app/join/family/[token]/page.tsx` | UPDATE | Consumes the helper; the service-role `family_invites` read keeps its `.eq("org_id", requestOrgId)` |
| `lib/supabase/server.ts` | UPDATE | Optional `orgSlug` override for the `x-two42-org` header; `createServiceClient` untouched |
| `lib/supabase/client.ts` | UPDATE | Same override on the **browser** client |
| `app/join/JoinForm.tsx` | UPDATE | Optional `orgSlug` prop, threaded to the browser client |
| `app/[orgSlug]/join/page.tsx` | CREATE | The public per-org join route |
| `docs/security/tenancy-model.md` | UPDATE | The claim that every client derives the header from the host was incomplete once the per-org routes pass the URL slug |
| `docs/security/service-role-inventory.md` | UPDATE | Points the Phase 3 narrative at the single helper; records that the new route adds no service-role client (**no new table row**) |
| `app/api/serving/link-action/route.ts` | **VERIFY ONLY** | No diff — see above |

### Security-relevant details

These are load-bearing, not incidental:

- **The URL slug grants nothing.** `app_request_org_id()` validates it against a real `organizations` row and returns NULL otherwise; an authenticated principal always resolves to their own org and the header is ignored. It only selects *which* org's already-public surface an anonymous request is about.
- **Both failure modes fail closed.** An RPC error and a NULL result each log and render `JoinUnavailable`. Never a fallback org.
- **No `notFound()` for an unknown slug.** A malformed slug, an unknown slug, and an RPC error all render the identical page — a distinguishing response would be an org-existence oracle.
- **The slug is shape-checked before it reaches an HTTP header.** Route params arrive URL-decoded, so a `%0d%0a` payload would otherwise reach undici as a raw header value and throw a 500 instead of failing closed. `ORG_SLUG_PATTERN` is the DB's own rule from `provision_organization()`; `{1,62}` means a two-character minimum, copied deliberately.
- **The browser client override is required, not cosmetic.** `JoinForm`'s `access_requests` insert goes browser → PostgREST directly and its RLS `WITH CHECK` is `org_id = (select public.app_request_org_id())`. Without it, `/{orgSlug}/join` would render a perfect form whose every submit returns a bare 42501 — while type-checking and building clean.
- **`lib/org.ts` imports nothing from `lib/supabase/server`.** It is reachable from the client bundle (`lib/supabase/client.ts` → `app/join/JoinForm.tsx`, a `"use client"` module), so `resolveRequestOrgId()` takes the client as a parameter. `import type { SupabaseClient }` is erased. A successful `npm run build` is the proof.
- **The `typeof data === "string"` narrowing stays.** The generated type claims `Returns: string`; the SQL function returns `uuid` **or NULL**.

## Tests

None added. This repo has no JS/TS test runner (`package.json` scripts are `dev` / `build` / `start` / `lint` / `db:types`), and adding one is out of scope for this PR. Coverage here is the pgTAP tenancy harness plus a manual matrix.

## Validation

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — exit 0; route manifest includes `ƒ /[orgSlug]/join`, which also proves no `next/headers` reached the client graph
- [x] `deno check supabase/functions/_shared/*.ts` — 5 modules clean
- [x] `deno test --allow-env supabase/functions/tests/` — 36 passed, 0 failed
- [x] pgTAP `tenancy_leak_suite.sql` / `tenancy_signup_provisioning_suite.sql` — **locally green modulo known drift**, see below
- [ ] `npm run lint` — **not a CI gate**; broken repo-wide (CWA-42). 4 errors + 1 warning, all pre-existing on `main` (two edge-function `any`s ×2, and the intentional `_host` param in `lib/org.ts`). None from this diff.
- [ ] No `format` script exists in this repo

### Manual matrix (anonymous, dev server on a free port)

| Check | Result |
|-------|--------|
| `/join` | 200, form renders — behaviour unchanged |
| `/default/join` | 200, form renders |
| Browser insert path (anon key + `x-two42-org: default` + `Prefer: return=minimal`, explicit `org_id`) | **201**; row read back with the `default` org's `org_id` and `status = pending`; test row deleted afterwards |
| Same insert with `x-two42-org: no-such-org` (negative control) | 42501 — RLS `WITH CHECK` rejects; no fallback org |
| `/no-such-org/join` | Unavailable render; logs `org resolution returned NULL for slug no-such-org`; no row |
| `/JOIN_ME/join` | Unavailable render; logs `rejected malformed org slug JOIN_ME`; no RPC issued |
| CRLF attempt `/%0d%0aX-Evil:%201/join` | Unavailable render, **not** a 500 |
| `/join/family/<garbage>` | 307 → `/join`, unchanged |
| Route precedence | `/login` 200; `/about`, `/dashboard`, `/events` 307 (pre-existing auth redirects) — nothing swallowed by `[orgSlug]` |

**Not exercised**, both on unchanged code paths: `/default/join` while signed in (no test credentials; the guard is `getOptionalUser()` → `redirect("/dashboard")` placed before any org resolution, code-identical to `/join`'s), and `/join/family/<valid token>` rendering (the shared local DB has no `family_invites` rows; the org-resolution half of that page was exercised by the garbage-token request, and the token-lookup half is untouched).

### pgTAP: 2 failures, both external to this branch

`tenancy_leak_suite.sql` 93/94 and `tenancy_signup_provisioning_suite.sql` 37/38 locally. Both failures trace to shared-local-stack drift, not to this branch — **this PR touches zero SQL** (`git diff --stat main -- '*.sql' supabase/` is empty, and a TypeScript-only diff cannot change pgTAP results).

The shared local Postgres has 74 applied migrations against 71 migration files here. The three extras (`20260802000000` `org_status_enum`, `20260802000001` `organizations_anon_column_grants`, `20260802000002` `access_requests_approved_role`) belong to a parallel branch and are not on `main`. `20260802000002` makes `provision_organization()` stamp `approved_role = 'admin'` on the founding owner, which explains both failures: one asserts that owner's role directly (`have: admin, want: member`), and the other evaluates `giving_can_manage_fund()` as the same principal, where `is_admin()` now short-circuits `true` before the org-scoping arm is reached. The function body itself is not drifted — it matches this branch's migration verbatim.

CI runs pgTAP against an ephemeral DB built from this branch's 71 migrations, where the founding owner is still `member`, so both assertions should pass there. Not fixed here deliberately: editing the suites to expect `admin` would encode a migration this PR does not carry, turning a passing CI run red. The tests and that migration must land together in the stream that owns `supabase/migrations/**`. No `supabase db reset` or `supabase test db` was run.

> Carry-forward for that parallel stream: its own copy of `tenancy_leak_suite.sql` still asserts `'…made them a member'` and will fail CI when the migration merges unless the suite is updated in the same PR.

`npm run db:types` was deliberately **not** run — it regenerates from the local DB, which currently carries that unmerged `approved_role` column, and would write it into `lib/supabase/database.types.ts`. CI regenerates against its own ephemeral DB.

## Deferred DDL

Needed but not included, because a parallel run owns `supabase/migrations/**` this wave:

1. **Anon `SELECT` on `organizations`** for public org surfaces. Without it, `/{orgSlug}/join` renders the *deployment's default* branding — for a second tenant, the wrong church's name. Working around this with a service-role read of `organizations` keyed on a URL slug is prohibited by `CLAUDE.md` ("never an id taken straight off the request body"), so it waits for the policy.
2. **`organizations.status = 'suspended'` is enforced nowhere.** `app_request_org_id()` deliberately ignores `status`, so `/{orgSlug}/join` will accept requests for a suspended org. The cut point belongs to the `/platform` stream.
3. **Anon tightening of `site_settings.is_public` / announcements to member-only** — the remaining #213 public-routes checkbox.

## Out of scope (please don't flag these as regressions)

Org name / branding on `/{orgSlug}/join` (blocked on item 1 above), the `/platform` admin area, the CWA-11 hard gate, published per-org public pages, suspended-org enforcement, and migrating `/join`'s markup to `PageContainer` (the card was extracted verbatim; restyling a working public page inside a tenancy PR is scope creep).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization-specific join pages using URL slugs.
  * Added clear unavailable states when an organization cannot be resolved.
  * Signed-in users are redirected to the dashboard.
* **Bug Fixes**
  * Improved validation for organization links and invite requests.
  * Join requests now consistently target the organization specified by the link.
  * Invalid or unresolved organizations fail safely without exposing access.
* **Documentation**
  * Updated security documentation for organization-specific join routes and resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->