### PR TITLE
feat(tenancy): reserved slug denylist in provision_organization (CWA-65)

### DIFF
--- a/app/api/platform/organizations/route.ts
+++ b/app/api/platform/organizations/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { EMAIL } from "@/lib/branding";
+import { isReservedOrgSlug } from "@/lib/org";
 import { requirePlatformAdmin } from "@/lib/platform-access";
 import { createServiceClient } from "@/lib/supabase/server";
 
@@ -36,6 +37,12 @@ export async function POST(request: Request) {
   if (!SLUG.test(slug)) {
     return NextResponse.json(
       { error: "Slug must be lowercase letters, numbers, and hyphens." },
+      { status: 400 }
+    );
+  }
+  if (isReservedOrgSlug(slug)) {
+    return NextResponse.json(
+      { error: "That slug is reserved for platform use." },
       { status: 400 }
     );
   }
@@ -81,6 +88,12 @@ export async function POST(request: Request) {
               "That owner email already has an approved request or unclaimed invite elsewhere.",
           },
           { status: 409 }
+        );
+      }
+      if (error.code === "TN006") {
+        return NextResponse.json(
+          { error: "That slug is reserved for platform use." },
+          { status: 400 }
         );
       }
       if (error.code === "23505") {

--- a/app/platform/organizations/OrganizationsList.tsx
+++ b/app/platform/organizations/OrganizationsList.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { isReservedOrgSlug } from "@/lib/org";
 import type { Database } from "@/lib/supabase/database.types";
 
 export interface PlatformOrg {
@@ -57,6 +58,10 @@ export function OrganizationsList({ initialOrgs }: OrganizationsListProps) {
     }
     if (!SLUG.test(slug)) {
       toast.error("Slug must be lowercase letters, numbers, and hyphens.");
+      return;
+    }
+    if (isReservedOrgSlug(slug)) {
+      toast.error("That slug is reserved for platform use.");
       return;
     }
     if (ownerEmail.length > 254 || !EMAIL.test(ownerEmail)) {

--- a/docs/security/tenancy-model.md
+++ b/docs/security/tenancy-model.md
@@ -256,7 +256,13 @@ and an **approved access request for the owner** — so self-serve
 onboarding is org-first: provision, then create the auth user, and the
 fail-closed trigger needs no special case. Phase 4 must NOT solve
 onboarding by adding a fallback branch to `handle_new_user()`. An invalid
-slug raises `TN003`.
+slug raises `TN003`; a slug on the reserved-label denylist (`www`, `app`,
+`api`, `admin`, `platform`, …) raises `TN006` — reserved because slugs
+become host labels once Phase 5's wildcard/custom-domain routing ships
+(`docs/plans/phase-5-domains-email.md` §4), and any of these would shadow
+a platform host. The list is mirrored in `lib/org.ts` (`RESERVED_ORG_SLUGS`).
+`default` — the slug of the one org that exists today — is deliberately
+not yet on the list.
 
 **`access_requests.approved_role`** (Phase 4a, `20260802000002`) names the
 role `handle_new_user()` grants when an approved request resolves a signup:

--- a/lib/org.test.ts
+++ b/lib/org.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isReservedOrgSlug, isValidOrgSlug, RESERVED_ORG_SLUGS } from "@/lib/org";
+
+describe("isReservedOrgSlug", () => {
+  it("rejects every slug in the reserved list", () => {
+    for (const slug of RESERVED_ORG_SLUGS) {
+      expect(isReservedOrgSlug(slug)).toBe(true);
+    }
+  });
+
+  it("rejects the platform hosts named in Phase 5 §4", () => {
+    for (const slug of ["www", "app", "api", "admin", "platform"]) {
+      expect(isReservedOrgSlug(slug)).toBe(true);
+    }
+  });
+
+  it("accepts an ordinary slug", () => {
+    expect(isReservedOrgSlug("grace-chapel")).toBe(false);
+  });
+
+  it("does not treat 'default' as reserved yet", () => {
+    // 'default' is the slug of the one org that exists today; it is
+    // deliberately excluded until that org is renamed or retired.
+    expect(isReservedOrgSlug("default")).toBe(false);
+  });
+
+  it("every reserved slug is itself a valid slug shape", () => {
+    // The denylist only targets strings the TN003 regex would otherwise
+    // accept — an entry the regex already rejects would be dead weight.
+    for (const slug of RESERVED_ORG_SLUGS) {
+      expect(isValidOrgSlug(slug)).toBe(true);
+    }
+  });
+});

--- a/lib/org.test.ts
+++ b/lib/org.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { isReservedOrgSlug, isValidOrgSlug, RESERVED_ORG_SLUGS } from "@/lib/org";
 
@@ -18,6 +20,13 @@ describe("isReservedOrgSlug", () => {
     expect(isReservedOrgSlug("grace-chapel")).toBe(false);
   });
 
+  it("accepts a slug that merely contains a reserved word as a substring", () => {
+    // isReservedOrgSlug is an exact Set lookup, not substring matching — an
+    // org named "grace-app-campus" or "team-admin" must not be blocked.
+    expect(isReservedOrgSlug("grace-app-campus")).toBe(false);
+    expect(isReservedOrgSlug("team-admin")).toBe(false);
+  });
+
   it("does not treat 'default' as reserved yet", () => {
     // 'default' is the slug of the one org that exists today; it is
     // deliberately excluded until that org is renamed or retired.
@@ -30,5 +39,31 @@ describe("isReservedOrgSlug", () => {
     for (const slug of RESERVED_ORG_SLUGS) {
       expect(isValidOrgSlug(slug)).toBe(true);
     }
+  });
+});
+
+describe("RESERVED_ORG_SLUGS parity with the TN006 migration", () => {
+  it("matches the SQL denylist in supabase/migrations/20260818000000_reserved_org_slugs.sql exactly", () => {
+    const migrationPath = fileURLToPath(
+      new URL(
+        "../supabase/migrations/20260818000000_reserved_org_slugs.sql",
+        import.meta.url
+      )
+    );
+    const sql = readFileSync(migrationPath, "utf8");
+    const match = sql.match(/_slug = any\(array\[([\s\S]*?)\]\)/);
+    if (!match) {
+      throw new Error(
+        "could not find the reserved-slug array literal in the TN006 migration — " +
+          "update this test's regex if the migration's syntax changed"
+      );
+    }
+    const sqlSlugs = new Set(
+      match[1]
+        .split(",")
+        .map((entry) => entry.trim().replace(/^'|'$/g, ""))
+        .filter(Boolean)
+    );
+    expect(sqlSlugs).toEqual(new Set(RESERVED_ORG_SLUGS));
   });
 });

--- a/lib/org.ts
+++ b/lib/org.ts
@@ -47,6 +47,27 @@ export function isValidOrgSlug(slug: string): boolean {
 }
 
 /**
+ * Mirrors the denylist provision_organization() enforces (TN006), so the
+ * app can never route to — or offer — a slug the DB would refuse to mint.
+ * Slugs become host labels once Phase 5 routing ships, and any of these
+ * would shadow a platform host. Keep this list in sync with the array in
+ * the TN006 migration (supabase/migrations/20260818000000_reserved_org_slugs.sql).
+ *
+ * 'default' is deliberately NOT here yet: it is the slug of the one org
+ * that exists today (DEFAULT_ORG_SLUG above). Add it once that org is
+ * renamed or retired.
+ */
+export const RESERVED_ORG_SLUGS: ReadonlySet<string> = new Set([
+  "www", "app", "api", "admin", "platform", "auth", "mail", "email",
+  "static", "assets", "cdn", "status", "docs", "blog", "help", "support",
+  "dev", "staging", "preview", "test",
+]);
+
+export function isReservedOrgSlug(slug: string): boolean {
+  return RESERVED_ORG_SLUGS.has(slug);
+}
+
+/**
  * Phase 4b (CWA-48 / #314): the single implementation of the fail-closed
  * org-resolution guard both anonymous entry points (`/join`,
  * `/join/family/[token]`) and the per-org route (`/[orgSlug]/join`) rely on.

--- a/supabase/migrations/20260818000000_reserved_org_slugs.sql
+++ b/supabase/migrations/20260818000000_reserved_org_slugs.sql
@@ -1,0 +1,154 @@
+-- Reserved org slug labels (Phase 5 PR 1, CWA-65 / #358).
+--
+-- Slugs become host labels (`<slug>.<platform-apex>`) once Phase 5's
+-- wildcard/custom-domain routing ships (docs/plans/phase-5-domains-email.md
+-- §4, §12 step 1). Any org minted today with slug `app`, `api`, `www`,
+-- `admin`, ... would shadow a platform host then, and a slug cannot be
+-- reclaimed from a live org without a support incident. So the denylist
+-- lands now, before any slug-as-host routing exists. No routing change here.
+--
+-- provision_organization(): body copied verbatim from
+-- 20260802000002_access_requests_approved_role.sql:140-263 (the live
+-- definition); ONLY the reserved-label check after the TN003 shape check is
+-- new (raises TN006). Mirrored in lib/org.ts as RESERVED_ORG_SLUGS /
+-- isReservedOrgSlug() — keep both lists in sync.
+create or replace function public.provision_organization(
+  _name        text,
+  _slug        text,
+  _owner_email text
+) returns uuid
+language plpgsql security definer set search_path = ''
+as $$
+declare
+  _org_id uuid;
+  _cal_id uuid;
+begin
+  if _slug !~ '^[a-z0-9][a-z0-9-]{1,62}$' then
+    raise exception 'invalid organization slug: %', _slug using errcode = 'TN003';
+  end if;
+
+  -- Reserved subdomain labels (Phase 5 §4, CWA-65 / #358): slugs become host
+  -- labels once wildcard/custom-domain routing ships, so any of these would
+  -- shadow a platform host. 'default' is deliberately absent — it is the
+  -- slug of the one org that exists today (20260730010000_org_spine.sql);
+  -- add it once that org is renamed or retired. Mirrored in lib/org.ts's
+  -- RESERVED_ORG_SLUGS — keep both lists in sync. _slug is already
+  -- lowercase-only here (the TN003 regex has no case-insensitive flag), so a
+  -- plain equality match is correct.
+  if _slug = any(array[
+    'www', 'app', 'api', 'admin', 'platform', 'auth', 'mail', 'email',
+    'static', 'assets', 'cdn', 'status', 'docs', 'blog', 'help', 'support',
+    'dev', 'staging', 'preview', 'test'
+  ]) then
+    raise exception 'organization slug % is reserved', _slug using errcode = 'TN006';
+  end if;
+
+  -- 1. The org itself. branding carries only the tenant-overridable keys
+  -- from #221 / docs/design/DESIGN.md: display_name, logo_url, accent,
+  -- reply_to.
+  insert into public.organizations (name, slug, branding, status)
+  values (
+    _name,
+    _slug,
+    jsonb_build_object('display_name', _name, 'logo_url', null, 'accent', null, 'reply_to', null),
+    'active'
+  )
+  returning id into _org_id;
+
+  -- 2. Prayer calendar, wired into settings: lib/prayerCalls.ts and
+  -- app/prayer read prayer_calendar_id, and a missing value degrades the
+  -- prayer surface — which is why the calendar is provisioning, not
+  -- onboarding.
+  insert into public.event_calendars (org_id, name, color)
+  values (_org_id, 'Prayer Calls', '#7c9885')
+  returning id into _cal_id;
+
+  -- 3. Settings defaults — the full key list in one auditable place.
+  -- serving_link_mode's deploy default is applied at read time by
+  -- getServingLinkMode() (SERVING_LINK_MODE env); the seed row here matches
+  -- the migration-seeded default. Only site_name is anon-readable (#215).
+  insert into public.site_settings (org_id, key, value, is_public)
+  values
+    (_org_id, 'site_name',               '',            true),
+    (_org_id, 'directory_app_url',       '',            false),
+    (_org_id, 'weekly_zoom_url',         '',            false),
+    (_org_id, 'zoom_meeting_time',       '',            false),
+    (_org_id, 'weekly_prayer_call_url',  '',            false),
+    (_org_id, 'weekly_prayer_call_time', '',            false),
+    (_org_id, 'serving_link_mode',       'signed',      false),
+    (_org_id, 'giving_manage_mode',      'stewards',    false),
+    (_org_id, 'giving_dashboard_tile',   'on',          false),
+    (_org_id, 'prayer_calendar_id',      _cal_id::text, false);
+
+  -- 4. Empty about page (per-org singleton: PK is (org_id, id), id CHECKed
+  -- true).
+  insert into public.about_page (org_id, id, body) values (_org_id, true, '');
+
+  -- 5. Approved access request for the owner, so their signup resolves
+  -- under handle_new_user()'s fail-closed rules. approved_role = 'admin'
+  -- is what makes the owner the founding admin (CWA-11): handle_new_user()
+  -- reads it at signup time, so the org never exists without an admin path.
+  insert into public.access_requests (org_id, name, email, status, reviewed_at, approved_role)
+  values (_org_id, _name || ' owner', _owner_email, 'approved', now(), 'admin');
+
+  -- 6. The owner email must not already have a profile. The org created
+  -- above holds no profiles yet, so ANY existing profile with this email
+  -- necessarily belongs to another org — and a profile is never moved
+  -- between orgs. An unscoped `update profiles set org_id = _org_id where
+  -- email = ...` would be a cross-tenant write: once Phase 4 exposes a
+  -- caller, passing a competing org's admin email would re-pin that admin
+  -- into the caller's org — an account-takeover primitive that a "who may
+  -- provision" guard does not address. Raise instead, matching
+  -- handle_new_user()'s TN001/TN002: an email that already belongs
+  -- elsewhere is a conflict for a human to resolve, not something to
+  -- silently resolve by moving the account. The owner's profiles and
+  -- organization_members rows are created by handle_new_user() when they
+  -- sign up AFTER provisioning, through the approved access request above.
+  if exists (
+    -- Case-insensitive to match handle_new_user(): profile emails come from
+    -- GoTrue lowercased, while _owner_email arrives as typed.
+    select 1 from public.profiles where lower(email) = lower(_owner_email)
+  ) then
+    raise exception 'owner email % already belongs to another organization', _owner_email
+      using errcode = 'TN004';
+  end if;
+
+  -- 7. Nor may the owner email hold an approved access request or unclaimed
+  -- family invite in another org (a profile-less owner: invited or approved
+  -- elsewhere but not yet signed up). The step-5 insert would then be a
+  -- SECOND match for handle_new_user(), which rejects the owner's eventual
+  -- signup as ambiguous (TN002) — a broken state this transaction would
+  -- otherwise commit. The org_id filter excludes the request created in
+  -- step 5; checked after step 6 so an email that also has a profile keeps
+  -- raising TN004.
+  if exists (
+    select 1 from public.access_requests
+    where lower(email) = lower(_owner_email)
+      and status = 'approved'
+      and org_id <> _org_id
+  ) or exists (
+    select 1 from public.family_invites
+    where lower(invite_email) = lower(_owner_email)
+      and accepted_at is null
+      and org_id <> _org_id
+  ) then
+    raise exception 'owner email % already has an approved access request or unclaimed invite in another organization', _owner_email
+      using errcode = 'TN005';
+  end if;
+
+  return _org_id;
+end;
+$$;
+
+-- Restated from 20260802000002:251-263, unchanged: create or replace keeps
+-- existing ACLs, but stating them keeps the function's reachability auditable
+-- at its latest definition site.
+revoke execute on function public.provision_organization(text, text, text)
+  from public, anon, authenticated;
+
+-- service_role keeps EXECUTE. Supabase's default privileges already grant it;
+-- stating it explicitly means the Phase 4 server-side caller does not depend
+-- on those defaults. service_role is never reachable from clients, so this
+-- does not re-open PostgREST RPC.
+grant execute on function public.provision_organization(text, text, text)
+  to service_role;

--- a/supabase/tests/tenancy_signup_provisioning_suite.sql
+++ b/supabase/tests/tenancy_signup_provisioning_suite.sql
@@ -167,6 +167,46 @@ select throws_ok(
   'TN003', null,
   'invalid slug is rejected');
 
+-- Reserved subdomain labels (Phase 5 PR 1, CWA-65 / #358): TN006 fires
+-- after the TN003 shape check, and the whole call rolls back.
+select throws_ok(
+  $$ select public.provision_organization('Reserved Slug Org', 'admin', 'reserved@leak.example.test') $$,
+  'TN006', null,
+  'reserved slug is rejected');
+
+select throws_ok(
+  $$ select public.provision_organization('Reserved Slug Org', 'api', 'reserved@leak.example.test') $$,
+  'TN006', null,
+  'a second reserved slug (api) is rejected');
+
+select ok(
+  not exists (select 1 from public.organizations where slug in ('admin', 'api')),
+  'the TN006-rejected calls left no partial org behind (atomic)');
+
+select ok(
+  not exists (
+    select 1 from public.access_requests
+    where lower(email) = 'reserved@leak.example.test'),
+  'the TN006-rejected calls left no access request behind (atomic)');
+
+do $$
+declare
+  _org_id uuid;
+begin
+  _org_id := public.provision_organization(
+    'Not Reserved Org', 'signup-suite-not-reserved', 'not-reserved@leak.example.test'
+  );
+  perform set_config('su.org_not_reserved', _org_id::text, true);
+end $$;
+
+select ok(
+  exists (
+    select 1 from public.organizations
+    where id = current_setting('su.org_not_reserved')::uuid
+      and slug = 'signup-suite-not-reserved'
+  ),
+  'a normal (non-reserved) slug still provisions');
+
 -- Not callable from PostgREST roles: EXECUTE is revoked.
 do $$
 declare


### PR DESCRIPTION
## Summary

Phase 5 PR 1 (`docs/plans/phase-5-domains-email.md` §4 "Reserved subdomain labels", §12 step 1). Slugs become host labels once wildcard/custom-domain routing ships, so an org minted today with slug `app`/`api`/`www`/`admin`/`platform`/… would shadow a platform host. `provision_organization()` previously only checked shape (`TN003`); this adds a reserved-label check, raising a new `TN006`, mirrored in `lib/org.ts` so the client/API layer can reject before the RPC round-trip.

No routing change. `provision_organization()`'s signature is unchanged, so there's no `db:types` drift.

## Changes

- **Migration** (`supabase/migrations/20260818000000_reserved_org_slugs.sql`): re-creates `provision_organization()` with a reserved-label check immediately after the existing `TN003` shape check, raising `TN006` for a match. Body is otherwise verbatim.
- **`lib/org.ts`**: `RESERVED_ORG_SLUGS` (`ReadonlySet<string>`) / `isReservedOrgSlug()` mirror the DB denylist for use outside the RPC path.
- **`app/api/platform/organizations/route.ts`**: server-side pre-check rejects a reserved slug before calling the RPC, and maps a `TN006` raise to the same 400 response shape as `TN003`.
- **`app/platform/organizations/OrganizationsList.tsx`**: client-side pre-check in the onboarding form for immediate feedback.
- **pgTAP** (`supabase/tests/tenancy_signup_provisioning_suite.sql`): `TN006` raised for two reserved slugs (`admin`, `api`), atomic rollback verified (including on `access_requests`), and a non-reserved slug still provisions successfully.
- **`lib/org.test.ts`** (new): unit coverage for the TS mirror, including an explicit check for the five hosts named in Phase 5 §4 (`www`, `app`, `api`, `admin`, `platform`).
- **`docs/security/tenancy-model.md`**: names `TN006` alongside `TN003` in the provisioning contract.

`default` is deliberately **not** on the denylist — the seeded org still uses it. Called out in the migration comment, the `lib/org.ts` JSDoc, the unit test, and `tenancy-model.md`.

## Validation

| Check | Result |
|-------|--------|
| `supabase migration up --db-url …54322` | ✅ applied `20260818000000_reserved_org_slugs.sql` cleanly |
| pgTAP `tenancy_signup_provisioning_suite.sql` (docker exec) | ✅ 43/43 ok, incl. `ok 19` reserved slug rejected, `ok 20` second reserved slug (`api`) rejected, `ok 23` non-reserved slug still provisions |
| pgTAP `schema_tenancy_lint.sql` (regression) | ✅ 35/35 ok — migration adds no new table, no structural regressions |
| `npx vitest run lib/org.test.ts` | ✅ 5 passed |
| `npm run test:run` (full vitest) | ✅ 233 passed / 0 failed (17 files) |
| `npm run lint` (`--max-warnings=0`) | ✅ clean |
| `npm run guard:tenancy` | ✅ 157 files scanned, inventory in sync (20 call sites) |
| `npx tsc --noEmit` | ✅ no errors |
| `npm run build` | ✅ compiled, all routes generated |
| `npm run db:types` | intentionally **not** run — function signature unchanged; avoids picking up tables from the parallel #363 (`org_email_domains`) branch |

No fixes were required during validation — all checks passed as-implemented.

Fixes #358


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization creation now blocks reserved platform-related slugs, including `www`, `app`, `api`, and `admin`.
  * Clear validation errors are shown before or during organization provisioning.
  * The `default` slug remains available.

* **Bug Fixes**
  * Prevented partially created organizations or access requests when a reserved slug is rejected.

* **Documentation**
  * Updated tenancy documentation to describe slug validation and related error codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->