### PR TITLE
fix(deps): bump nanoid to 3.3.18 for CVE-2026-67213

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8878,9 +8878,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Trivy's HIGH/CRITICAL gate is currently red on every open PR (#349, #351) because the locked `nanoid` 3.3.17 carries CVE-2026-67213 (DoS via infinite loop). This bumps the single lockfile entry to the fixed 3.3.18 — a surgical 3-line change, no other lockfile churn.

`nanoid` reaches production through `ics` (calendar generation) and `postcss`, hence `fix` rather than `chore`.

Unblocks the Trivy check for #349 and #351 once merged.