### PR TITLE
fix(profile): hide admin photo control without a storage write arm (#337)

### DIFF
--- a/app/admin/members/[id]/page.tsx
+++ b/app/admin/members/[id]/page.tsx
@@ -26,7 +26,7 @@ export default async function EditMemberPage({ params }: EditMemberPageProps) {
 
   const { data: currentProfile } = await supabase
     .from("profiles")
-    .select("role")
+    .select("role, family_id")
     .eq("id", user.id)
     .single();
 
@@ -67,6 +67,11 @@ export default async function EditMemberPage({ params }: EditMemberPageProps) {
         profile={profile}
         families={families || []}
         isAdmin={true}
+        canManageAvatar={
+          profile.id === user.id ||
+          (!!currentProfile?.family_id &&
+            currentProfile.family_id === profile.family_id)
+        }
       />
 
       <MemberGroupsSection profileId={profile.id} />

--- a/app/admin/members/[id]/page.tsx
+++ b/app/admin/members/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import { siteConfig } from "@/lib/config";
 import { displayName } from "@/lib/names";
+import { canManageAvatar } from "@/lib/members/avatar-eligibility";
 import type { Profile, FamilyUnit } from "@/lib/types";
 
 export const metadata = { title: `Edit Member | ${siteConfig.name}` };
@@ -26,7 +27,7 @@ export default async function EditMemberPage({ params }: EditMemberPageProps) {
 
   const { data: currentProfile } = await supabase
     .from("profiles")
-    .select("role, family_id")
+    .select("role, family_id, relationship")
     .eq("id", user.id)
     .single();
 
@@ -68,9 +69,15 @@ export default async function EditMemberPage({ params }: EditMemberPageProps) {
         families={families || []}
         isAdmin={true}
         canManageAvatar={
-          profile.id === user.id ||
-          (!!currentProfile?.family_id &&
-            currentProfile.family_id === profile.family_id)
+          !!currentProfile &&
+          canManageAvatar(
+            {
+              id: user.id,
+              family_id: currentProfile.family_id,
+              relationship: currentProfile.relationship,
+            },
+            { id: profile.id, family_id: profile.family_id }
+          )
         }
       />
 

--- a/app/admin/members/[id]/page.tsx
+++ b/app/admin/members/[id]/page.tsx
@@ -7,7 +7,6 @@ import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import { siteConfig } from "@/lib/config";
 import { displayName } from "@/lib/names";
-import { canManageAvatar } from "@/lib/members/avatar-eligibility";
 import type { Profile, FamilyUnit } from "@/lib/types";
 
 export const metadata = { title: `Edit Member | ${siteConfig.name}` };
@@ -68,14 +67,16 @@ export default async function EditMemberPage({ params }: EditMemberPageProps) {
         profile={profile}
         families={families || []}
         isAdmin={true}
-        canManageAvatar={canManageAvatar(
-          {
-            id: user.id,
-            family_id: currentProfile.family_id,
-            relationship: currentProfile.relationship,
-          },
-          { id: profile.id, family_id: profile.family_id }
-        )}
+        // Caller context (not a precomputed boolean) so the form can
+        // re-derive avatar-write eligibility after it saves a family
+        // reassignment — a boolean computed here from the initial
+        // profile.family_id goes stale the moment the admin moves the
+        // member in or out of their household (CWA-62 / #337).
+        avatarCaller={{
+          id: user.id,
+          family_id: currentProfile.family_id,
+          relationship: currentProfile.relationship,
+        }}
       />
 
       <MemberGroupsSection profileId={profile.id} />

--- a/app/admin/members/[id]/page.tsx
+++ b/app/admin/members/[id]/page.tsx
@@ -68,17 +68,14 @@ export default async function EditMemberPage({ params }: EditMemberPageProps) {
         profile={profile}
         families={families || []}
         isAdmin={true}
-        canManageAvatar={
-          !!currentProfile &&
-          canManageAvatar(
-            {
-              id: user.id,
-              family_id: currentProfile.family_id,
-              relationship: currentProfile.relationship,
-            },
-            { id: profile.id, family_id: profile.family_id }
-          )
-        }
+        canManageAvatar={canManageAvatar(
+          {
+            id: user.id,
+            family_id: currentProfile.family_id,
+            relationship: currentProfile.relationship,
+          },
+          { id: profile.id, family_id: profile.family_id }
+        )}
       />
 
       <MemberGroupsSection profileId={profile.id} />

--- a/components/profile/ProfileForm.tsx
+++ b/components/profile/ProfileForm.tsx
@@ -47,13 +47,16 @@ interface ProfileFormProps {
   /** Admin mode allows editing family assignment + ignores privacy enforcement on save */
   isAdmin?: boolean;
   /**
-   * Whether the caller is allowed to write this profile's avatar object.
-   * Only meaningful when isAdmin is true — self- and household-leader edits
-   * always have a matching storage write arm, so this defaults to true and
-   * only the admin route needs to compute and pass a real value. When false
-   * under isAdmin, the photo control is hidden rather than shown and left to
-   * fail (no admin write arm exists for another household's profiles/ path;
-   * see CWA-62 / #337).
+   * Whether the caller is allowed to write this profile's avatar object —
+   * see lib/members/avatar-eligibility.ts for the exact predicate, which
+   * mirrors the storage RLS policy's two write arms (self, and a household
+   * leader with relationship primary/spouse editing another member of the
+   * same household). Only meaningful when isAdmin is true — self- and
+   * household-leader edits always have a matching storage write arm, so
+   * this defaults to true and only the admin route needs to compute and
+   * pass a real value. When false under isAdmin, the photo control is
+   * hidden rather than shown and left to fail (no matching storage write
+   * arm exists; see CWA-62 / #337).
    */
   canManageAvatar?: boolean;
   /**
@@ -450,7 +453,8 @@ export function ProfileForm({
           )}
 
           {/* Photo — hidden for admins editing a profile they have no
-              storage write arm for (not themselves, not their household);
+              storage write arm for: not themselves, and not a household
+              they lead (relationship primary/spouse) with the target;
               see CWA-62 / #337. */}
           {(!isAdmin || canManageAvatar) && (
             <div className="flex items-center gap-5">

--- a/components/profile/ProfileForm.tsx
+++ b/components/profile/ProfileForm.tsx
@@ -33,6 +33,10 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { toast } from "sonner";
 import { Camera, Check } from "lucide-react";
+import {
+  canManageAvatar,
+  type AvatarEligibilityCaller,
+} from "@/lib/members/avatar-eligibility";
 import type { Profile, FamilyUnit } from "@/lib/types";
 
 interface ProfileFormProps {
@@ -47,18 +51,21 @@ interface ProfileFormProps {
   /** Admin mode allows editing family assignment + ignores privacy enforcement on save */
   isAdmin?: boolean;
   /**
-   * Whether the caller is allowed to write this profile's avatar object —
-   * see lib/members/avatar-eligibility.ts for the exact predicate, which
+   * Identity + household context of the person editing, used to decide
+   * whether they can write this profile's avatar object — see
+   * lib/members/avatar-eligibility.ts for the exact predicate, which
    * mirrors the storage RLS policy's two write arms (self, and a household
    * leader with relationship primary/spouse editing another member of the
-   * same household). Only meaningful when isAdmin is true — self- and
+   * same household). Only the admin route needs to pass it — self- and
    * household-leader edits always have a matching storage write arm, so
-   * this defaults to true and only the admin route needs to compute and
-   * pass a real value. When false under isAdmin, the photo control is
-   * hidden rather than shown and left to fail (no matching storage write
-   * arm exists; see CWA-62 / #337).
+   * when omitted the photo control is always shown. When provided and the
+   * predicate fails, the control is hidden rather than shown and left to
+   * fail (no matching storage write arm exists; see CWA-62 / #337). The
+   * form re-evaluates the predicate against the last *saved* family
+   * assignment, so reassigning the member's family in this form updates
+   * the control's visibility on save without a page refresh.
    */
-  canManageAvatar?: boolean;
+  avatarCaller?: AvatarEligibilityCaller | null;
   /**
    * When true, skips the birthday and visible-contact requirements.
    * Used when a household primary/spouse edits another member's profile —
@@ -217,11 +224,19 @@ export function ProfileForm({
   family = null,
   isAdmin = false,
   relaxValidation = false,
-  canManageAvatar = true,
+  avatarCaller = null,
   onSaved,
 }: ProfileFormProps) {
   const [state, setState] = useState<FormState>(initialState(profile));
   const [avatarUrl, setAvatarUrl] = useState<string | null>(profile.avatar_url);
+  // The family assignment as last persisted — what the storage RLS policy
+  // actually evaluates on an avatar write. The live state.family_id can
+  // differ while the admin has an unsaved selection in the Family select,
+  // so avatar-write eligibility is derived from this value, updated only
+  // after a successful save (CWA-62 / #337).
+  const [savedFamilyId, setSavedFamilyId] = useState<string | null>(
+    profile.family_id,
+  );
 
   // Family defaults: last name falls back to the family surname and address
   // to the family's home address unless the member marks theirs different.
@@ -432,9 +447,17 @@ export function ProfileForm({
       return;
     }
 
+    if (isAdmin) setSavedFamilyId(state.family_id || null);
     toast.success("Profile saved.");
     onSaved?.();
   };
+
+  // Recomputed per render so a saved family reassignment immediately
+  // shows or hides the photo control. No caller context means a route
+  // whose write arm is guaranteed (self-edit, household-leader edit).
+  const avatarWritable =
+    !avatarCaller ||
+    canManageAvatar(avatarCaller, { id: profile.id, family_id: savedFamilyId });
 
   const initials =
     `${state.first_name.charAt(0)}${state.last_name.charAt(0)}`.toUpperCase() ||
@@ -454,9 +477,11 @@ export function ProfileForm({
 
           {/* Photo — hidden for admins editing a profile they have no
               storage write arm for: not themselves, and not a household
-              they lead (relationship primary/spouse) with the target;
-              see CWA-62 / #337. */}
-          {(!isAdmin || canManageAvatar) && (
+              they lead (relationship primary/spouse) with the target.
+              Follows the last saved family assignment, so reassigning
+              the family in this form updates it on save; see CWA-62 /
+              #337. */}
+          {avatarWritable && (
             <div className="flex items-center gap-5">
               <Avatar className="h-20 w-20 shrink-0">
                 {avatarUrl && <AvatarImage src={avatarUrl} alt="Profile photo" />}

--- a/components/profile/ProfileForm.tsx
+++ b/components/profile/ProfileForm.tsx
@@ -47,6 +47,16 @@ interface ProfileFormProps {
   /** Admin mode allows editing family assignment + ignores privacy enforcement on save */
   isAdmin?: boolean;
   /**
+   * Whether the caller is allowed to write this profile's avatar object.
+   * Only meaningful when isAdmin is true — self- and household-leader edits
+   * always have a matching storage write arm, so this defaults to true and
+   * only the admin route needs to compute and pass a real value. When false
+   * under isAdmin, the photo control is hidden rather than shown and left to
+   * fail (no admin write arm exists for another household's profiles/ path;
+   * see CWA-62 / #337).
+   */
+  canManageAvatar?: boolean;
+  /**
    * When true, skips the birthday and visible-contact requirements.
    * Used when a household primary/spouse edits another member's profile —
    * the person being edited may have an incomplete profile that they will
@@ -204,6 +214,7 @@ export function ProfileForm({
   family = null,
   isAdmin = false,
   relaxValidation = false,
+  canManageAvatar = true,
   onSaved,
 }: ProfileFormProps) {
   const [state, setState] = useState<FormState>(initialState(profile));
@@ -438,35 +449,39 @@ export function ProfileForm({
             </p>
           )}
 
-          {/* Photo */}
-          <div className="flex items-center gap-5">
-            <Avatar className="h-20 w-20 shrink-0">
-              {avatarUrl && <AvatarImage src={avatarUrl} alt="Profile photo" />}
-              <AvatarFallback className="bg-brand-primary text-2xl text-white">
-                {initials}
-              </AvatarFallback>
-            </Avatar>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={uploadingAvatar}
-            >
-              <Camera className="mr-2 h-4 w-4" />
-              {uploadingAvatar
-                ? "Uploading..."
-                : relaxValidation
-                  ? "Change their photo"
-                  : "Change my photo"}
-            </Button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              onChange={handleAvatarUpload}
-              className="hidden"
-            />
-          </div>
+          {/* Photo — hidden for admins editing a profile they have no
+              storage write arm for (not themselves, not their household);
+              see CWA-62 / #337. */}
+          {(!isAdmin || canManageAvatar) && (
+            <div className="flex items-center gap-5">
+              <Avatar className="h-20 w-20 shrink-0">
+                {avatarUrl && <AvatarImage src={avatarUrl} alt="Profile photo" />}
+                <AvatarFallback className="bg-brand-primary text-2xl text-white">
+                  {initials}
+                </AvatarFallback>
+              </Avatar>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploadingAvatar}
+              >
+                <Camera className="mr-2 h-4 w-4" />
+                {uploadingAvatar
+                  ? "Uploading..."
+                  : relaxValidation
+                    ? "Change their photo"
+                    : "Change my photo"}
+              </Button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleAvatarUpload}
+                className="hidden"
+              />
+            </div>
+          )}
 
           {/* Name */}
           <div className={familySurname ? "space-y-2" : "grid gap-4 sm:grid-cols-2"}>

--- a/lib/members/avatar-eligibility.test.ts
+++ b/lib/members/avatar-eligibility.test.ts
@@ -1,0 +1,66 @@
+// Unit tests for the admin avatar-write eligibility gate (CWA-62 / #337).
+// Every branch here is a security decision, and the fail-closed ones (null
+// family_id, non-leader relationship) are what a refactor is most likely to
+// invert — reopening the "Failed to upload photo" bug this predicate exists
+// to prevent, in a narrower form each time.
+
+import { describe, expect, it } from "vitest";
+import { canManageAvatar } from "@/lib/members/avatar-eligibility";
+
+describe("canManageAvatar", () => {
+  it("allows the caller to manage their own avatar", () => {
+    expect(
+      canManageAvatar(
+        { id: "u1", family_id: null, relationship: null },
+        { id: "u1", family_id: null }
+      )
+    ).toBe(true);
+  });
+
+  it("allows a household leader (primary) to manage another member's avatar", () => {
+    expect(
+      canManageAvatar(
+        { id: "u1", family_id: "fam-1", relationship: "primary" },
+        { id: "u2", family_id: "fam-1" }
+      )
+    ).toBe(true);
+  });
+
+  it("allows a household leader (spouse) to manage another member's avatar", () => {
+    expect(
+      canManageAvatar(
+        { id: "u1", family_id: "fam-1", relationship: "spouse" },
+        { id: "u2", family_id: "fam-1" }
+      )
+    ).toBe(true);
+  });
+
+  it("denies a non-leader member of the same household — matches storage RLS", () => {
+    // The exact narrower bug the HIGH review finding called out: family_id
+    // equality alone is not the storage policy's requirement.
+    expect(
+      canManageAvatar(
+        { id: "u1", family_id: "fam-1", relationship: "child" },
+        { id: "u2", family_id: "fam-1" }
+      )
+    ).toBe(false);
+  });
+
+  it("denies an admin with no shared household and no matching id", () => {
+    expect(
+      canManageAvatar(
+        { id: "u1", family_id: "fam-1", relationship: "primary" },
+        { id: "u2", family_id: "fam-2" }
+      )
+    ).toBe(false);
+  });
+
+  it("denies when both caller and target have a null family_id (not the same household)", () => {
+    expect(
+      canManageAvatar(
+        { id: "u1", family_id: null, relationship: "primary" },
+        { id: "u2", family_id: null }
+      )
+    ).toBe(false);
+  });
+});

--- a/lib/members/avatar-eligibility.ts
+++ b/lib/members/avatar-eligibility.ts
@@ -1,0 +1,41 @@
+/**
+ * Whether `caller` is allowed to write `target`'s avatar object in storage —
+ * a pure mirror of the two write arms granted by the storage RLS policies in
+ * supabase/migrations/20260803000000_storage_org_partitioned_policies.sql:
+ * a caller writing their own avatar, and a household leader (relationship
+ * `primary` or `spouse`) writing another enrolled member of the *same*
+ * household. Used by the admin member-edit page to decide whether to show
+ * the photo control at all (CWA-62 / #337) — without this check, an admin
+ * editing a profile with no matching storage write arm sees the control,
+ * then hits "Failed to upload photo" on save.
+ *
+ * Every branch here is a security decision:
+ * - A null `family_id` on both sides is NOT a match — two members outside
+ *   any household are not the same household.
+ * - `family_id` equality alone is not enough: the storage policy also
+ *   requires the caller's own `relationship` be `primary` or `spouse`. An
+ *   admin who merely shares a household with the target (e.g. a child or
+ *   sibling) has no storage write arm either.
+ */
+export interface AvatarEligibilityCaller {
+  id: string;
+  family_id: string | null;
+  relationship: string | null;
+}
+
+export interface AvatarEligibilityTarget {
+  id: string;
+  family_id: string | null;
+}
+
+export function canManageAvatar(
+  caller: AvatarEligibilityCaller,
+  target: AvatarEligibilityTarget
+): boolean {
+  if (caller.id === target.id) return true;
+  return (
+    !!caller.family_id &&
+    caller.family_id === target.family_id &&
+    (caller.relationship === "primary" || caller.relationship === "spouse")
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #337 (option 2: withdraw the control).

`ProfileForm` rendered its "Change their photo" button unconditionally, but the storage write policies for `profiles/<id>/avatar` only have two arms: self (`profile.id === auth.uid()`) and same-household (`family_id` match). Admins have no write arm for another household's `profiles/` path, so the button always failed with "Failed to upload photo" for members outside the admin's household — a working-looking control the database silently refuses.

## Changes

- **`components/profile/ProfileForm.tsx`** — new optional `canManageAvatar` prop (default `true`, documented); the photo block (avatar + button + hidden file input) now renders only when `!isAdmin || canManageAvatar`. Non-admin call sites (`MyProfileView`, `HouseholdMemberEditClient`) never pass the prop and are behaviorally unchanged.
- **`app/admin/members/[id]/page.tsx`** — the only `isAdmin={true}` call site: fetches the caller's `family_id` alongside `role` and passes `canManageAvatar` mirroring the two storage write arms — self, or matching **non-null** `family_id` (two null-family profiles never count as the same household).

App-layer only: no storage policy changes, no migrations. Granting the admin write capability (issue option 1) is deferred to its own review per the issue.

## Validation

- `npm run lint` (`--max-warnings=0`) — clean
- `npm run guard:tenancy` — OK, inventory in sync
- `npx tsc --noEmit` — exit 0

Manual checks to confirm on review: admin editing self or own-household member still sees the photo button; admin editing an out-of-household member no longer sees the photo block, with the rest of the form unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permission-based avatar management to profile editing.
  * Members can manage their own avatars, while household primary members and spouses can manage avatars for others in the same household.
  * Avatar upload controls are hidden when the editor lacks permission.
  * Permissions remain accurate after a profile’s household assignment changes.

* **Bug Fixes**
  * Improved protection for profiles outside the editor’s household and profiles without an assigned household.
  * Added consistent enforcement of avatar-management permissions across profile editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->